### PR TITLE
ovsdb: Add Error Types

### DIFF
--- a/cmd/stress/stress.go
+++ b/cmd/stress/stress.go
@@ -85,20 +85,14 @@ func run() {
 }
 
 func transact(ovs *client.OvsdbClient, operations []ovsdb.Operation) (ok bool, uuid string) {
-	reply, _ := ovs.Transact(operations...)
-
-	if len(reply) < len(operations) {
-		fmt.Println("Number of Replies should be atleast equal to number of Operations")
+	reply, err := ovs.Transact(operations...)
+	if err != nil {
+		ok = false
+		return
 	}
-	ok = true
-	for i, o := range reply {
-		if o.Error != "" && i < len(operations) {
-			fmt.Println("Transaction Failed due to an error :", o.Error, " details:", o.Details, " in ", operations[i])
-			ok = false
-		} else if o.Error != "" {
-			fmt.Println("Transaction Failed due to an error :", o.Error)
-			ok = false
-		}
+	if _, err := ovsdb.CheckOperationResults(reply, operations); err != nil {
+		ok = false
+		return
 	}
 	uuid = reply[0].UUID.GoUUID
 	return

--- a/example/play_with_ovs/play_with_ovs.go
+++ b/example/play_with_ovs/play_with_ovs.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/libovsdb/ovsdb"
 )
 
 // Silly game that detects creation of Bridge named "stop" and exits
@@ -86,23 +87,10 @@ func createBridge(ovs *client.OvsdbClient, bridgeName string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	if len(reply) < len(operations) {
-		fmt.Println("Number of Replies should be atleast equal to number of Operations")
+	if _, err := ovsdb.CheckOperationResults(reply, operations); err != nil {
+		log.Fatal(err)
 	}
-	ok := true
-	for i, o := range reply {
-		if o.Error != "" && i < len(operations) {
-			fmt.Println("Transaction Failed due to an error :", o.Error, " details:", o.Details, " in ", operations[i])
-			ok = false
-		} else if o.Error != "" {
-			fmt.Println("Transaction Failed due to an error :", o.Error)
-			ok = false
-		}
-	}
-	if ok {
-		fmt.Println("Bridge Addition Successful : ", reply[0].UUID.GoUUID)
-	}
+	fmt.Println("Bridge Addition Successful : ", reply[0].UUID.GoUUID)
 }
 
 func processInput(ovs *client.OvsdbClient) {

--- a/ovsdb/error.go
+++ b/ovsdb/error.go
@@ -1,0 +1,333 @@
+package ovsdb
+
+import "fmt"
+
+const (
+	referentialIntegrityViolation = "referential integrity violation"
+	constraintViolation           = "constraint violation"
+	resourcesExhausted            = "resources exhausted"
+	ioError                       = "I/O error"
+	duplicateUUIDName             = "duplicate uuid name"
+	domainError                   = "domain error"
+	rangeError                    = "range error"
+	timedOut                      = "timed out"
+	notSupported                  = "not supported"
+	aborted                       = "aborted"
+	notOwner                      = "not owner"
+)
+
+// errorFromResult returns an specific OVSDB error type from
+// an OperationResult
+func errorFromResult(op *Operation, r OperationResult) OperationError {
+	if r.Error == "" {
+		return nil
+	}
+	switch r.Error {
+	case referentialIntegrityViolation:
+		return &ReferentialIntegrityViolation{r.Details, op}
+	case constraintViolation:
+		return &ConstraintViolation{r.Details, op}
+	case resourcesExhausted:
+		return &ResourcesExhausted{r.Details, op}
+	case ioError:
+		return &IOError{r.Details, op}
+	case duplicateUUIDName:
+		return &DuplicateUUIDName{r.Details, op}
+	case domainError:
+		return &DomainError{r.Details, op}
+	case rangeError:
+		return &RangeError{r.Details, op}
+	case timedOut:
+		return &TimedOut{r.Details, op}
+	case notSupported:
+		return &NotSupported{r.Details, op}
+	case aborted:
+		return &Aborted{r.Details, op}
+	case notOwner:
+		return &NotOwner{r.Details, op}
+	default:
+		return &Error{r.Error, r.Details, op}
+	}
+}
+
+// CheckOperationResults checks whether the provided operation was a success
+// If the operation was a success, it will return nil, nil
+// If the operation failed, due to a error committing the transaction it will
+// return nil, error.
+// Finally, in the case where one or more of the operations in the transaction
+// failed, we return []OperationErrors, error
+// Within []OperationErrors, the OperationErrors.Index() corresponds to the same index in
+// the original Operations struct. You may also perform type assertions against
+// the error so the caller can decide how best to handle it
+func CheckOperationResults(result []OperationResult, ops []Operation) ([]OperationError, error) {
+	// this shouldn't happen, but we'll cover the case to be certain
+	if len(result) < len(ops) {
+		return nil, fmt.Errorf("ovsdb transaction error. %d operations submitted but only %d results recieved", len(ops), len(result))
+	}
+	var errs []OperationError
+	for i, op := range result {
+		// RFC 7047: if all of the operations succeed, but the results cannot
+		// be committed, then "result" will have one more element than "params",
+		// with the additional element being an <error>.
+		if i >= len(ops) {
+			return errs, errorFromResult(nil, op)
+		}
+		if err := errorFromResult(&ops[i], op); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return errs, fmt.Errorf("%d ovsdb operations failed", len(errs))
+	}
+	return nil, nil
+}
+
+// OperationError represents an error that occurred as part of an
+// OVSDB Operation
+type OperationError interface {
+	error
+	// Operation is a pointer to the operation which casued the error
+	Operation() *Operation
+}
+
+// ReferentialIntegrityViolation is explained in RFC 7047 4.1.3
+type ReferentialIntegrityViolation struct {
+	details   string
+	operation *Operation
+}
+
+// Error implements the error interface
+func (e *ReferentialIntegrityViolation) Error() string {
+	msg := referentialIntegrityViolation
+	if e.details != "" {
+		msg += ": " + e.details
+	}
+	return msg
+}
+
+// Operation implements the OperationError interface
+func (e *ReferentialIntegrityViolation) Operation() *Operation {
+	return e.operation
+}
+
+// ConstraintViolation is described in RFC 7047: 4.1.3
+type ConstraintViolation struct {
+	details   string
+	operation *Operation
+}
+
+// Error implements the error interface
+func (e *ConstraintViolation) Error() string {
+	msg := constraintViolation
+	if e.details != "" {
+		msg += ": " + e.details
+	}
+	return msg
+}
+
+// Operation implements the OperationError interface
+func (e *ConstraintViolation) Operation() *Operation {
+	return e.operation
+}
+
+// ResourcesExhasued is described in RFC 7047: 4.1.3
+type ResourcesExhausted struct {
+	details   string
+	operation *Operation
+}
+
+// Error implements the error interface
+func (e *ResourcesExhausted) Error() string {
+	msg := resourcesExhausted
+	if e.details != "" {
+		msg += ": " + e.details
+	}
+	return msg
+}
+
+// Operation implements the OperationError interface
+func (e *ResourcesExhausted) Operation() *Operation {
+	return e.operation
+}
+
+// IOError is described in RFC7047: 4.1.3
+type IOError struct {
+	details   string
+	operation *Operation
+}
+
+// Error implements the error interface
+func (e *IOError) Error() string {
+	msg := ioError
+	if e.details != "" {
+		msg += ": " + e.details
+	}
+	return msg
+}
+
+// Operation implements the OperationError interface
+func (e *IOError) Operation() *Operation {
+	return e.operation
+}
+
+// DuplicateUUIDName is described in RFC7047 5.2.1
+type DuplicateUUIDName struct {
+	details   string
+	operation *Operation
+}
+
+// Error implements the error interface
+func (e *DuplicateUUIDName) Error() string {
+	msg := duplicateUUIDName
+	if e.details != "" {
+		msg += ": " + e.details
+	}
+	return msg
+}
+
+// Operation implements the OperationError interface
+func (e *DuplicateUUIDName) Operation() *Operation {
+	return e.operation
+}
+
+// DomainError is described in RFC 7047: 5.2.4
+type DomainError struct {
+	details   string
+	operation *Operation
+}
+
+// Error implements the error interface
+func (e *DomainError) Error() string {
+	msg := domainError
+	if e.details != "" {
+		msg += ": " + e.details
+	}
+	return msg
+}
+
+// Operation implements the OperationError interface
+func (e *DomainError) Operation() *Operation {
+	return e.operation
+}
+
+// RangeError is described in RFC 7047: 5.2.4
+type RangeError struct {
+	details   string
+	operation *Operation
+}
+
+// Error implements the error interface
+func (e *RangeError) Error() string {
+	msg := rangeError
+	if e.details != "" {
+		msg += ": " + e.details
+	}
+	return msg
+}
+
+// Operation implements the OperationError interface
+func (e *RangeError) Operation() *Operation {
+	return e.operation
+}
+
+// TimedOut is described in RFC 7047: 5.2.6
+type TimedOut struct {
+	details   string
+	operation *Operation
+}
+
+// Error implements the error interface
+func (e *TimedOut) Error() string {
+	msg := timedOut
+	if e.details != "" {
+		msg += ": " + e.details
+	}
+	return msg
+}
+
+// Operation implements the OperationError interface
+func (e *TimedOut) Operation() *Operation {
+	return e.operation
+}
+
+// NotSupported is described in RFC 7047: 5.2.7
+type NotSupported struct {
+	details   string
+	operation *Operation
+}
+
+// Error implements the error interface
+func (e *NotSupported) Error() string {
+	msg := notSupported
+	if e.details != "" {
+		msg += ": " + e.details
+	}
+	return msg
+}
+
+// Operation implements the OperationError interface
+func (e *NotSupported) Operation() *Operation {
+	return e.operation
+}
+
+// ABorted is described in RFC 7047: 5.2.8
+type Aborted struct {
+	details   string
+	operation *Operation
+}
+
+// Error implements the error interface
+func (e *Aborted) Error() string {
+	msg := aborted
+	if e.details != "" {
+		msg += ": " + e.details
+	}
+	return msg
+}
+
+// Operation implements the OperationError interface
+func (e *Aborted) Operation() *Operation {
+	return e.operation
+}
+
+// NotOwner is described in RFC 7047: 5.2.9
+type NotOwner struct {
+	details   string
+	operation *Operation
+}
+
+// Error implements the error interface
+func (e *NotOwner) Error() string {
+	msg := notOwner
+	if e.details != "" {
+		msg += ": " + e.details
+	}
+	return msg
+}
+
+// Operation implements the OperationError interface
+func (e *NotOwner) Operation() *Operation {
+	return e.operation
+}
+
+// Error is a generic OVSDB Error type that implements the
+// OperationError and error interfaces
+type Error struct {
+	name      string
+	details   string
+	operation *Operation
+}
+
+// Error implements the error interface
+func (e *Error) Error() string {
+	msg := e.name
+	if e.details != "" {
+		msg += ": " + e.details
+	}
+	return msg
+}
+
+// Operation implements the OperationError interface
+func (e *Error) Operation() *Operation {
+	return e.operation
+}

--- a/ovsdb/error_test.go
+++ b/ovsdb/error_test.go
@@ -1,0 +1,136 @@
+package ovsdb
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorFromResult(t *testing.T) {
+	type args struct {
+		op *Operation
+		r  OperationResult
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected interface{}
+	}{
+		{
+			referentialIntegrityViolation,
+			args{nil, OperationResult{Error: referentialIntegrityViolation}},
+			&ReferentialIntegrityViolation{},
+		},
+		{
+			constraintViolation,
+			args{nil, OperationResult{Error: constraintViolation}},
+			&ConstraintViolation{},
+		},
+		{
+			resourcesExhausted,
+			args{nil, OperationResult{Error: resourcesExhausted}},
+			&ResourcesExhausted{},
+		},
+		{
+			ioError,
+			args{nil, OperationResult{Error: ioError}},
+			&IOError{},
+		},
+		{
+			duplicateUUIDName,
+			args{nil, OperationResult{Error: duplicateUUIDName}},
+			&DuplicateUUIDName{},
+		},
+		{
+			domainError,
+			args{nil, OperationResult{Error: domainError}},
+			&DomainError{},
+		},
+		{
+			rangeError,
+			args{nil, OperationResult{Error: rangeError}},
+			&RangeError{},
+		},
+		{
+			timedOut,
+			args{nil, OperationResult{Error: timedOut}},
+			&TimedOut{},
+		},
+		{
+			notSupported,
+			args{nil, OperationResult{Error: notSupported}},
+			&NotSupported{},
+		},
+		{
+			aborted,
+			args{nil, OperationResult{Error: aborted}},
+			&Aborted{},
+		},
+		{
+			notOwner,
+			args{nil, OperationResult{Error: notOwner}},
+			&NotOwner{},
+		},
+		{
+			"generic error",
+			args{nil, OperationResult{Error: "foo"}},
+			&Error{},
+		},
+		{
+			"nil",
+			args{nil, OperationResult{Error: ""}},
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := errorFromResult(tt.args.op, tt.args.r)
+			assert.IsType(t, tt.expected, err)
+		})
+	}
+}
+
+func TestCheckOperationResults(t *testing.T) {
+	type args struct {
+		result []OperationResult
+		ops    []Operation
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []OperationError
+		wantErr bool
+	}{
+		{
+			"success",
+			args{[]OperationResult{{}}, []Operation{{Op: "insert"}}},
+			nil,
+			false,
+		},
+		{
+			"commit error",
+			args{[]OperationResult{{}, {Error: constraintViolation}}, []Operation{{Op: "insert"}}},
+			nil,
+			true,
+		},
+		{
+			"transaction error",
+			args{[]OperationResult{{Error: constraintViolation, Details: "foo"}, {Error: constraintViolation, Details: "bar"}}, []Operation{{Op: "insert"}, {Op: "mutate"}}},
+			[]OperationError{&ConstraintViolation{details: "foo", operation: &Operation{Op: "insert"}}, &ConstraintViolation{details: "bar", operation: &Operation{Op: "mutate"}}},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CheckOperationResults(tt.args.result, tt.args.ops)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckOperationResults() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CheckOperationResults() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds all of the errors listed in RFC 7047 and
provides a functions to return all errors for a transaction
in a way that's easy to use

Fixes: #95 