### PR TITLE
fixup import path

### DIFF
--- a/Godeps/_workspace/src/github.com/cenkalti/rpc2/jsonrpc/jsonrpc.go
+++ b/Godeps/_workspace/src/github.com/cenkalti/rpc2/jsonrpc/jsonrpc.go
@@ -21,7 +21,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2"
+	"github.com/cenkalti/rpc2"
 )
 
 type jsonCodec struct {

--- a/Godeps/_workspace/src/github.com/cenkalti/rpc2/jsonrpc/jsonrpc_test.go
+++ b/Godeps/_workspace/src/github.com/cenkalti/rpc2/jsonrpc/jsonrpc_test.go
@@ -1,7 +1,7 @@
 package jsonrpc
 
 import (
-	"github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2"
+	"github.com/cenkalti/rpc2"
 	"net"
 	"testing"
 	"time"

--- a/Godeps/_workspace/src/github.com/cenkalti/rpc2/server.go
+++ b/Godeps/_workspace/src/github.com/cenkalti/rpc2/server.go
@@ -8,7 +8,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/hub"
+	"github.com/cenkalti/hub"
 )
 
 // Precompute the reflect type for error.  Can't use error directly

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 all: build test
 
-build:
-	go build -v
+godep:
+	go get github.com/tools/godep
 
-test:
-	go test -covermode=count -coverprofile=coverage.out -test.short -v
+build: godep
+	godep go build -v
 
-test-all:
-	go test -covermode=count -coverprofile=coverage.out -v
+test: godep
+	godep go test -covermode=count -coverprofile=coverage.out -test.short -v
+
+test-all: godep
+	godep go test -covermode=count -coverprofile=coverage.out -v
 

--- a/client.go
+++ b/client.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"net"
 
-	"github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2"
-	"github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2/jsonrpc"
+	"github.com/cenkalti/rpc2"
+	"github.com/cenkalti/rpc2/jsonrpc"
 )
 
 type OvsdbClient struct {


### PR DESCRIPTION
Don't force go to use forced path, resulting in in incompatibility with other project using the same librairies.
godep frontend tool is the right way to build / compile.
