### PR TITLE
Fix disconnect from calling clearConnection recursively

### DIFF
--- a/client.go
+++ b/client.go
@@ -289,5 +289,4 @@ func handleDisconnectNotification(c *rpc2.Client) {
 // Disconnect will close the OVSDB connection
 func (ovs OvsdbClient) Disconnect() {
 	ovs.rpcClient.Close()
-	clearConnection(ovs.rpcClient)
 }


### PR DESCRIPTION
OvsdbClient `Disconnect()` was calling `clearConnection(ovs.rpcClient)`. `clearConnection()` was also invoked by the `handleDisconnectNotification()` go routine. Because the disconnect handler is invoked anyway, calling `clearConnection(ovs.rpcClient)` directly in Disconnect() was causing a deadlock.
