### PR TITLE
Removed 'omitempty' from Operation.Where json tag

### DIFF
--- a/notation.go
+++ b/notation.go
@@ -11,7 +11,7 @@ type Operation struct {
 	Columns   []string                 `json:"columns,omitempty"`
 	Mutations []interface{}            `json:"mutations,omitempty"`
 	Timeout   int                      `json:"timeout,omitempty"`
-	Where     []interface{}            `json:"where,omitempty"`
+	Where     []interface{}            `json:"where"`
 	Until     string                   `json:"until,omitempty"`
 	UUIDName  string                   `json:"uuid-name,omitempty"`
 }


### PR DESCRIPTION
Removed 'omitempty' from Operation.Where json tag to allow querying whole table
RFC7047#5.2.2
> If "where" is an empty array, every row in "table" is selected.