### PR TITLE
Improve Monitor tests

### DIFF
--- a/ovs_integration_test.go
+++ b/ovs_integration_test.go
@@ -242,10 +242,40 @@ func TestMonitor(t *testing.T) {
 		panic(err)
 	}
 
-	reply, err := ovs.MonitorAll("Open_vSwitch", nil)
+	requests := make(map[string]MonitorRequest)
+	requests["Bridge"] = MonitorRequest{
+		Columns: []string{"name"},
+		Select: MonitorSelect{
+			Initial: true,
+			Insert:  true,
+			Delete:  true,
+			Modify:  true,
+		}}
+
+	reply, err := ovs.Monitor("Open_vSwitch", nil, requests)
 
 	if reply == nil || err != nil {
 		t.Error("Monitor operation failed with reply=", reply, " and error=", err)
+	}
+	ovs.Disconnect()
+}
+
+func TestMonitorAll(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ovs, err := Connect(os.Getenv("DOCKER_IP"), int(6640))
+	if err != nil {
+		log.Fatal("Failed to Connect. error:", err)
+		panic(err)
+	}
+
+	reply, err := ovs.MonitorAll("Open_vSwitch", nil)
+
+	if reply == nil || err != nil {
+		t.Error("Monitor All operation failed with reply=", reply, " and error=", err)
 	}
 	ovs.Disconnect()
 }


### PR DESCRIPTION
This change creates a particular test to validate the MonitorAll
function and fix the current TestMonitor to call the Monitor api instead
of the MonitorAll api.