### PR TITLE
Implement a Cache For Monitor Updates

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,272 @@
+package libovsdb
+
+import (
+	"reflect"
+	"sync"
+
+	"log"
+)
+
+const (
+	updateEvent = "update"
+	addEvent    = "add"
+	deleteEvent = "delete"
+	bufferSize  = 65536
+)
+
+// RowCache is a collections of Rows hashed by UUID
+type RowCache struct {
+	cache map[string]Row
+	mutex sync.RWMutex
+}
+
+// Row returns one row the from the cache by UUID
+func (r *RowCache) Row(uuid string) *Row {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	if row, ok := r.cache[uuid]; ok {
+		return &row
+	}
+	return nil
+}
+
+// Rows returns a list of row UUIDs as strings
+func (r *RowCache) Rows() []string {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	var result []string
+	for k := range r.cache {
+		result = append(result, k)
+	}
+	return result
+}
+
+func newRowCache() *RowCache {
+	return &RowCache{
+		cache: make(map[string]Row),
+	}
+}
+
+// EventHandler can handle events when the contents of the cache changes
+type EventHandler interface {
+	OnAdd(table string, row Row)
+	OnUpdate(table string, old Row, new Row)
+	OnDelete(table string, row Row)
+}
+
+// EventHandlerFuncs is a wrapper for the EventHandler interface
+// It allows a caller to only implement the functions they need
+type EventHandlerFuncs struct {
+	AddFunc    func(table string, row Row)
+	UpdateFunc func(table string, old Row, new Row)
+	DeleteFunc func(table string, row Row)
+}
+
+// OnAdd calls AddFunc if it is not nil
+func (e *EventHandlerFuncs) OnAdd(table string, row Row) {
+	if e.AddFunc != nil {
+		e.AddFunc(table, row)
+	}
+}
+
+// OnUpdate calls UpdateFunc if it is not nil
+func (e *EventHandlerFuncs) OnUpdate(table string, old, new Row) {
+	if e.UpdateFunc != nil {
+		e.UpdateFunc(table, old, new)
+	}
+}
+
+// OnDelete calls DeleteFunc if it is not nil
+func (e *EventHandlerFuncs) OnDelete(table string, row Row) {
+	if e.DeleteFunc != nil {
+		e.DeleteFunc(table, row)
+	}
+}
+
+// TableCache contains a collection of RowCaches, hashed by name,
+// and an array of EventHandlers that respond to cache updates
+type TableCache struct {
+	cache          map[string]*RowCache
+	cacheMutex     sync.RWMutex
+	eventProcessor *eventProcessor
+}
+
+func newTableCache() *TableCache {
+	eventProcessor := newEventProcessor(bufferSize)
+	return &TableCache{
+		cache:          make(map[string]*RowCache),
+		eventProcessor: eventProcessor,
+	}
+}
+
+// Table returns the a Table from the cache with a given name
+func (t *TableCache) Table(name string) *RowCache {
+	t.cacheMutex.RLock()
+	defer t.cacheMutex.RUnlock()
+	if table, ok := t.cache[name]; ok {
+		return table
+	}
+	return nil
+}
+
+// Tables returns a list of table names that are in the cache
+func (t *TableCache) Tables() []string {
+	t.cacheMutex.RLock()
+	defer t.cacheMutex.RUnlock()
+	var result []string
+	for k := range t.cache {
+		result = append(result, k)
+	}
+	return result
+}
+
+// Update implements the update method of the NotificationHandler interface
+// this populates the cache with new updates
+func (t *TableCache) Update(context interface{}, tableUpdates TableUpdates) {
+	if len(tableUpdates.Updates) == 0 {
+		return
+	}
+	t.populate(tableUpdates)
+}
+
+// Locked implements the locked method of the NotificationHandler interface
+func (t *TableCache) Locked([]interface{}) {
+}
+
+// Stolen implements the stolen method of the NotificationHandler interface
+func (t *TableCache) Stolen([]interface{}) {
+}
+
+// Echo implements the echo method of the NotificationHandler interface
+func (t *TableCache) Echo([]interface{}) {
+}
+
+// Disconnected implements the disconnected method of the NotificationHandler interface
+func (t *TableCache) Disconnected() {
+}
+
+// populate adds data to the cache and places an event on the channel
+func (t *TableCache) populate(tableUpdates TableUpdates) {
+	t.cacheMutex.Lock()
+	defer t.cacheMutex.Unlock()
+	for table, updates := range tableUpdates.Updates {
+		var tCache *RowCache
+		var ok bool
+		if tCache, ok = t.cache[table]; !ok {
+			t.cache[table] = newRowCache()
+			tCache = t.cache[table]
+		}
+		tCache.mutex.Lock()
+		for uuid, row := range updates.Rows {
+			if !reflect.DeepEqual(row.New, Row{}) {
+				if existing, ok := tCache.cache[uuid]; ok {
+					if !reflect.DeepEqual(row.New, existing) {
+						tCache.cache[uuid] = row.New
+						t.eventProcessor.AddEvent(updateEvent, table, row.Old, row.New)
+					}
+					// no diff
+					continue
+				}
+				tCache.cache[uuid] = row.New
+				t.eventProcessor.AddEvent(addEvent, table, row.Old, row.New)
+				continue
+			} else {
+				// delete from cache
+				delete(tCache.cache, uuid)
+				t.eventProcessor.AddEvent(deleteEvent, table, row.Old, row.New)
+				continue
+			}
+		}
+		tCache.mutex.Unlock()
+	}
+}
+
+// AddEventHandler registers the supplied EventHandler to recieve cache events
+func (t *TableCache) AddEventHandler(handler EventHandler) {
+	t.eventProcessor.AddEventHandler(handler)
+}
+
+// Run starts the event processing loop. It blocks until the channel is closed.
+func (t *TableCache) Run(stopCh <-chan struct{}) {
+	t.eventProcessor.Run(stopCh)
+}
+
+// event encapsualtes a cache event
+type event struct {
+	eventType string
+	table     string
+	old       Row
+	new       Row
+}
+
+// eventProcessor handles the queueing and processing of cache events
+type eventProcessor struct {
+	events chan event
+	// handlersMutex locks the handlers array when we add a handler or dispatch events
+	// we don't need a RWMutex in this case as we only have one thread reading and the write
+	// volume is very low (i.e only when AddEventHandler is called)
+	handlersMutex sync.Mutex
+	handlers      []EventHandler
+}
+
+func newEventProcessor(capacity int) *eventProcessor {
+	return &eventProcessor{
+		events:   make(chan event, capacity),
+		handlers: []EventHandler{},
+	}
+}
+
+// AddEventHandler registers the supplied EventHandler with the eventProcessor
+// EventHandlers MUST process events quickly, for example, pushing them to a queue
+// to be processed by the client. Long Running handler functions adversely affect
+// other handlers and MAY cause loss of data if the channel buffer is full
+func (e *eventProcessor) AddEventHandler(handler EventHandler) {
+	e.handlersMutex.Lock()
+	defer e.handlersMutex.Unlock()
+	e.handlers = append(e.handlers, handler)
+}
+
+// AddEvent writes an event to the channel
+func (e *eventProcessor) AddEvent(eventType string, table string, old Row, new Row) {
+	// We don't need to check for error here since there
+	// is only a single writer. RPC is run in blocking mode
+	event := event{
+		eventType: eventType,
+		table:     table,
+		old:       old,
+		new:       new,
+	}
+	select {
+	case e.events <- event:
+		// noop
+		return
+	default:
+		log.Print("dropping event because event buffer is full")
+	}
+}
+
+// Run runs the eventProcessor loop.
+// It will block until the stopCh has been closed
+// Otherwise it will wait for events to arrive on the event channel
+// Once recieved, it will dispatch the event to each registered handler
+func (e *eventProcessor) Run(stopCh <-chan struct{}) {
+	for {
+		select {
+		case <-stopCh:
+			return
+		case event := <-e.events:
+			e.handlersMutex.Lock()
+			for _, handler := range e.handlers {
+				switch event.eventType {
+				case addEvent:
+					handler.OnAdd(event.table, event.new)
+				case updateEvent:
+					handler.OnUpdate(event.table, event.old, event.new)
+				case deleteEvent:
+					handler.OnDelete(event.table, event.new)
+				}
+			}
+			e.handlersMutex.Unlock()
+		}
+	}
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,368 @@
+package libovsdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRowCache_Row(t *testing.T) {
+	type fields struct {
+		cache map[string]Row
+	}
+	type args struct {
+		uuid string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *Row
+	}{
+		{
+			"returns a row that exists",
+			fields{cache: map[string]Row{"test": {}}},
+			args{uuid: "test"},
+			&Row{},
+		},
+		{
+			"returns a nil for a row that does not exist",
+			fields{cache: map[string]Row{"test": {}}},
+			args{uuid: "foo"},
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &RowCache{
+				cache: tt.fields.cache,
+			}
+			got := r.Row(tt.args.uuid)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRowCache_Rows(t *testing.T) {
+	type fields struct {
+		cache map[string]Row
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []string
+	}{
+		{
+			"returns a row that exist",
+			fields{cache: map[string]Row{"test1": {}, "test2": {}, "test3": {}}},
+			[]string{"test1", "test2", "test3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &RowCache{
+				cache: tt.fields.cache,
+			}
+			got := r.Rows()
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+func TestEventHandlerFuncs_OnAdd(t *testing.T) {
+	calls := 0
+	type fields struct {
+		AddFunc    func(table string, row Row)
+		UpdateFunc func(table string, old Row, new Row)
+		DeleteFunc func(table string, row Row)
+	}
+	type args struct {
+		table string
+		row   Row
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			"doesn't call nil function",
+			fields{nil, nil, nil},
+			args{"testTable", Row{}},
+		},
+		{
+			"calls onadd function",
+			fields{func(string, Row) {
+				calls++
+			}, nil, nil},
+			args{"testTable", Row{}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &EventHandlerFuncs{
+				AddFunc:    tt.fields.AddFunc,
+				UpdateFunc: tt.fields.UpdateFunc,
+				DeleteFunc: tt.fields.DeleteFunc,
+			}
+			e.OnAdd(tt.args.table, tt.args.row)
+			if e.AddFunc != nil {
+				assert.Equal(t, 1, calls)
+			}
+		})
+	}
+}
+
+func TestEventHandlerFuncs_OnUpdate(t *testing.T) {
+	calls := 0
+	type fields struct {
+		AddFunc    func(table string, row Row)
+		UpdateFunc func(table string, old Row, new Row)
+		DeleteFunc func(table string, row Row)
+	}
+	type args struct {
+		table string
+		old   Row
+		new   Row
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			"doesn't call nil function",
+			fields{nil, nil, nil},
+			args{"testTable", Row{}, Row{}},
+		},
+		{
+			"calls onupdate function",
+			fields{nil, func(string, Row, Row) {
+				calls++
+			}, nil},
+			args{"testTable", Row{}, Row{}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &EventHandlerFuncs{
+				AddFunc:    tt.fields.AddFunc,
+				UpdateFunc: tt.fields.UpdateFunc,
+				DeleteFunc: tt.fields.DeleteFunc,
+			}
+			e.OnUpdate(tt.args.table, tt.args.old, tt.args.new)
+			if e.UpdateFunc != nil {
+				assert.Equal(t, 1, calls)
+			}
+		})
+	}
+}
+
+func TestEventHandlerFuncs_OnDelete(t *testing.T) {
+	calls := 0
+	type fields struct {
+		AddFunc    func(table string, row Row)
+		UpdateFunc func(table string, old Row, new Row)
+		DeleteFunc func(table string, row Row)
+	}
+	type args struct {
+		table string
+		row   Row
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			"doesn't call nil function",
+			fields{nil, nil, nil},
+			args{"testTable", Row{}},
+		},
+		{
+			"calls ondelete function",
+			fields{nil, nil, func(string, Row) {
+				calls++
+			}},
+			args{"testTable", Row{}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &EventHandlerFuncs{
+				AddFunc:    tt.fields.AddFunc,
+				UpdateFunc: tt.fields.UpdateFunc,
+				DeleteFunc: tt.fields.DeleteFunc,
+			}
+			e.OnDelete(tt.args.table, tt.args.row)
+			if e.DeleteFunc != nil {
+				assert.Equal(t, 1, calls)
+			}
+		})
+	}
+}
+
+func TestTableCache_Table(t *testing.T) {
+	type fields struct {
+		cache map[string]*RowCache
+	}
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *RowCache
+	}{
+		{
+			"returns nil for an empty table",
+			fields{
+				cache: map[string]*RowCache{"bar": newRowCache()},
+			},
+			args{
+				"foo",
+			},
+			nil,
+		},
+		{
+			"returns nil for an empty table",
+			fields{
+				cache: map[string]*RowCache{"bar": newRowCache()},
+			},
+			args{
+				"bar",
+			},
+			newRowCache(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := &TableCache{
+				cache: tt.fields.cache,
+			}
+			got := tr.Table(tt.args.name)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTableCache_Tables(t *testing.T) {
+	type fields struct {
+		cache map[string]*RowCache
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []string
+	}{
+		{
+			"returns a table that exists",
+			fields{cache: map[string]*RowCache{"test1": newRowCache(), "test2": newRowCache(), "test3": newRowCache()}},
+			[]string{"test1", "test2", "test3"},
+		},
+		{
+			"returns an empty slice if no tables exist",
+			fields{cache: map[string]*RowCache{}},
+			[]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := &TableCache{
+				cache: tt.fields.cache,
+			}
+			got := tr.Tables()
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+func TestTableCache_populate(t *testing.T) {
+	t.Log("Create")
+	tc := newTableCache()
+	testRow := Row{Fields: map[string]interface{}{"_uuid": "test", "foo": "bar"}}
+	updates := TableUpdates{
+		Updates: map[string]TableUpdate{
+			"Open_vSwitch": {
+				Rows: map[string]RowUpdate{
+					"test": {
+						Old: Row{},
+						New: testRow,
+					},
+				},
+			},
+		},
+	}
+	tc.populate(updates)
+
+	got := tc.cache["Open_vSwitch"].cache["test"]
+	assert.Equal(t, testRow, got)
+
+	t.Log("Update")
+	updatedRow := Row{Fields: map[string]interface{}{"_uuid": "test", "foo": "quux"}}
+	updates = TableUpdates{
+		Updates: map[string]TableUpdate{
+			"Open_vSwitch": {
+				Rows: map[string]RowUpdate{
+					"test": {
+						Old: testRow,
+						New: updatedRow,
+					},
+				},
+			},
+		},
+	}
+	tc.populate(updates)
+
+	got = tc.cache["Open_vSwitch"].cache["test"]
+	assert.Equal(t, updatedRow, got)
+
+	t.Log("Delete")
+	updates = TableUpdates{
+		Updates: map[string]TableUpdate{
+			"Open_vSwitch": {
+				Rows: map[string]RowUpdate{
+					"test": {
+						Old: updatedRow,
+						New: Row{},
+					},
+				},
+			},
+		},
+	}
+
+	tc.populate(updates)
+
+	_, ok := tc.cache["Open_vSwitch"].cache["test"]
+	assert.False(t, ok)
+}
+
+func TestEventProcessor_AddEvent(t *testing.T) {
+	ep := newEventProcessor(16)
+	var events []event
+	for i := 0; i < 17; i++ {
+		events = append(events, event{
+			table:     "bridge",
+			eventType: addEvent,
+			new: Row{
+				Fields: map[string]interface{}{"number": i},
+			},
+		})
+	}
+	// overfill channel so event 16 is dropped
+	for _, e := range events {
+		ep.AddEvent(e.eventType, e.table, Row{}, e.new)
+	}
+	// assert channel is full of events
+	assert.Equal(t, 16, len(ep.events))
+
+	// read events and ensure they are in FIFO order
+	for i := 0; i < 16; i++ {
+		event := <-ep.events
+		assert.Equal(t, Row{Fields: map[string]interface{}{"number": i}}, event.new)
+	}
+
+	// assert channel is empty
+	assert.Equal(t, 0, len(ep.events))
+}

--- a/client.go
+++ b/client.go
@@ -165,7 +165,7 @@ type NotificationHandler interface {
 	// RFC 7047 section 4.1.11 Echo Notification
 	Echo([]interface{})
 
-	Disconnected(*OvsdbClient)
+	Disconnected()
 }
 
 // RFC 7047 : Section 4.1.6 : Echo
@@ -321,7 +321,7 @@ func getTableUpdatesFromRawUnmarshal(raw map[string]map[string]RowUpdate) TableU
 func (ovs *OvsdbClient) clearConnection() {
 	for _, handler := range ovs.handlers {
 		if handler != nil {
-			handler.Disconnected(ovs)
+			handler.Disconnected()
 		}
 	}
 }

--- a/example/play_with_ovs/play_with_ovs.go
+++ b/example/play_with_ovs/play_with_ovs.go
@@ -86,7 +86,7 @@ func createBridge(ovs *libovsdb.OvsdbClient, bridgeName string) {
 	}
 
 	operations := []libovsdb.Operation{insertOp, mutateOp}
-	reply, _ := ovs.Transact(ovsDb, operations...)
+	reply, _ := ovs.Transact(operations...)
 
 	if len(reply) < len(operations) {
 		fmt.Println("Number of Replies should be atleast equal to number of Operations")
@@ -157,7 +157,7 @@ func main() {
 	var notifier myNotifier
 	ovs.Register(notifier)
 
-	initial, _ := ovs.MonitorAll(ovsDb, "")
+	initial, _ := ovs.MonitorAll("")
 	populateCache(*initial)
 
 	fmt.Println(`Silly game of stopping this app when a Bridge with name "stop" is monitored !`)

--- a/example/play_with_ovs/play_with_ovs.go
+++ b/example/play_with_ovs/play_with_ovs.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"reflect"
 
 	"github.com/ovn-org/libovsdb"
 )
@@ -12,33 +11,26 @@ import (
 // Just a demonstration of how an app can use libovsdb library to configure and manage OVS
 const (
 	bridgeTable = "Bridge"
-	ovsDb       = "Open_vSwitch"
-	ovsTable    = ovsDb
+	ovsTable    = "Open_vSwitch"
 )
 
 var quit chan bool
-var update chan *libovsdb.TableUpdates
-var cache map[string]map[string]libovsdb.Row
+var update chan libovsdb.Row
+var rootUUID string
 
 func play(ovs *libovsdb.OvsdbClient) {
 	go processInput(ovs)
-	for currUpdate := range update {
-		for table, tableUpdate := range currUpdate.Updates {
-			if table == bridgeTable {
-				for uuid, row := range tableUpdate.Rows {
-					rowData, err := ovs.API.GetRowData(bridgeTable, &row.New)
-					if err != nil {
-						fmt.Println("ERROR getting Bridge Data", err)
-					}
-					if _, ok := rowData["name"]; ok {
-						name := rowData["name"].(string)
-						if name == "stop" {
-							fmt.Println("Bridge stop detected : ", uuid)
-							ovs.Disconnect()
-							quit <- true
-						}
-					}
-				}
+	for row := range update {
+		rowData, err := ovs.API.GetRowData(bridgeTable, &row)
+		if err != nil {
+			fmt.Println("ERROR getting Bridge Data", err)
+		}
+		if _, ok := rowData["name"]; ok {
+			name := rowData["name"].(string)
+			if name == "stop" {
+				fmt.Println("Bridge stop detected : ", rowData["_uuid"])
+				ovs.Disconnect()
+				quit <- true
 			}
 		}
 	}
@@ -68,7 +60,7 @@ func createBridge(ovs *libovsdb.OvsdbClient, bridgeName string) {
 	if err != nil {
 		log.Fatalf("Mutation Error: %s", err.Error())
 	}
-	condition, err := ovs.API.NewCondition(ovsTable, "_uuid", "==", getRootUUID())
+	condition, err := ovs.API.NewCondition(ovsTable, "_uuid", "==", rootUUID)
 	if err != nil {
 		log.Fatalf("Condition Error: %s", err.Error())
 	}
@@ -114,37 +106,11 @@ func processInput(ovs *libovsdb.OvsdbClient) {
 	}
 }
 
-func getRootUUID() string {
-	for uuid := range cache[ovsTable] {
-		return uuid
-	}
-	return ""
-}
-
-func populateCache(updates libovsdb.TableUpdates) {
-	for table, tableUpdate := range updates.Updates {
-		if _, ok := cache[table]; !ok {
-			cache[table] = make(map[string]libovsdb.Row)
-
-		}
-		for uuid, row := range tableUpdate.Rows {
-			empty := libovsdb.Row{}
-			if !reflect.DeepEqual(row.New, empty) {
-				cache[table][uuid] = row.New
-			} else {
-				delete(cache[table], uuid)
-			}
-		}
-	}
-}
-
 func main() {
 	quit = make(chan bool)
-	update = make(chan *libovsdb.TableUpdates)
-	cache = make(map[string]map[string]libovsdb.Row)
-
+	update = make(chan libovsdb.Row)
 	// By default libovsdb connects to 127.0.0.0:6400.
-	ovs, err := libovsdb.Connect("tcp:", "Open_vSwitch", nil)
+	ovs, err := libovsdb.Connect("tcp:", ovsTable, nil)
 
 	// If you prefer to connect to OVS in a specific location :
 	// ovs, err := libovsdb.Connect("tcp:192.168.56.101:6640", nil)
@@ -152,29 +118,23 @@ func main() {
 	if err != nil {
 		log.Fatal("Unable to Connect ", err)
 	}
-	var notifier myNotifier
-	ovs.Register(notifier)
 
-	initial, _ := ovs.MonitorAll("")
-	populateCache(*initial)
+	ovs.Cache.AddEventHandler(&libovsdb.EventHandlerFuncs{
+		AddFunc: func(table string, row libovsdb.Row) {
+			if table == bridgeTable {
+				update <- row
+			}
+		},
+	})
+
+	err = ovs.MonitorAll("")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rootUUID = ovs.Cache.Table(ovsTable).Rows()[0]
 
 	fmt.Println(`Silly game of stopping this app when a Bridge with name "stop" is monitored !`)
 	go play(ovs)
 	<-quit
-}
-
-type myNotifier struct {
-}
-
-func (n myNotifier) Update(context interface{}, tableUpdates libovsdb.TableUpdates) {
-	populateCache(tableUpdates)
-	update <- &tableUpdates
-}
-func (n myNotifier) Locked([]interface{}) {
-}
-func (n myNotifier) Stolen([]interface{}) {
-}
-func (n myNotifier) Echo([]interface{}) {
-}
-func (n myNotifier) Disconnected() {
 }

--- a/example/play_with_ovs/play_with_ovs.go
+++ b/example/play_with_ovs/play_with_ovs.go
@@ -178,5 +178,5 @@ func (n myNotifier) Stolen([]interface{}) {
 }
 func (n myNotifier) Echo([]interface{}) {
 }
-func (n myNotifier) Disconnected(client *libovsdb.OvsdbClient) {
+func (n myNotifier) Disconnected() {
 }

--- a/example/play_with_ovs/play_with_ovs.go
+++ b/example/play_with_ovs/play_with_ovs.go
@@ -26,7 +26,7 @@ func play(ovs *libovsdb.OvsdbClient) {
 		for table, tableUpdate := range currUpdate.Updates {
 			if table == bridgeTable {
 				for uuid, row := range tableUpdate.Rows {
-					rowData, err := ovs.Apis[ovsDb].GetRowData(bridgeTable, &row.New)
+					rowData, err := ovs.API.GetRowData(bridgeTable, &row.New)
 					if err != nil {
 						fmt.Println("ERROR getting Bridge Data", err)
 					}
@@ -45,14 +45,13 @@ func play(ovs *libovsdb.OvsdbClient) {
 }
 
 func createBridge(ovs *libovsdb.OvsdbClient, bridgeName string) {
-	api := ovs.Apis[ovsDb]
 	namedUUID := "gopher"
 	// bridge row to insert
 	bridge := make(map[string]interface{})
 	bridge["name"] = bridgeName
 	bridge["external_ids"] = map[string]string{"purpose": "fun"}
 
-	brow, err := api.NewRow(bridgeTable, bridge)
+	brow, err := ovs.API.NewRow(bridgeTable, bridge)
 	if err != nil {
 		fmt.Printf("Row Error: %s", err.Error())
 		os.Exit(1)
@@ -67,12 +66,12 @@ func createBridge(ovs *libovsdb.OvsdbClient, bridgeName string) {
 	}
 
 	// Inserting a Bridge row in Bridge table requires mutating the open_vswitch table.
-	mutation, err := api.NewMutation(ovsTable, "bridges", "insert", []string{namedUUID})
+	mutation, err := ovs.API.NewMutation(ovsTable, "bridges", "insert", []string{namedUUID})
 	if err != nil {
 		fmt.Printf("Mutation Error: %s", err.Error())
 		os.Exit(1)
 	}
-	condition, err := api.NewCondition(ovsTable, "_uuid", "==", getRootUUID())
+	condition, err := ovs.API.NewCondition(ovsTable, "_uuid", "==", getRootUUID())
 	if err != nil {
 		fmt.Printf("Condition Error: %s", err.Error())
 		os.Exit(1)
@@ -146,7 +145,7 @@ func main() {
 	cache = make(map[string]map[string]libovsdb.Row)
 
 	// By default libovsdb connects to 127.0.0.0:6400.
-	ovs, err := libovsdb.Connect("tcp:", nil)
+	ovs, err := libovsdb.Connect("tcp:", "Open_vSwitch", nil)
 
 	// If you prefer to connect to OVS in a specific location :
 	// ovs, err := libovsdb.Connect("tcp:192.168.56.101:6640", nil)

--- a/example/stress/stress.go
+++ b/example/stress/stress.go
@@ -34,7 +34,7 @@ func list() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	final, err := ovs.MonitorAll("Open_vSwitch", "")
+	final, err := ovs.MonitorAll("")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -45,7 +45,7 @@ func run() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	initial, _ := ovs.MonitorAll("Open_vSwitch", "")
+	initial, _ := ovs.MonitorAll("")
 	if *verbose {
 		fmt.Printf("initial : %v\n\n", initial)
 	}
@@ -79,7 +79,7 @@ OUTER:
 }
 
 func transact(ovs *libovsdb.OvsdbClient, operations []libovsdb.Operation) (ok bool, uuid string) {
-	reply, _ := ovs.Transact("Open_vSwitch", operations...)
+	reply, _ := ovs.Transact(operations...)
 
 	if len(reply) < len(operations) {
 		fmt.Println("Number of Replies should be atleast equal to number of Operations")

--- a/example/stress/stress.go
+++ b/example/stress/stress.go
@@ -30,7 +30,7 @@ var (
 )
 
 func list() {
-	ovs, err := libovsdb.Connect(*connection, nil)
+	ovs, err := libovsdb.Connect(*connection, "Open_vSwitch", nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -41,7 +41,7 @@ func list() {
 	populateCache(ovs, *final)
 }
 func run() {
-	ovs, err := libovsdb.Connect(*connection, nil)
+	ovs, err := libovsdb.Connect(*connection, "Open_vSwitch", nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func populateCache(ovs *libovsdb.OvsdbClient, updates libovsdb.TableUpdates) {
 			empty := libovsdb.Row{}
 			if !reflect.DeepEqual(row.New, empty) {
 				if *api == "native" {
-					rowData, err := ovs.Apis["Open_vSwitch"].GetRowData(table, &row.New)
+					rowData, err := ovs.API.GetRowData(table, &row.New)
 					if err != nil {
 						log.Fatal(err)
 					}
@@ -133,15 +133,15 @@ func deleteBridge(ovs *libovsdb.OvsdbClient, uuid string) {
 	var mutCondition []interface{}
 
 	if *api == "native" {
-		delCondition, err = ovs.Apis["Open_vSwitch"].NewCondition("Bridge", "_uuid", "==", uuid)
+		delCondition, err = ovs.API.NewCondition("Bridge", "_uuid", "==", uuid)
 		if err != nil {
 			log.Fatal(err)
 		}
-		mutation, err = ovs.Apis["Open_vSwitch"].NewMutation("Open_vSwitch", "bridges", "delete", []string{uuid})
+		mutation, err = ovs.API.NewMutation("Open_vSwitch", "bridges", "delete", []string{uuid})
 		if err != nil {
 			log.Fatal(err)
 		}
-		mutCondition, err = ovs.Apis["Open_vSwitch"].NewMutation("Open_vSwitch", "_uuid", "==", rootUUID)
+		mutCondition, err = ovs.API.NewMutation("Open_vSwitch", "_uuid", "==", rootUUID)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -198,7 +198,7 @@ func createBridge(ovs *libovsdb.OvsdbClient, iter int) {
 		bridge["datapath_id"] = datapathID
 		nbridge["external_ids"] = externalIds
 
-		bridge, err = ovs.Apis["Open_vSwitch"].NewRow("Bridge", nbridge)
+		bridge, err = ovs.API.NewRow("Bridge", nbridge)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -234,11 +234,11 @@ func createBridge(ovs *libovsdb.OvsdbClient, iter int) {
 	// Inserting a Bridge row in Bridge table requires mutating the open_vswitch table.
 	if *api == "native" {
 		// Inserting a Bridge row in Bridge table requires mutating the open_vswitch table.
-		mutation, err = ovs.Apis["Open_vSwitch"].NewMutation("Open_vSwitch", "bridges", "insert", []string{namedUUID})
+		mutation, err = ovs.API.NewMutation("Open_vSwitch", "bridges", "insert", []string{namedUUID})
 		if err != nil {
 			log.Fatalf("Mutation Error: %s", err.Error())
 		}
-		condition, err = ovs.Apis["Open_vSwitch"].NewCondition("Open_vSwitch", "_uuid", "==", rootUUID)
+		condition, err = ovs.API.NewCondition("Open_vSwitch", "_uuid", "==", rootUUID)
 		if err != nil {
 			log.Fatalf("Condition Error: %s", err.Error())
 		}

--- a/example/stress/stress.go
+++ b/example/stress/stress.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"reflect"
 	"runtime"
 	"runtime/pprof"
 
@@ -20,56 +19,44 @@ var verbose = flag.Bool("verbose", false, "Be verbose")
 var connection = flag.String("ovsdb", "unix:/var/run/openvswitch/db.sock", "OVSDB connection string")
 
 var (
-	cache    map[string]map[string]interface{}
-	rootUUID string
-	summary  = map[string]int{
-		"deletions":  0,
-		"insertions": 0,
-		"listings":   0,
-	}
+	rootUUID   string
+	insertions int
+	deletions  int
 )
 
-func list() {
-	ovs, err := libovsdb.Connect(*connection, "Open_vSwitch", nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-	final, err := ovs.MonitorAll("")
-	if err != nil {
-		log.Fatal(err)
-	}
-	populateCache(ovs, *final)
-}
 func run() {
 	ovs, err := libovsdb.Connect(*connection, "Open_vSwitch", nil)
 	if err != nil {
 		log.Fatal(err)
 	}
-	initial, _ := ovs.MonitorAll("")
-	if *verbose {
-		fmt.Printf("initial : %v\n\n", initial)
+	defer ovs.Disconnect()
+	ovs.Cache.AddEventHandler(
+		&libovsdb.EventHandlerFuncs{
+			AddFunc: func(table string, row libovsdb.Row) {
+				insertions++
+			},
+			DeleteFunc: func(table string, row libovsdb.Row) {
+				deletions++
+			},
+		},
+	)
+
+	if err := ovs.MonitorAll(""); err != nil {
+		log.Fatal(err)
 	}
 
 	// Get root UUID
-OUTER:
-	for table, update := range initial.Updates {
-		if table == "Open_vSwitch" {
-			for uuid := range update.Rows {
-				rootUUID = uuid
-				if *verbose {
-					fmt.Printf("rootUUID is %v", rootUUID)
-				}
-				break OUTER
-			}
+	for _, uuid := range ovs.Cache.Table("Open_vSwitch").Rows() {
+		rootUUID = uuid
+		if *verbose {
+			fmt.Printf("rootUUID is %v", rootUUID)
 		}
 	}
 
 	// Remove all existing bridges
-	for table, update := range initial.Updates {
-		if table == "Bridge" {
-			for uuid := range update.Rows {
-				deleteBridge(ovs, uuid)
-			}
+	if ovs.Cache.Table("Bridge") != nil {
+		for _, uuid := range ovs.Cache.Table("Bridge").Rows() {
+			deleteBridge(ovs, uuid)
 		}
 	}
 
@@ -96,34 +83,6 @@ func transact(ovs *libovsdb.OvsdbClient, operations []libovsdb.Operation) (ok bo
 	}
 	uuid = reply[0].UUID.GoUUID
 	return
-}
-
-func populateCache(ovs *libovsdb.OvsdbClient, updates libovsdb.TableUpdates) {
-	cache = make(map[string]map[string]interface{})
-	for table, tableUpdate := range updates.Updates {
-		if _, ok := cache[table]; !ok {
-			cache[table] = make(map[string]interface{})
-		}
-		for uuid, row := range tableUpdate.Rows {
-			empty := libovsdb.Row{}
-			if !reflect.DeepEqual(row.New, empty) {
-				if *api == "native" {
-					rowData, err := ovs.API.GetRowData(table, &row.New)
-					if err != nil {
-						log.Fatal(err)
-					}
-
-					cache[table][uuid] = rowData
-
-				} else {
-					cache[table][uuid] = row.New
-				}
-				summary["listings"]++
-			} else {
-				delete(cache[table], uuid)
-			}
-		}
-	}
 }
 
 func deleteBridge(ovs *libovsdb.OvsdbClient, uuid string) {
@@ -170,7 +129,6 @@ func deleteBridge(ovs *libovsdb.OvsdbClient, uuid string) {
 	operations := []libovsdb.Operation{deleteOp, mutateOp}
 	ok, _ := transact(ovs, operations)
 	if ok {
-		summary["deletions"]++
 		if *verbose {
 			fmt.Println("Bridge Deletion Successful : ", uuid)
 		}
@@ -261,7 +219,6 @@ func createBridge(ovs *libovsdb.OvsdbClient, iter int) {
 	operations := []libovsdb.Operation{insertOp, mutateOp}
 	ok, uuid := transact(ovs, operations)
 	if ok {
-		summary["insertions"]++
 		if *verbose {
 			fmt.Println("Bridge Addition Successful : ", uuid)
 		}
@@ -281,12 +238,10 @@ func main() {
 	}
 
 	run()
-	list()
 
 	fmt.Printf("Summary:\n")
-	fmt.Printf("\tInsertions: %d\n", summary["insertions"])
-	fmt.Printf("\tDeletions: %d\n", summary["deletions"])
-	fmt.Printf("\tLintings: %d\n", summary["listings"])
+	fmt.Printf("\tInsertions: %d\n", insertions)
+	fmt.Printf("\tDeletions: %d\n", deletions)
 
 	if *memprofile != "" {
 		f, err := os.Create(*memprofile)

--- a/ovs_integration_test.go
+++ b/ovs_integration_test.go
@@ -195,7 +195,7 @@ func TestInsertTransactIntegration(t *testing.T) {
 	}
 
 	operations := []Operation{insertOp, mutateOp}
-	reply, err := ovs.Transact("Open_vSwitch", operations...)
+	reply, err := ovs.Transact(operations...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,10 +263,11 @@ func TestDeleteTransactIntegration(t *testing.T) {
 	}
 
 	operations := []Operation{deleteOp, mutateOp}
-	reply, err := ovs.Transact("Open_vSwitch", operations...)
+	reply, err := ovs.Transact(operations...)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if len(reply) < len(operations) {
 		t.Error("Number of Replies should be atleast equal to number of Operations")
 	}
@@ -300,7 +301,7 @@ func TestMonitorIntegration(t *testing.T) {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
 
-	reply, err := ovs.MonitorAll("Open_vSwitch", nil)
+	reply, err := ovs.MonitorAll(nil)
 
 	if reply == nil || err != nil {
 		t.Error("Monitor operation failed with reply=", reply, " and error=", err)
@@ -388,37 +389,6 @@ func (n Notifier) Echo([]interface{}) {
 func (n Notifier) Disconnected(*OvsdbClient) {
 }
 
-func TestDBSchemaValidationIntegration(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
-	SetConfig()
-	if testing.Short() {
-		t.Skip()
-	}
-
-	ovs, err := Connect(cfg.Addr, defDB, nil)
-	if err != nil {
-		t.Fatalf("Failed to Connect. error: %s", err)
-	}
-
-	bridge := make(map[string]interface{})
-	bridge["name"] = "docker-ovs"
-
-	operation := Operation{
-		Op:    "insert",
-		Table: "Bridge",
-		Row:   bridge,
-	}
-
-	_, err = ovs.Transact("Invalid_DB", operation)
-	if err == nil {
-		t.Error("Invalid DB operation Validation failed")
-	}
-
-	ovs.Disconnect()
-}
-
 func TestTableSchemaValidationIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
@@ -441,7 +411,7 @@ func TestTableSchemaValidationIntegration(t *testing.T) {
 		Table: "InvalidTable",
 		Row:   bridge,
 	}
-	_, err = ovs.Transact("Open_vSwitch", operation)
+	_, err = ovs.Transact(operation)
 
 	if err == nil {
 		t.Error("Invalid Table Name Validation failed")
@@ -474,7 +444,7 @@ func TestColumnSchemaInRowValidationIntegration(t *testing.T) {
 		Row:   bridge,
 	}
 
-	_, err = ovs.Transact("Open_vSwitch", operation)
+	_, err = ovs.Transact(operation)
 
 	if err == nil {
 		t.Error("Invalid Column Name Validation failed")
@@ -512,7 +482,7 @@ func TestColumnSchemaInMultipleRowsValidationIntegration(t *testing.T) {
 		Table: "Bridge",
 		Rows:  rows,
 	}
-	_, err = ovs.Transact("Open_vSwitch", operation)
+	_, err = ovs.Transact(operation)
 
 	if err == nil {
 		t.Error("Invalid Column Name Validation failed")
@@ -540,7 +510,7 @@ func TestColumnSchemaValidationIntegration(t *testing.T) {
 		Table:   "Bridge",
 		Columns: []string{"name", "invalidColumn"},
 	}
-	_, err = ovs.Transact("Open_vSwitch", operation)
+	_, err = ovs.Transact(operation)
 
 	if err == nil {
 		t.Error("Invalid Column Name Validation failed")
@@ -575,7 +545,7 @@ func TestMonitorCancelIntegration(t *testing.T) {
 			Modify:  true,
 		}}
 
-	_, _ = ovs.Monitor("Open_vSwitch", monitorID, requests)
+	_, _ = ovs.Monitor(monitorID, requests)
 
 	err = ovs.MonitorCancel(monitorID)
 

--- a/ovs_integration_test.go
+++ b/ovs_integration_test.go
@@ -301,10 +301,9 @@ func TestMonitorIntegration(t *testing.T) {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
 
-	reply, err := ovs.MonitorAll(nil)
-
-	if reply == nil || err != nil {
-		t.Error("Monitor operation failed with reply=", reply, " and error=", err)
+	err = ovs.MonitorAll(nil)
+	if err != nil {
+		t.Fatal(err)
 	}
 	ovs.Disconnect()
 }
@@ -545,7 +544,10 @@ func TestMonitorCancelIntegration(t *testing.T) {
 			Modify:  true,
 		}}
 
-	_, _ = ovs.Monitor(monitorID, requests)
+	err = ovs.Monitor(monitorID, requests)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	err = ovs.MonitorCancel(monitorID)
 

--- a/ovs_integration_test.go
+++ b/ovs_integration_test.go
@@ -386,7 +386,7 @@ func (n Notifier) Stolen([]interface{}) {
 func (n Notifier) Echo([]interface{}) {
 	n.echoChan <- true
 }
-func (n Notifier) Disconnected(*OvsdbClient) {
+func (n Notifier) Disconnected() {
 }
 
 func TestTableSchemaValidationIntegration(t *testing.T) {

--- a/ovs_integration_test.go
+++ b/ovs_integration_test.go
@@ -12,6 +12,7 @@ import (
 const (
 	defOvsRunDir = "/var/run/openvswitch"
 	defOvsSocket = "db.sock"
+	defDB        = "Open_vSwitch"
 )
 
 var cfg *Config
@@ -49,14 +50,14 @@ func TestConnectIntegration(t *testing.T) {
 	go func() {
 		// Use Convenience params. Ignore failure even if any
 
-		_, err := Connect(cfg.Addr, nil)
+		_, err := Connect(cfg.Addr, defDB, nil)
 		if err != nil {
 			log.Println("Couldnt establish OVSDB connection with Defult params. No big deal")
 		}
 	}()
 
 	go func() {
-		ovs, err := Connect(cfg.Addr, nil)
+		ovs, err := Connect(cfg.Addr, defDB, nil)
 		if err != nil {
 			connected <- false
 		} else {
@@ -84,7 +85,7 @@ func TestListDbsIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -106,7 +107,7 @@ func TestListDbsIntegration(t *testing.T) {
 		t.Error("Expected: 'Open_vSwitch'", reply)
 	}
 	var b bytes.Buffer
-	ovs.Schema[reply[0]].Print(&b)
+	ovs.Schema.Print(&b)
 	ovs.Disconnect()
 }
 
@@ -119,7 +120,7 @@ func TestGetSchemasIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -150,7 +151,7 @@ func TestInsertTransactIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -233,7 +234,7 @@ func TestDeleteTransactIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -294,7 +295,7 @@ func TestMonitorIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -316,7 +317,7 @@ func TestNotifyIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -350,7 +351,7 @@ func TestRemoveNotifyIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -396,7 +397,7 @@ func TestDBSchemaValidationIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -427,7 +428,7 @@ func TestTableSchemaValidationIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -458,7 +459,7 @@ func TestColumnSchemaInRowValidationIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -491,7 +492,7 @@ func TestColumnSchemaInMultipleRowsValidationIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -529,7 +530,7 @@ func TestColumnSchemaValidationIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -557,7 +558,7 @@ func TestMonitorCancelIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}


### PR DESCRIPTION
(See Original Comments on ebay/libovsdb#35)

This makes a few significant API changes in order to provide a cache for monitor updates.
Not only does it improve the API, but it also makes it possible to implement a `Get` (from cache) in the ORM API proposed in #78 

The API changes are as follows:

1. Restrict the client to have only one DatabaseSchema. This mirrors how ovsdb-server is run in the wild (even though techincally a server can support multiple schemas). This has the advantage of removing the `database` argument from the `Transact`, `Monitor`... APIs
1. Replace `Disconnected(*OvsClient)` with `Disconnected()`.The client needs to know about a handler to register it, but the handler shouldn't need to know about the client. Even if it did, that could be achieved through channels. Either way, the Go compiler didn't seem to like passing that client around once I'd added the cache feature.

The feature itself can be seen in operation in the `play_with_ovs` example.

In short, the `OvsClient` exposes a `Cache` and associated handler to ensure the cache is updated.
As such, a user can call `Monitor` without a handler defined and the initial state and all updates will populate in to the cache.

The cache API is very simple:

```go
# Get a list of all tables
client.Cache.Tables()

# Get a table
client.Cache.Table("Open_vSwitch")

# Get a list of all row uuids in a table
client.Cache.Tables("Open_vSwitch").Rows()

# Get a row in a table by UUID
client.Cache.Tables("Open_vSwitch").Row("uuid")
```

In addition, a user may choose to register a calback so they can perform an action when a cache item is updated:

```go
ovs.Cache.AddEventHandler(&libovsdb.EventHandlerFuncs{
AddFunc: func(table string, row libovsdb.Row) {
	if table == bridgeTable {
		update <- row
	}
},
})
```

Misc changes included in this PR to make sure CI is green:

1. Fix linting/formatting of `encoding_test.go`
2. Fix play_with_ovs which was a case of `s/"ovsTable"/ovsTable/g`

/cc @amorenoz @hzhou8 

Closes: #85 