### PR TITLE
Rename github.com/cenk to github.com/cenkalti

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,8 +11,8 @@ import (
 
 	"os"
 
-	"github.com/cenk/rpc2"
-	"github.com/cenk/rpc2/jsonrpc"
+	"github.com/cenkalti/rpc2"
+	"github.com/cenkalti/rpc2/jsonrpc"
 )
 
 // OvsdbClient is an OVSDB client


### PR DESCRIPTION
The repository github.com/cenk/rpc2 is now pointing to
github.com/cenkalti/rpc2 in GitHub, causing build issues.