### PR TITLE
api: allow Create()ing multiple Models per call

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -43,11 +43,11 @@ type API interface {
 	// preferred way is Where({condition}).List()
 	Get(Model) error
 
-	// Create returns the operation needed to add a model to the Database
+	// Create returns the operation needed to add the model(s) to the Database
 	// Only fields with non-default values will be added to the transaction
 	// If the field associated with column "_uuid" has some content, it will be
 	// treated as named-uuid
-	Create(Model) (*ovsdb.Operation, error)
+	Create(...Model) ([]ovsdb.Operation, error)
 }
 
 // ConditionalAPI is an interface used to perform operations that require / use Conditions
@@ -250,39 +250,44 @@ func (a api) Get(model Model) error {
 
 // Create is a generic function capable of creating any row in the DB
 // A valud Model (pointer to object) must be provided.
-func (a api) Create(model Model) (*ovsdb.Operation, error) {
-	var namedUUID string
-	var err error
+func (a api) Create(models ...Model) ([]ovsdb.Operation, error) {
+	var operations []ovsdb.Operation
 
-	tableName, err := a.getTableFromModel(model)
-	if err != nil {
-		return nil, err
-	}
-	table := a.cache.orm.schema.Table(tableName)
+	for _, model := range models {
+		var namedUUID string
+		var err error
 
-	// Read _uuid field, and use it as named-uuid
-	info, err := newORMInfo(table, model)
-	if err != nil {
-		return nil, err
-	}
-	if uuid, err := info.fieldByColumn("_uuid"); err == nil {
-		namedUUID = uuid.(string)
-	} else {
-		return nil, err
-	}
+		tableName, err := a.getTableFromModel(model)
+		if err != nil {
+			return nil, err
+		}
 
-	row, err := a.cache.orm.newRow(tableName, model)
-	if err != nil {
-		return nil, err
-	}
+		table := a.cache.orm.schema.Table(tableName)
 
-	insertOp := ovsdb.Operation{
-		Op:       opInsert,
-		Table:    tableName,
-		Row:      row,
-		UUIDName: namedUUID,
+		// Read _uuid field, and use it as named-uuid
+		info, err := newORMInfo(table, model)
+		if err != nil {
+			return nil, err
+		}
+		if uuid, err := info.fieldByColumn("_uuid"); err == nil {
+			namedUUID = uuid.(string)
+		} else {
+			return nil, err
+		}
+
+		row, err := a.cache.orm.newRow(tableName, model)
+		if err != nil {
+			return nil, err
+		}
+
+		operations = append(operations, ovsdb.Operation{
+			Op:       opInsert,
+			Table:    tableName,
+			Row:      row,
+			UUIDName: namedUUID,
+		})
 	}
-	return &insertOp, nil
+	return operations, nil
 }
 
 // Mutate returns the operations needed to transform the one Model into another one

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -529,52 +529,77 @@ func TestAPICreate(t *testing.T) {
 
 	test := []struct {
 		name   string
-		input  Model
-		result *ovsdb.Operation
+		input  []Model
+		result []ovsdb.Operation
 		err    bool
 	}{
 		{
 			name:  "empty",
-			input: &testLogicalSwitch{},
-			result: &ovsdb.Operation{
+			input: []Model{&testLogicalSwitch{}},
+			result: []ovsdb.Operation{{
 				Op:       "insert",
 				Table:    "Logical_Switch",
 				Row:      map[string]interface{}{},
 				UUIDName: "",
-			},
+			}},
 			err: false,
 		},
 		{
 			name: "With some values",
-			input: &testLogicalSwitch{
+			input: []Model{&testLogicalSwitch{
 				Name: "foo",
-			},
-			result: &ovsdb.Operation{
+			}},
+			result: []ovsdb.Operation{{
 				Op:       "insert",
 				Table:    "Logical_Switch",
 				Row:      map[string]interface{}{"name": "foo"},
 				UUIDName: "",
-			},
+			}},
 			err: false,
 		},
 		{
 			name: "With named UUID ",
-			input: &testLogicalSwitch{
+			input: []Model{&testLogicalSwitch{
 				UUID: "foo",
-			},
-			result: &ovsdb.Operation{
+			}},
+			result: []ovsdb.Operation{{
 				Op:       "insert",
 				Table:    "Logical_Switch",
 				Row:      map[string]interface{}{},
 				UUIDName: "foo",
+			}},
+			err: false,
+		},
+		{
+			name: "Multiple",
+			input: []Model{
+				&testLogicalSwitch{
+					UUID: "fooUUID",
+					Name: "foo",
+				},
+				&testLogicalSwitch{
+					UUID: "barUUID",
+					Name: "bar",
+				},
 			},
+			result: []ovsdb.Operation{{
+				Op:       "insert",
+				Table:    "Logical_Switch",
+				Row:      map[string]interface{}{"name": "foo"},
+				UUIDName: "fooUUID",
+			}, {
+				Op:       "insert",
+				Table:    "Logical_Switch",
+				Row:      map[string]interface{}{"name": "bar"},
+				UUIDName: "barUUID",
+			}},
 			err: false,
 		},
 	}
 	for _, tt := range test {
 		t.Run(fmt.Sprintf("ApiCreate: %s", tt.name), func(t *testing.T) {
 			api := newAPI(cache)
-			op, err := api.Create(tt.input)
+			op, err := api.Create(tt.input...)
 			if tt.err {
 				assert.NotNil(t, err)
 			} else {

--- a/cmd/stress/stress.go
+++ b/cmd/stress/stress.go
@@ -162,7 +162,7 @@ func createBridge(ovs *client.OvsdbClient, iter int) {
 		log.Fatal(err)
 	}
 
-	operations := []ovsdb.Operation{*insertOp, mutateOp[0]}
+	operations := append(insertOp, mutateOp...)
 	ok, uuid := transact(ovs, operations)
 	if ok {
 		if *verbose {

--- a/example/play_with_ovs/play_with_ovs.go
+++ b/example/play_with_ovs/play_with_ovs.go
@@ -6,7 +6,6 @@ import (
 	"log"
 
 	"github.com/ovn-org/libovsdb/client"
-	"github.com/ovn-org/libovsdb/ovsdb"
 )
 
 // Silly game that detects creation of Bridge named "stop" and exits
@@ -82,7 +81,7 @@ func createBridge(ovs *client.OvsdbClient, bridgeName string) {
 		log.Fatal(err)
 	}
 
-	operations := []ovsdb.Operation{*insertOp, mutateOps[0]}
+	operations := append(insertOp, mutateOps...)
 	reply, err := ovs.Transact(operations...)
 	if err != nil {
 		log.Fatal(err)

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=


### PR DESCRIPTION
Apart from convenient, it has the added benefit of unifyint the API to
return []ovsdb.Operation for all the calls

Fixes: #101 #98 
Signed-off-by: Adrian Moreno <amorenoz@redhat.com>