### PR TITLE
Separation of default values and unset fields in MonitorSelect object .

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -271,12 +271,12 @@ func (ovs OvsdbClient) MonitorAll(jsonContext interface{}) error {
 		}
 		requests[table] = ovsdb.MonitorRequest{
 			Columns: columns,
-			Select: ovsdb.MonitorSelect{
-				Initial: true,
-				Insert:  true,
-				Delete:  true,
-				Modify:  true,
-			}}
+			Select: &ovsdb.MonitorSelect{
+				Initial: ovsdb.NewMonitorSelectValue(true),
+				Insert:  ovsdb.NewMonitorSelectValue(true),
+				Delete:  ovsdb.NewMonitorSelectValue(true),
+				Modify:  ovsdb.NewMonitorSelectValue(true)},
+		}
 	}
 	return ovs.Monitor(jsonContext, requests)
 }

--- a/client/ovs_integration_test.go
+++ b/client/ovs_integration_test.go
@@ -517,12 +517,12 @@ func TestMonitorCancelIntegration(t *testing.T) {
 	requests := make(map[string]ovsdb.MonitorRequest)
 	requests["Bridge"] = ovsdb.MonitorRequest{
 		Columns: []string{"name"},
-		Select: ovsdb.MonitorSelect{
-			Initial: true,
-			Insert:  true,
-			Delete:  true,
-			Modify:  true,
-		}}
+		Select: &ovsdb.MonitorSelect{
+			Initial: ovsdb.NewMonitorSelectValue(true),
+			Insert:  ovsdb.NewMonitorSelectValue(true),
+			Delete:  ovsdb.NewMonitorSelectValue(true),
+			Modify:  ovsdb.NewMonitorSelectValue(true)},
+	}
 
 	err = ovs.Monitor(monitorID, requests)
 	if err != nil {

--- a/ovsdb/notation_test.go
+++ b/ovsdb/notation_test.go
@@ -2,6 +2,7 @@ package ovsdb
 
 import (
 	"encoding/json"
+	"github.com/stretchr/testify/assert"
 	"log"
 	"testing"
 )
@@ -163,4 +164,18 @@ func TestNewMutation(t *testing.T) {
 	if string(mutationStr) != expected {
 		t.Error("mutation is not correctly formatted")
 	}
+}
+
+func TestSelectSerialization(t *testing.T) {
+	monitorSelect := MonitorSelect{Initial: NewMonitorSelectValue(true), Delete: NewMonitorSelectValue(false)}
+	jsonSelect, err := json.Marshal(monitorSelect)
+	assert.Nil(t, err)
+	expected := `{"delete":false,"initial":true}`
+	assert.JSONEqf(t, expected, string(jsonSelect), "they should be equal\n")
+
+	var mSelect MonitorSelect
+	err = json.Unmarshal(jsonSelect, &mSelect)
+	assert.Nil(t, err)
+	assert.Equal(t, monitorSelect, mSelect, "they should be equal\n")
+
 }

--- a/ovsdb/rpc_test.go
+++ b/ovsdb/rpc_test.go
@@ -2,6 +2,7 @@ package ovsdb
 
 import (
 	"encoding/json"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -53,12 +54,11 @@ func TestNewMonitorArgs(t *testing.T) {
 	value := 1
 	r := MonitorRequest{
 		Columns: []string{"name", "ports", "external_ids"},
-		Select: MonitorSelect{
-			Initial: true,
-			Insert:  true,
-			Delete:  true,
-			Modify:  true,
-		},
+		Select: &MonitorSelect{
+			Initial: NewMonitorSelectValue(true),
+			Insert:  NewMonitorSelectValue(true),
+			Delete:  NewMonitorSelectValue(true),
+			Modify:  NewMonitorSelectValue(true)},
 	}
 	requests := make(map[string]MonitorRequest)
 	requests["Bridge"] = r
@@ -66,9 +66,7 @@ func TestNewMonitorArgs(t *testing.T) {
 	args := NewMonitorArgs(database, value, requests)
 	argString, _ := json.Marshal(args)
 	expected := `["Open_vSwitch",1,{"Bridge":{"columns":["name","ports","external_ids"],"select":{"initial":true,"insert":true,"delete":true,"modify":true}}}]`
-	if string(argString) != expected {
-		t.Error("Expected: ", expected, " Got: ", string(argString))
-	}
+	assert.JSONEqf(t, expected, string(argString), "they should be equal\n")
 }
 
 func TestNewMonitorCancelArgs(t *testing.T) {


### PR DESCRIPTION
The RFC 7047 defines that if any of the MonitorSelect parameters is not set,
it equals to 'true'.
For example, for "Insert" - 'If "insert" is omitted or true, "update"
notifications are sent for rows newly inserted into the table.'

The current implementation uses bools for the MonitorSelect fields,
so unset fields get the default value -"false", which violates the RFC
definition.

Another small change here is a replacement of the Select field in MonitorRequest
from the MonitorSelect struct by a pointer to the struct.
The Select field has the "omitempty" tag, but the tag doesn't make sense for
structs and Json marshaling adds empty struct (Select[]) for unset Select field.

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>