### PR TITLE
Rename cenk repository to cenkalty on client.go

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,8 +11,8 @@ import (
 
 	"os"
 
-	"github.com/cenk/rpc2"
-	"github.com/cenk/rpc2/jsonrpc"
+	"github.com/cenkalti/rpc2"
+	"github.com/cenkalti/rpc2/jsonrpc"
 )
 
 // OvsdbClient is an OVSDB client


### PR DESCRIPTION
@dave-tucker Please, take a look.

The repository below changed the canonical name and currently the libovsdb is not compiling if you create your environment from scratch:

old:
"github.com/cenk/rpc2"

new:
"github.com/cenkalti/rpc2"