### PR TITLE
Pass correct context to update notification callbacks

### DIFF
--- a/client.go
+++ b/client.go
@@ -196,7 +196,7 @@ func update(client *rpc2.Client, params []interface{}, reply *interface{}) error
 		connections[client].handlersMutex.Lock()
 		defer connections[client].handlersMutex.Unlock()
 		for _, handler := range connections[client].handlers {
-			handler.Update(params, tableUpdates)
+			handler.Update(params[0], tableUpdates)
 		}
 	}
 


### PR DESCRIPTION
In the current implementation, the first argument passed to Update() callback is an array with the context and the tableUpdates, which is also being passed as the second argument. Thus, tableUpdates is being passed twice.

This patch fixes that by passing only the context as the first argument. It also makes the API more consistent with the RFC.
