### PR TITLE
Update CI to test against more OVS Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,23 @@ on:
 jobs:
 
   build:
-    name: Build
+    name: Build & Test
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ovs_version:
+          - latest
+          - 2.15.0
+          - 2.14.0
+          - 2.13.0
+
     services:
-      openvswitch:
-        image: socketplane/openvswitch:2.4.0
+      ovs:
+        image: libovsdb/ovs:${{ matrix.ovs_version }}
+        options: --tty
         ports:
-        - 6640/tcp
+          - 6640:6640
 
     steps:
 
@@ -39,9 +49,8 @@ jobs:
     - name: Test
       run: go test -race -v -coverprofile=profile.cov ./...
       env:
-        OVS_HOST: localhost
-        OVS_PORT: ${{ job.services.openvswitch.ports[6640] }}
-        
+        OVS_DB: tcp:127.0.0.1:6640
+
     - name: Send coverage
       uses: shogo82148/actions-goveralls@v1
       with:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,0 +1,64 @@
+name: libovsb-ci
+
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    # run weekly to ensure our copy of ovs is up-to-date
+    - cron:  '42 0 * * 0'
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+        - ovs_version: master
+          tag: latest
+        - ovs_version: v2.15.0
+          tag: 2.15.0
+        - ovs_version: v2.14.0
+          tag: 2.14.0
+        - ovs_version: v2.13.0
+          tag: 2.13.0
+
+
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./ovs
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          build-args: OVS_VERSION=${{ matrix.image.ovs_version }}
+          tags: libovdb/ovs:${{ matrix.image.tag }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ test-local: install-deps fmt lint
 	@go test -race -v ./...
 
 test:
+	@docker-compose pull
 	@docker-compose run --rm test
 
 install-deps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,18 +2,17 @@ version: "3"
 
 services:
   ovs:
-    image: socketplane/openvswitch:2.4.0
-    volumes:
-      - ./run:/usr/local/var/run/openvswitch
+    image: libovsdb/ovs:latest
     ports:
       - "6640/tcp"
     cap_add:
       - NET_ADMIN
+    tty: true
   test:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    links:
+    depends_on:
       - ovs
     volumes: 
       - .:/go/src/github.com/socketplane/libovsdb

--- a/ovs/Dockerfile
+++ b/ovs/Dockerfile
@@ -1,0 +1,33 @@
+FROM gcc:10.3.0 as build
+
+ARG OVS_VERSION=v2.15.0
+
+ADD https://github.com/openvswitch/ovs/archive/${OVS_VERSION}.tar.gz /src/
+
+WORKDIR /src
+RUN mkdir -p /src/ovs
+RUN tar --strip-components=1 -C ovs -xvf ${OVS_VERSION}.tar.gz
+
+WORKDIR /src/ovs
+RUN ./boot.sh
+RUN ./configure
+RUN make && make install
+
+FROM debian:sid-slim
+
+COPY --from=build /usr/local/bin/ovs* /usr/local/bin/
+COPY --from=build /usr/local/bin/vtep* /usr/local/bin/
+COPY --from=build /usr/local/sbin/* /usr/local/sbin/
+COPY --from=build /usr/local/etc/openvswitch /usr/local/etc/openvswitch
+COPY --from=build /usr/local/share/openvswitch /usr/local/share/openvswitch
+COPY --from=build /usr/local/lib/lib* /usr/local/lib/
+
+RUN apt-get update && apt-get -qy install libatomic1
+
+RUN ovsdb-tool create /usr/local/etc/openvswitch/conf.db /usr/local/share/openvswitch/vswitch.ovsschema
+
+RUN mkdir -p /usr/local/var/run/openvswitch
+
+ADD start.sh /
+
+ENTRYPOINT ["/start.sh"]

--- a/ovs/start.sh
+++ b/ovs/start.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -mex
+
+ovs_version=$(ovs-vsctl -V | grep ovs-vsctl | awk '{print $4}')
+ovs_db_version=$(ovsdb-tool schema-version /usr/local/share/openvswitch/vswitch.ovsschema)
+
+ovsdb-server --remote=punix:/usr/local/var/run/openvswitch/db.sock --remote=ptcp:6640 --pidfile=ovsdb-server.pid &
+
+# wait for ovsdb server to start
+sleep 0.1
+
+# begin configuring
+ovs-vsctl --no-wait -- init
+ovs-vsctl --no-wait -- set Open_vSwitch . db-version="${ovs_db_version}"
+ovs-vsctl --no-wait -- set Open_vSwitch . ovs-version="${ovs_version}"
+ovs-vsctl --no-wait -- set Open_vSwitch . system-type="docker-ovs"
+ovs-vsctl --no-wait -- set Open_vSwitch . system-version="0.1"
+ovs-vsctl --no-wait -- set Open_vSwitch . external-ids:system-id=`cat /proc/sys/kernel/random/uuid`
+ovs-vsctl --no-wait -- set-manager ptcp:6640
+ovs-appctl -t ovsdb-server ovsdb-server/add-remote db:Open_vSwitch,Open_vSwitch,manager_options
+
+fg %1


### PR DESCRIPTION
This PR adds the following:

- A Dockerfile that builds OVS versions from source (for testing)
- A workflow that pushes these images to Docker Hub
- A matrix in the existing workflow so we test against the latest OVS development release, and other releases between this and the last LTS version.
- Updates the `docker-compose.yml` appropriately for local developement to test again the `libovsdb/ovs:latest` images