### PR TITLE
Fix go vet warning on play_with_ovs.go sample

### DIFF
--- a/example/play_with_ovs.go
+++ b/example/play_with_ovs.go
@@ -55,10 +55,11 @@ func createBridge(ovs *libovsdb.OvsdbClient, bridgeName string) {
 	}
 
 	// Inserting a Bridge row in Bridge table requires mutating the open_vswitch table.
+	uuidParameter := libovsdb.UUID{GoUUID: getRootUUID()}
 	mutateUUID := []libovsdb.UUID{{namedUUID}}
 	mutateSet, _ := libovsdb.NewOvsSet(mutateUUID)
 	mutation := libovsdb.NewMutation("bridges", "insert", mutateSet)
-	condition := libovsdb.NewCondition("_uuid", "==", libovsdb.UUID{getRootUUID()})
+	condition := libovsdb.NewCondition("_uuid", "==", uuidParameter)
 
 	// simple mutate operation
 	mutateOp := libovsdb.Operation{


### PR DESCRIPTION
This change fixes the warning 'composite literal uses unkeyed fields' detected by go vet

Signed-off-by: Vandewilly Silva vandewilly.oli.silva@hpe.com
