### PR TITLE
api: list all rows if given a empty non-nil slice

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -144,7 +144,7 @@ func (a api) List(result interface{}) error {
 
 	// If given a null slice, fill it in the cache table completely, if not, just up to
 	// its capability
-	if resultVal.IsNil() {
+	if resultVal.IsNil() || resultVal.Cap() == 0 {
 		resultVal.Set(reflect.MakeSlice(resultVal.Type(), 0, tableCache.Len()))
 	}
 	i := resultVal.Len()

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -108,6 +108,14 @@ func TestAPIListSimple(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Len(t, result, 0, "Should be empty since cache is empty")
 	})
+
+	t.Run("ApiList: Empty List", func(t *testing.T) {
+		result := []testLogicalSwitch{}
+		api := newAPI(cache)
+		err := api.List(&result)
+		assert.Nil(t, err)
+		assert.Len(t, result, len(lscacheList))
+	})
 }
 
 func TestAPIListPredicate(t *testing.T) {


### PR DESCRIPTION
This case clearly does not mean the user is trying to do memory
optimizations, so consider it as if it were a nil slice

Fixes #97

Signed-off-by: Adrian Moreno <amorenoz@redhat.com>