### PR TITLE
Use blocking mode for rpc to enforce ordering for transaction commit

### DIFF
--- a/client.go
+++ b/client.go
@@ -58,6 +58,7 @@ func ConnectUsingProtocol(protocol string, target string) (*OvsdbClient, error) 
 	}
 
 	c := rpc2.NewClientWithCodec(jsonrpc.NewJSONCodec(conn))
+	c.SetBlocking(true)
 	c.Handle("echo", echo)
 	c.Handle("update", update)
 	go c.Run()


### PR DESCRIPTION
When implement cache based on libovsdb, if a transaction commit is
successfully returned, the client should immediately see the new data
from local cache. This is how the C/Python ovsdb idl works. This
behavior is guaranteed by the order of transaction commit response
and update notification for the same commit: the update notification
always come BEFORE the response of the same commit [1]. However, in the
rpc2 go lib used here, the handling of rpc requests is asynchronized
by default thus the order is not preserved. To preserve the ordering,
rpc2 Client can be set to blocking mode. The blocking mode support was
just added by [2]. This patch is to set the Client to blocking mode
so that the ordering problem is resolved.

[1] https://mail.openvswitch.org/pipermail/ovs-discuss/2017-March/043858.html

[2] https://github.com/cenkalti/rpc2/pull/14