### PR TITLE
modelgen: Generate golint-safe bindings

### DIFF
--- a/cmd/modelgen/dbmodel.go
+++ b/cmd/modelgen/dbmodel.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ovn-org/libovsdb/client"
 )
 
-// FullDatabaseModel() returns the DatabaseModel object to be used in libovsdb
+// FullDatabaseModel returns the DatabaseModel object to be used in libovsdb
 func FullDatabaseModel() (*client.DBModel, error) {
 	return client.NewDBModel("{{ .DatabaseName }}", map[string]client.Model{
     {{ range $tableName, $structName := .Tables }} "{{ $tableName }}" : &{{ $structName }}{}, 

--- a/cmd/modelgen/table_test.go
+++ b/cmd/modelgen/table_test.go
@@ -66,9 +66,18 @@ type test struct {
 }
 
 func TestFieldName(t *testing.T) {
-	if s := FieldName("foo"); s != "Foo" {
-		t.Fatalf("got %s, wanted Foo", s)
+	cases := []struct {
+		in       string
+		expected string
+	}{
+		{"foo", "Foo"},
 	}
+	for _, tt := range cases {
+		if s := FieldName(tt.in); s != tt.expected {
+			t.Fatalf("got %s, wanted %s", s, tt.expected)
+		}
+	}
+
 }
 
 func TestStructName(t *testing.T) {
@@ -126,7 +135,23 @@ func TestFileName(t *testing.T) {
 }
 
 func TestCamelCase(t *testing.T) {
-	if s := camelCase("foo_bar_baz"); s != "FooBarBaz" {
-		t.Fatalf("got %s, wanted FooBarBaz", s)
+	cases := []struct {
+		in       string
+		expected string
+	}{
+		{"foo_bar_baz", "FooBarBaz"},
+		{"foo-bar-baz", "FooBarBaz"},
+		{"foos-bars-bazs", "FoosBarsBazs"},
+		{"ip_port_mappings", "IPPortMappings"},
+		{"external_ids", "ExternalIDs"},
+		{"ip_prefix", "IPPrefix"},
+		{"dns_records", "DNSRecords"},
+		{"logical_ip", "LogicalIP"},
+		{"ip", "IP"},
+	}
+	for _, tt := range cases {
+		if s := camelCase(tt.in); s != tt.expected {
+			t.Fatalf("got %s, wanted %s", s, tt.expected)
+		}
 	}
 }


### PR DESCRIPTION
This PR 

1. Fixes the comment on FullDatabaseModel so golint doesn't complain
2. Ensures that common initialisms are factored in when calling `camelCase` such that the resulting code passes the golint and go-staticcheck.

Fixes: #105 