### PR TITLE
modelgen: Don't append package to output directory

### DIFF
--- a/cmd/modelgen/main.go
+++ b/cmd/modelgen/main.go
@@ -50,7 +50,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if err := os.MkdirAll(filepath.Join(outDir, pkgName), 0700); err != nil {
+	if err := os.MkdirAll(outDir, 0755); err != nil {
 		log.Fatal(err)
 	}
 
@@ -86,7 +86,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		outFile := filepath.Join(outDir, pkgName, gen.FileName())
+		outFile := filepath.Join(outDir, gen.FileName())
 		if err := writeFile(outFile, code); err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
This allows for modelgen to be used by `go generate`,
where a package would have a skeleton `gen.go` file and
modelgen would place all generated files in that directory.

The -o flag can be used to reinstate the original behaviour.
E.g -p foo -o foo.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>