### PR TITLE
Add Benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
         go-version: 1.16
       id: go
 
+    - name: Install benchstat
+      run:  go install golang.org/x/perf/cmd/benchstat@latest
+
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
@@ -50,6 +53,27 @@ jobs:
       run: go test -race -v -coverprofile=profile.cov ./...
       env:
         OVS_DB: tcp:127.0.0.1:6640
+
+    - name: Benchmark
+      run: go test -run=XXX -count 5 -bench=. | tee bench.out
+
+    - name: Download Artifacts
+      id: download
+      uses: actions/download-artifact@v2
+      continue-on-error: true
+      with:
+        name: bench.out
+        path: bench-old.out
+
+    - name: Archive Artifacts
+      uses: actions/upload-artifact@v2
+      if: contains(github.ref, 'main')
+      with:
+        path: bench.out
+
+    - name: Compare Benchmarks
+      if: steps.download.outputs.download-path != ''
+      run: benchstat bench-old.out bench.out
 
     - name: Send coverage
       uses: shogo82148/actions-goveralls@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,26 +7,9 @@ on:
     branches: [ main ]
 
 jobs:
-
   build:
-    name: Build & Test
+    name: Build & Unit Test
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        ovs_version:
-          - latest
-          - 2.15.0
-          - 2.14.0
-          - 2.13.0
-
-    services:
-      ovs:
-        image: libovsdb/ovs:${{ matrix.ovs_version }}
-        options: --tty
-        ports:
-          - 6640:6640
-
     steps:
 
     - name: Set up Go 1.16
@@ -46,34 +29,99 @@ jobs:
       with:
         version: v1.39
 
+    - name: Check Formatting
+      run: make fmt
+
     - name: Build
-      run: go build -v .
+      run: make build-local
 
     - name: Test
-      run: go test -race -v -coverprofile=profile.cov ./...
+      run: make test-local
+
+    - name: Upload Unit Test Coverage
+      uses: actions/upload-artifact@v2
+      with:
+        path: unit.cov
+        name: unit.cov
+
+    - name: Benchmark
+      run: make bench-local
+
+    - name: Restore Latest Main Benchmark
+      id: old-benchmark
+      uses: actions/cache@v2
+      with:
+        path: bench-main.out
+        key: benchmark-main-${{ hashfiles('**/*.go') }}
+        restore-keys: |
+          benchmark-main-
+
+    - name: Compare Benchmarks
+      if: hashFiles('bench-main.out') != ''
+      run: benchstat bench-main.out bench.out
+
+    - name: Create New Main Benchmark On Cache Miss
+      if: steps.old-benchmark.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main'
+      run: cp -f bench.out bench-main.out
+
+  test:
+    name: Integration Test
+    needs: build
+    strategy:
+      matrix:
+        ovs_version:
+          - latest
+          - 2.15.0
+          - 2.14.0
+          - 2.13.0
+
+    runs-on: ubuntu-latest
+    services:
+      ovs:
+        image: libovsdb/ovs:${{ matrix.ovs_version }}
+        options: --tty
+        ports:
+          - 6640:6640
+
+    steps:
+    - name: Set up Go 1.16
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.16
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Integration Test
+      run: make integration-test-local
       env:
         OVS_DB: tcp:127.0.0.1:6640
 
-    - name: Benchmark
-      run: go test -run=XXX -count 5 -bench=. | tee bench.out
-
-    - name: Download Artifacts
-      id: download
-      uses: actions/download-artifact@v2
-      continue-on-error: true
-      with:
-        name: bench.out
-        path: bench-old.out
-
-    - name: Archive Artifacts
+    - name: Upload Integration Test Coverage
       uses: actions/upload-artifact@v2
-      if: contains(github.ref, 'main')
       with:
-        path: bench.out
+        path: integration.cov
+        name: integration.cov
 
-    - name: Compare Benchmarks
-      if: steps.download.outputs.download-path != ''
-      run: benchstat bench-old.out bench.out
+  coverage:
+    name: Upload Coverage
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go 1.16
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.16
+      id: go
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Restore Coverage Files
+      uses: actions/download-artifact@v2
+
+    - name: Combine Reports
+      run: cat unit.cov/unit.cov <(tail -n +2 integration.cov/integration.cov) > profile.cov
 
     - name: Send coverage
       uses: shogo82148/actions-goveralls@v1

--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,4 @@ Temporary Items
 *.iml
 
 ### Project-Specific
-
-coverage.out
+*.out

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ Temporary Items
 
 ### Project-Specific
 *.out
+*.cov

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ all: test
 test-local: install-deps fmt lint
 	@echo "+ $@"
 	@go test -race -v ./...
+	@go test -run=XXX -bench=. -cpuprofile=bench.out
 
 test:
 	@docker-compose pull

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,25 @@
-.PHONY: all test test-local install-deps lint fmt
+.PHONY: all local test test-local integration-test-local install-deps lint fmt
 
 all: test
 
-test-local: install-deps fmt lint
+local: install-deps fmt lint build-local test-local bench-local
+
+build-local: 
 	@echo "+ $@"
-	@go test -race -v ./...
-	@go test -run=XXX -bench=. -cpuprofile=bench.out
+	@go build -v .
+
+test-local:
+	@echo "+ $@"
+	@go test -race -coverprofile=unit.cov -short -v ./...
+
+bench-local:
+	@echo "+ $@"
+	@go test -run=XXX -count=3 -bench=. | tee bench.out
+	@benchstat bench.out
+
+integration-test-local:
+	@echo "+ $@"
+	@go test -race -v -coverprofile=integration.cov -run Integration ./...
 
 test:
 	@docker-compose pull
@@ -14,6 +28,7 @@ test:
 install-deps:
 	@echo "+ $@"
 	@golangci-lint --version
+	@go install golang.org/x/perf/cmd/benchstat@latest
 
 lint:
 	@echo "+ $@"
@@ -22,4 +37,3 @@ lint:
 fmt:
 	@echo "+ $@"
 	@test -z "$$(gofmt -s -l . | tee /dev/stderr)"
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,4 +20,4 @@ services:
     environment:
       DOCKER_IP: "ovs"
       OVS_DB: "tcp:ovs:6640"
-    command: make test-local
+    command: make local integration-test-local

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/cenk/hub v1.0.1 // indirect
 	github.com/cenkalti/hub v1.0.1 // indirect
 	github.com/cenkalti/rpc2 v0.0.0-20170726070524-c51a77e5f664
+	github.com/google/uuid v1.2.0 // indirect
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/cenkalti/rpc2 v0.0.0-20170726070524-c51a77e5f664 h1:GqbYbGcGyW6AwuNC+
 github.com/cenkalti/rpc2 v0.0.0-20170726070524-c51a77e5f664/go.mod h1:v2npkhrXyk5BCnkNIiPdRI23Uq6uWPUQGL2hnRcRr/M=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/map_test.go
+++ b/map_test.go
@@ -1,0 +1,62 @@
+package libovsdb
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func benchmarkMap(m map[string]string, b *testing.B) {
+	testMap, err := NewOvsMap(m)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for n := 0; n < b.N; n++ {
+		_, err := json.Marshal(testMap)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+func BenchmarkMapMarshalJSON1(b *testing.B) { benchmarkMap(map[string]string{"foo": "bar"}, b) }
+func BenchmarkMapMarshalJSON2(b *testing.B) {
+	benchmarkMap(map[string]string{"foo": "bar", "baz": "quuz"}, b)
+}
+func BenchmarkMapMarshalJSON3(b *testing.B) {
+	benchmarkMap(map[string]string{"foo": "bar", "baz": "quuz", "foobar": "foobaz"}, b)
+}
+func BenchmarkMapMarshalJSON5(b *testing.B) {
+	benchmarkMap(map[string]string{"foo": "bar", "baz": "quuz", "foofoo": "foobar", "foobaz": "fooquuz", "barfoo": "barbar"}, b)
+}
+func BenchmarkMapMarshalJSON8(b *testing.B) {
+	benchmarkMap(map[string]string{"foo": "bar", "baz": "quuz", "foofoo": "foobar", "foobaz": "fooquuz", "barfoo": "barbar", "barbaz": "barquuz", "bazfoo": "bazbar", "bazbaz": "bazquux"}, b)
+}
+
+func benchmarkMapUnmarshalJSON(data []byte, b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		var m OvsMap
+		err := json.Unmarshal(data, &m)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMapUnmarshalJSON1(b *testing.B) {
+	benchmarkMapUnmarshalJSON([]byte(`[ "map", [["foo","bar"]]]`), b)
+}
+
+func BenchmarkMapUnmarshalJSON2(b *testing.B) {
+	benchmarkMapUnmarshalJSON([]byte(`[ "map", [["foo","bar"],["baz", "quuz"]]]`), b)
+}
+
+func BenchmarkMapUnmarshalJSON3(b *testing.B) {
+	benchmarkMapUnmarshalJSON([]byte(`[ "map", [["foo","bar"],["baz", "quuz"],["foofoo", "foobar"]]]`), b)
+}
+
+func BenchmarkMapUnmarshalJSON5(b *testing.B) {
+	benchmarkMapUnmarshalJSON([]byte(`[ "map", [["foo","bar"],["baz", "quuz"],["foofoo", "foobar"],["foobaz", "fooquuz"], ["barfoo", "barbar"]]]`), b)
+}
+
+func BenchmarkMapUnmarshalJSON8(b *testing.B) {
+	benchmarkMapUnmarshalJSON([]byte(`[ "map", [["foo","bar"],["baz", "quuz"],["foofoo", "foobar"],["foobaz", "fooquuz"], ["barfoo", "barbar"],["barbaz", "barquux"],["bazfoo", "bazbar"], ["bazbaz", "bazquux"]]]`), b)
+}

--- a/ovs_integration_test.go
+++ b/ovs_integration_test.go
@@ -31,7 +31,10 @@ func SetConfig() {
 	}
 }
 
-func TestConnect(t *testing.T) {
+func TestConnectIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	SetConfig()
 	if testing.Short() {
 		t.Skip()
@@ -72,7 +75,10 @@ func TestConnect(t *testing.T) {
 	}
 }
 
-func TestListDbs(t *testing.T) {
+func TestListDbsIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	SetConfig()
 	if testing.Short() {
 		t.Skip()
@@ -104,7 +110,10 @@ func TestListDbs(t *testing.T) {
 	ovs.Disconnect()
 }
 
-func TestGetSchemas(t *testing.T) {
+func TestGetSchemasIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	SetConfig()
 	if testing.Short() {
 		t.Skip()
@@ -132,7 +141,10 @@ func TestGetSchemas(t *testing.T) {
 var bridgeName = "gopher-br7"
 var bridgeUUID string
 
-func TestInsertTransact(t *testing.T) {
+func TestInsertTransactIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	SetConfig()
 	if testing.Short() {
 		t.Skip()
@@ -207,7 +219,10 @@ func TestInsertTransact(t *testing.T) {
 	ovs.Disconnect()
 }
 
-func TestDeleteTransact(t *testing.T) {
+func TestDeleteTransactIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	SetConfig()
 
 	if testing.Short() {
@@ -270,7 +285,10 @@ func TestDeleteTransact(t *testing.T) {
 	ovs.Disconnect()
 }
 
-func TestMonitor(t *testing.T) {
+func TestMonitorIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	SetConfig()
 	if testing.Short() {
 		t.Skip()
@@ -289,7 +307,10 @@ func TestMonitor(t *testing.T) {
 	ovs.Disconnect()
 }
 
-func TestNotify(t *testing.T) {
+func TestNotifyIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	SetConfig()
 	if testing.Short() {
 		t.Skip()
@@ -320,7 +341,10 @@ func TestNotify(t *testing.T) {
 	ovs.Disconnect()
 }
 
-func TestRemoveNotify(t *testing.T) {
+func TestRemoveNotifyIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	SetConfig()
 	if testing.Short() {
 		t.Skip()
@@ -363,7 +387,10 @@ func (n Notifier) Echo([]interface{}) {
 func (n Notifier) Disconnected(*OvsdbClient) {
 }
 
-func TestDBSchemaValidation(t *testing.T) {
+func TestDBSchemaValidationIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	SetConfig()
 	if testing.Short() {
 		t.Skip()
@@ -391,7 +418,10 @@ func TestDBSchemaValidation(t *testing.T) {
 	ovs.Disconnect()
 }
 
-func TestTableSchemaValidation(t *testing.T) {
+func TestTableSchemaValidationIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	SetConfig()
 	if testing.Short() {
 		t.Skip()
@@ -419,7 +449,10 @@ func TestTableSchemaValidation(t *testing.T) {
 	ovs.Disconnect()
 }
 
-func TestColumnSchemaInRowValidation(t *testing.T) {
+func TestColumnSchemaInRowValidationIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	SetConfig()
 	if testing.Short() {
 		t.Skip()
@@ -449,7 +482,10 @@ func TestColumnSchemaInRowValidation(t *testing.T) {
 	ovs.Disconnect()
 }
 
-func TestColumnSchemaInMultipleRowsValidation(t *testing.T) {
+func TestColumnSchemaInMultipleRowsValidationIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	SetConfig()
 	if testing.Short() {
 		t.Skip()
@@ -484,7 +520,10 @@ func TestColumnSchemaInMultipleRowsValidation(t *testing.T) {
 	ovs.Disconnect()
 }
 
-func TestColumnSchemaValidation(t *testing.T) {
+func TestColumnSchemaValidationIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	SetConfig()
 	if testing.Short() {
 		t.Skip()
@@ -509,7 +548,10 @@ func TestColumnSchemaValidation(t *testing.T) {
 	ovs.Disconnect()
 }
 
-func TestMonitorCancel(t *testing.T) {
+func TestMonitorCancelIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	SetConfig()
 	if testing.Short() {
 		t.Skip()

--- a/set_test.go
+++ b/set_test.go
@@ -1,0 +1,162 @@
+package libovsdb
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func benchmarkSetMarshalJSON(s interface{}, b *testing.B) {
+	testSet, err := NewOvsSet(s)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for n := 0; n < b.N; n++ {
+		_, err := json.Marshal(testSet)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+func BenchmarkSetMarshalJSONString1(b *testing.B) { benchmarkSetMarshalJSON("foo", b) }
+func BenchmarkSetMarshalJSONString2(b *testing.B) {
+	benchmarkSetMarshalJSON([]string{"foo", "bar"}, b)
+}
+func BenchmarkSetMarshalJSONString3(b *testing.B) {
+	benchmarkSetMarshalJSON([]string{"foo", "bar", "baz"}, b)
+}
+func BenchmarkSetMarshalJSONString5(b *testing.B) {
+	benchmarkSetMarshalJSON([]string{"foo", "bar", "baz", "quux", "foofoo"}, b)
+}
+func BenchmarkSetMarshalJSONString8(b *testing.B) {
+	benchmarkSetMarshalJSON([]string{"foo", "bar", "baz", "quux", "foofoo", "foobar", "foobaz", "fooquux"}, b)
+}
+
+func BenchmarkSetMarshalJSONInt1(b *testing.B) { benchmarkSetMarshalJSON(1, b) }
+func BenchmarkSetMarshalJSONInt2(b *testing.B) {
+	benchmarkSetMarshalJSON([]int{1, 2}, b)
+}
+func BenchmarkSetMarshalJSONInt3(b *testing.B) {
+	benchmarkSetMarshalJSON([]int{1, 2, 3}, b)
+}
+func BenchmarkSetMarshalJSONInt5(b *testing.B) {
+	benchmarkSetMarshalJSON([]int{1, 2, 3, 4, 5}, b)
+}
+func BenchmarkSetMarshalJSONInt8(b *testing.B) {
+	benchmarkSetMarshalJSON([]int{1, 2, 3, 4, 5, 6, 7, 8}, b)
+}
+
+func BenchmarkSetMarshalJSONFloat1(b *testing.B) { benchmarkSetMarshalJSON(1.0, b) }
+func BenchmarkSetMarshalJSONFloat2(b *testing.B) {
+	benchmarkSetMarshalJSON([]int{1.0, 2.0}, b)
+}
+func BenchmarkSetMarshalJSONFloat3(b *testing.B) {
+	benchmarkSetMarshalJSON([]int{1.0, 2.0, 3.0}, b)
+}
+func BenchmarkSetMarshalJSONFloat5(b *testing.B) {
+	benchmarkSetMarshalJSON([]int{1.0, 2.0, 3.0, 4.0, 5.0}, b)
+}
+func BenchmarkSetMarshalJSONFloat8(b *testing.B) {
+	benchmarkSetMarshalJSON([]int{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0}, b)
+}
+
+func BenchmarkSetMarshalJSONUUID1(b *testing.B) { benchmarkSetMarshalJSON(uuid.New(), b) }
+func BenchmarkSetMarshalJSONUUID2(b *testing.B) {
+	benchmarkSetMarshalJSON([]uuid.UUID{uuid.New(), uuid.New()}, b)
+}
+func BenchmarkSetMarshalJSONUUID3(b *testing.B) {
+	benchmarkSetMarshalJSON([]uuid.UUID{uuid.New(), uuid.New(), uuid.New()}, b)
+}
+func BenchmarkSetMarshalJSONUUID5(b *testing.B) {
+	benchmarkSetMarshalJSON([]uuid.UUID{uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()}, b)
+}
+func BenchmarkSetMarshalJSONUUID8(b *testing.B) {
+	benchmarkSetMarshalJSON([]uuid.UUID{uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()}, b)
+}
+
+func benchmarkSetUnmarshalJSON(data []byte, b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		var s OvsSet
+		err := json.Unmarshal(data, &s)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSetUnmarshalJSONString1(b *testing.B) {
+	benchmarkSetUnmarshalJSON([]byte(`"foo"`), b)
+}
+
+func BenchmarkSetUnmarshalJSONString2(b *testing.B) {
+	benchmarkSetUnmarshalJSON([]byte(`[ "set", ["foo","bar"] ]`), b)
+}
+
+func BenchmarkSetUnmarshalJSONString3(b *testing.B) {
+	benchmarkSetUnmarshalJSON([]byte(`[ "set", ["foo","bar","baz"] ]`), b)
+}
+
+func BenchmarkSetUnmarshalJSONString5(b *testing.B) {
+	benchmarkSetUnmarshalJSON([]byte(`[ "set", ["foo","bar","baz","quuz","foofoo"] ]`), b)
+}
+
+func BenchmarkSetUnmarshalJSONString8(b *testing.B) {
+	benchmarkSetUnmarshalJSON([]byte(`[ "set", ["foo","bar","baz","quuz","foofoo","foobar","foobaz","fooquuz"] ]`), b)
+}
+
+func BenchmarkSetUnmarshalJSONInt1(b *testing.B) { benchmarkSetUnmarshalJSON([]byte("1"), b) }
+func BenchmarkSetUnmarshalJSONInt2(b *testing.B) {
+	benchmarkSetUnmarshalJSON([]byte(`["set", [1, 2]]`), b)
+}
+func BenchmarkSetUnmarshalJSONInt3(b *testing.B) {
+	benchmarkSetUnmarshalJSON([]byte(`["set", [1, 2, 3]]`), b)
+}
+func BenchmarkSetUnmarshalJSONInt5(b *testing.B) {
+	benchmarkSetUnmarshalJSON([]byte(`["set", [1, 2, 3, 4, 5]]`), b)
+}
+func BenchmarkSetUnmarshalJSONInt8(b *testing.B) {
+	benchmarkSetUnmarshalJSON([]byte(`["set", [1, 2, 3, 4, 5, 6, 7, 8]]`), b)
+}
+
+func BenchmarkSetUnmarshalJSONFloat1(b *testing.B) { benchmarkSetUnmarshalJSON([]byte(`1.0`), b) }
+func BenchmarkSetUnmarshalJSONFloat2(b *testing.B) {
+	benchmarkSetUnmarshalJSON([]byte(`["set", [1.0, 2.0]]`), b)
+}
+func BenchmarkSetUnmarshalJSONFloat3(b *testing.B) {
+	benchmarkSetUnmarshalJSON([]byte(`["set", [1.0, 2.0, 3.0]]`), b)
+}
+func BenchmarkSetUnmarshalJSONFloat5(b *testing.B) {
+	benchmarkSetUnmarshalJSON([]byte(`["set", [1.0, 2.0, 3.0, 4.0, 5.0]]`), b)
+}
+func BenchmarkSetUnmarshalJSONFloat8(b *testing.B) {
+	benchmarkSetUnmarshalJSON([]byte(`["set", [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]]`), b)
+}
+
+func BenchmarkSetUnmarshalJSONUUID1(b *testing.B) {
+	benchmarkSetUnmarshalJSON([]byte(`"`+uuid.New().String()+`"`), b)
+}
+func BenchmarkSetUnmarshalJSONUUID2(b *testing.B) {
+	benchmarkSetUnmarshalJSON(setify([]uuid.UUID{uuid.New(), uuid.New()}), b)
+}
+func BenchmarkSetUnmarshalJSONUUID3(b *testing.B) {
+	benchmarkSetUnmarshalJSON(setify([]uuid.UUID{uuid.New(), uuid.New(), uuid.New()}), b)
+}
+func BenchmarkSetUnmarshalJSONUUID5(b *testing.B) {
+	benchmarkSetUnmarshalJSON(setify([]uuid.UUID{uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()}), b)
+}
+func BenchmarkSetUnmarshalJSONUUID8(b *testing.B) {
+	benchmarkSetUnmarshalJSON(setify([]uuid.UUID{uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()}), b)
+}
+
+func setify(i interface{}) []byte {
+	var s []string
+	iv := reflect.ValueOf(i)
+	for j := 0; j < iv.Len(); j++ {
+		s = append(s, fmt.Sprintf("%v", iv.Index(j)))
+	}
+	return []byte(fmt.Sprintf(`[ "set", [ "%s" ]]`, strings.Join(s, `","`)))
+}


### PR DESCRIPTION
This PR add benchmark tests and results comparison in to CI.

**Comparison of two similar benchmarks**

NOTE: % differs by < 2%

``` bash
 $ go tool pprof -top -diff_base=bench.out -normalize -show="github.com/socketplane/libovsdb.*" -hide="github.com/socketplane/libovsdb\.[bB]ench.*" bench1.out 
File: libovsdb.test
Type: cpu
Time: Apr 14, 2021 at 12:02pm (BST)
Duration: 2.94mins, Total samples = 97.83s (55.44%)
Active filters:
   hide=github.com/socketplane/libovsdb\.[bB]ench.*
   show=github.com/socketplane/libovsdb.*
Showing nodes accounting for -0.14s, 0.15% of 97.83s total
      flat  flat%   sum%        cum   cum%
     1.59s  1.63%  1.63%      1.59s  1.63%  github.com/socketplane/libovsdb.OvsSet.MarshalJSON
    -0.92s  0.94%  0.69%     -0.92s  0.94%  github.com/socketplane/libovsdb.OvsMap.MarshalJSON
    -0.63s  0.65% 0.044%     -0.63s  0.65%  github.com/socketplane/libovsdb.(*OvsMap).UnmarshalJSON
    -0.08s 0.084%  0.04%     -0.18s  0.18%  github.com/socketplane/libovsdb.(*OvsSet).UnmarshalJSON
    -0.05s 0.054% 0.094%     -0.09s 0.097%  github.com/socketplane/libovsdb.(*OvsSet).UnmarshalJSON.func1 (inline)
    -0.04s 0.043%  0.14%     -0.04s 0.043%  github.com/socketplane/libovsdb.ovsSliceToGoNotation
    -0.01s  0.01%  0.15%     -0.01s  0.01%  github.com/socketplane/libovsdb.setify
```

**Comparison of tow dissimilar benchmarks**
NOTE: % differs by > 20% where a 1 second sleep was added in the OvsSet.UnmarshalJSON function

``` bash
$ go tool pprof -top -diff_base=bench.out -normalize -show="github.com/socketplane/libovsdb.*" -hide="github.com/socketplane/libovsdb\.[bB]ench.*" bench2.out
File: libovsdb.test
Type: cpu
Time: Apr 14, 2021 at 11:32am (BST)
Duration: 2.75mins, Total samples = 97.83s (59.35%)
Active filters:
   hide=github.com/socketplane/libovsdb\.[bB]ench.*
   show=github.com/socketplane/libovsdb.*
Showing nodes accounting for -3.41s, 3.49% of 97.83s total
Dropped 1 node (cum <= 0.49s)
      flat  flat%   sum%        cum   cum%
   -21.69s 22.17% 22.17%    -24.89s 25.44%  github.com/socketplane/libovsdb.(*OvsSet).UnmarshalJSON
    14.21s 14.52%  7.65%     14.21s 14.52%  github.com/socketplane/libovsdb.OvsSet.MarshalJSON
     4.13s  4.22%  3.43%      4.13s  4.22%  github.com/socketplane/libovsdb.(*OvsMap).UnmarshalJSON
     3.14s  3.21%  0.22%      3.14s  3.21%  github.com/socketplane/libovsdb.OvsMap.MarshalJSON
    -3.06s  3.13%  3.35%     -3.20s  3.27%  github.com/socketplane/libovsdb.(*OvsSet).UnmarshalJSON.func1 (inline)
    -0.14s  0.14%  3.49%     -0.14s  0.14%  github.com/socketplane/libovsdb.ovsSliceToGoNotation
 ```
 
 I'm expecting this to fail CI on the `download-artifact` step, since no artifacts have been generated yet...
 
 Closes: #80