### PR TITLE
Provides correct unmarshalling for results rows

### DIFF
--- a/client.go
+++ b/client.go
@@ -205,7 +205,7 @@ func update(client *rpc2.Client, params []interface{}, reply *interface{}) error
 
 // GetSchema returns the schema in use for the provided database name
 // RFC 7047 : get_schema
-func (ovs OvsdbClient) GetSchema(dbName string) (*DatabaseSchema, error) {
+func (ovs *OvsdbClient) GetSchema(dbName string) (*DatabaseSchema, error) {
 	args := NewGetSchemaArgs(dbName)
 	var reply DatabaseSchema
 	err := ovs.rpcClient.Call("get_schema", args, &reply)
@@ -218,7 +218,7 @@ func (ovs OvsdbClient) GetSchema(dbName string) (*DatabaseSchema, error) {
 
 // ListDbs returns the list of databases on the server
 // RFC 7047 : list_dbs
-func (ovs OvsdbClient) ListDbs() ([]string, error) {
+func (ovs *OvsdbClient) ListDbs() ([]string, error) {
 	var dbs []string
 	err := ovs.rpcClient.Call("list_dbs", nil, &dbs)
 	if err != nil {
@@ -229,7 +229,7 @@ func (ovs OvsdbClient) ListDbs() ([]string, error) {
 
 // Transact performs the provided Operation's on the database
 // RFC 7047 : transact
-func (ovs OvsdbClient) Transact(database string, operation ...Operation) ([]OperationResult, error) {
+func (ovs *OvsdbClient) Transact(database string, operation ...Operation) ([]OperationResult, error) {
 	var reply []OperationResult
 	db, ok := ovs.Schema[database]
 	if !ok {
@@ -249,7 +249,7 @@ func (ovs OvsdbClient) Transact(database string, operation ...Operation) ([]Oper
 }
 
 // MonitorAll is a convenience method to monitor every table/column
-func (ovs OvsdbClient) MonitorAll(database string, jsonContext interface{}) (*TableUpdates, error) {
+func (ovs *OvsdbClient) MonitorAll(database string, jsonContext interface{}) (*TableUpdates, error) {
 	schema, ok := ovs.Schema[database]
 	if !ok {
 		return nil, errors.New("invalid Database Schema")
@@ -275,7 +275,7 @@ func (ovs OvsdbClient) MonitorAll(database string, jsonContext interface{}) (*Ta
 
 // Monitor will provide updates for a given table/column
 // RFC 7047 : monitor
-func (ovs OvsdbClient) Monitor(database string, jsonContext interface{}, requests map[string]MonitorRequest) (*TableUpdates, error) {
+func (ovs *OvsdbClient) Monitor(database string, jsonContext interface{}, requests map[string]MonitorRequest) (*TableUpdates, error) {
 	var reply TableUpdates
 
 	args := NewMonitorArgs(database, jsonContext, requests)
@@ -322,7 +322,7 @@ func handleDisconnectNotification(c *rpc2.Client) {
 }
 
 // Disconnect will close the OVSDB connection
-func (ovs OvsdbClient) Disconnect() {
+func (ovs *OvsdbClient) Disconnect() {
 	ovs.rpcClient.Close()
 	clearConnection(ovs.rpcClient)
 }

--- a/notation.go
+++ b/notation.go
@@ -110,11 +110,11 @@ type TransactResponse struct {
 
 // OperationResult is the result of an Operation
 type OperationResult struct {
-	Count   int                      `json:"count,omitempty"`
-	Error   string                   `json:"error,omitempty"`
-	Details string                   `json:"details,omitempty"`
-	UUID    UUID                     `json:"uuid,omitempty"`
-	Rows    []ResultRow              `json:"rows,omitempty"`
+	Count   int         `json:"count,omitempty"`
+	Error   string      `json:"error,omitempty"`
+	Details string      `json:"details,omitempty"`
+	UUID    UUID        `json:"uuid,omitempty"`
+	Rows    []ResultRow `json:"rows,omitempty"`
 }
 
 func ovsSliceToGoNotation(val interface{}) (interface{}, error) {

--- a/notation.go
+++ b/notation.go
@@ -114,7 +114,7 @@ type OperationResult struct {
 	Error   string                   `json:"error,omitempty"`
 	Details string                   `json:"details,omitempty"`
 	UUID    UUID                     `json:"uuid,omitempty"`
-	Rows    []map[string]interface{} `json:"rows,omitempty"`
+	Rows    []ResultRow              `json:"rows,omitempty"`
 }
 
 func ovsSliceToGoNotation(val interface{}) (interface{}, error) {

--- a/row.go
+++ b/row.go
@@ -21,3 +21,21 @@ func (r *Row) UnmarshalJSON(b []byte) (err error) {
 	}
 	return err
 }
+
+// ResultRow is an properly unmarshalled row returned by Transact
+type ResultRow map[string]interface{}
+
+// UnmarshalJSON unmarshalls a byte array to an OVSDB Row
+func (r *ResultRow) UnmarshalJSON(b []byte) (err error) {
+	*r = make(map[string]interface{})
+	var raw map[string]interface{}
+	err = json.Unmarshal(b, &raw)
+	for key, val := range raw {
+		val, err = ovsSliceToGoNotation(val)
+		if err != nil {
+			return err
+		}
+		(*r)[key] = val
+	}
+	return err
+}

--- a/schema.go
+++ b/schema.go
@@ -44,19 +44,25 @@ func (schema DatabaseSchema) validateOperations(operations ...Operation) bool {
 		if ok {
 			for column := range op.Row {
 				if _, ok := table.Columns[column]; !ok {
-					return false
+					if column != "_uuid" && column != "_version" {
+						return false
+					}
 				}
 			}
 			for _, row := range op.Rows {
 				for column := range row {
 					if _, ok := table.Columns[column]; !ok {
-						return false
+						if column != "_uuid" && column != "_version" {
+							return false
+						}
 					}
 				}
 			}
 			for _, column := range op.Columns {
 				if _, ok := table.Columns[column]; !ok {
-					return false
+					if column != "_uuid" && column != "_version" {
+						return false
+					}
 				}
 			}
 		} else {


### PR DESCRIPTION
Provides correct unmarshalling for results rows as suggested at socketplane/libovsdb#43.

Will break compatibility with existing code expecting raw data instead of libovsd interfaces (UUID, Map and Set)