### PR TITLE
Provides correct unmarshalling for results rows

### DIFF
--- a/notation.go
+++ b/notation.go
@@ -110,11 +110,11 @@ type TransactResponse struct {
 
 // OperationResult is the result of an Operation
 type OperationResult struct {
-	Count   int                      `json:"count,omitempty"`
-	Error   string                   `json:"error,omitempty"`
-	Details string                   `json:"details,omitempty"`
-	UUID    UUID                     `json:"uuid,omitempty"`
-	Rows    []ResultRow              `json:"rows,omitempty"`
+	Count   int         `json:"count,omitempty"`
+	Error   string      `json:"error,omitempty"`
+	Details string      `json:"details,omitempty"`
+	UUID    UUID        `json:"uuid,omitempty"`
+	Rows    []ResultRow `json:"rows,omitempty"`
 }
 
 func ovsSliceToGoNotation(val interface{}) (interface{}, error) {

--- a/notation.go
+++ b/notation.go
@@ -114,7 +114,7 @@ type OperationResult struct {
 	Error   string                   `json:"error,omitempty"`
 	Details string                   `json:"details,omitempty"`
 	UUID    UUID                     `json:"uuid,omitempty"`
-	Rows    []map[string]interface{} `json:"rows,omitempty"`
+	Rows    []ResultRow              `json:"rows,omitempty"`
 }
 
 func ovsSliceToGoNotation(val interface{}) (interface{}, error) {

--- a/row.go
+++ b/row.go
@@ -21,3 +21,21 @@ func (r *Row) UnmarshalJSON(b []byte) (err error) {
 	}
 	return err
 }
+
+// ResultRow is an properly unmarshalled row returned by Transact
+type ResultRow map[string]interface{}
+
+// UnmarshalJSON unmarshalls a byte array to an OVSDB Row
+func (r *ResultRow) UnmarshalJSON(b []byte) (err error) {
+	*r = make(map[string]interface{})
+	var raw map[string]interface{}
+	err = json.Unmarshal(b, &raw)
+	for key, val := range raw {
+		val, err = ovsSliceToGoNotation(val)
+		if err != nil {
+			return err
+		}
+		(*r)[key] = val
+	}
+	return err
+}


### PR DESCRIPTION
Provides correct unmarshalling for results rows as suggested at socketplane/libovsdb#43.

Will break compatibility with existing code expecting raw data instead of libovsd interfaces (UUID, Map and Set)