### PR TITLE
Simplify Where API

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -26,15 +26,15 @@ type API interface {
 	// Create a Condition from a Function that is used to filter cached data
 	// The function must accept a Model implementation and return a boolean. E.g:
 	// ConditionFromFunc(func(l *LogicalSwitch) bool { return l.Enabled })
-	ConditionFromFunc(predicate interface{}) ConditionFactory
+	ConditionFromFunc(predicate interface{}) Conditional
 
 	// Create a Condition from a Model's data. It uses the database indexes
 	// to search the most apropriate field to use for matches and conditions
 	// Optionally, a list of fields can indicate an alternative index
-	ConditionFromModel(Model, ...interface{}) ConditionFactory
+	ConditionFromModel(Model, ...interface{}) Conditional
 
 	// Create a ConditionalAPI from a Condition
-	Where(condition ConditionFactory) ConditionalAPI
+	Where(condition Conditional) ConditionalAPI
 
 	// Get retrieves a model from the cache
 	// The way the object will be fetch depends on the data contained in the
@@ -112,7 +112,7 @@ var ErrNotFound = errors.New("object not found")
 // Where() can be used to create a ConditionalAPI api
 type api struct {
 	cache *TableCache
-	cond  ConditionFactory
+	cond  Conditional
 }
 
 // List populates a slice of Models given as parameter based on the configured Condition
@@ -170,34 +170,34 @@ func (a api) List(result interface{}) error {
 }
 
 // Where returns a conditionalAPI based a Condition
-func (a api) Where(condition ConditionFactory) ConditionalAPI {
+func (a api) Where(condition Conditional) ConditionalAPI {
 	return newConditionalAPI(a.cache, condition)
 }
 
-// ConditionFactory interface implementation
+// Conditional interface implementation
 // FromFunc returns a Condition from a function
-func (a api) ConditionFromFunc(predicate interface{}) ConditionFactory {
+func (a api) ConditionFromFunc(predicate interface{}) Conditional {
 	table, err := a.getTableFromFunc(predicate)
 	if err != nil {
-		return newErrorCondition(err)
+		return newErrorConditional(err)
 	}
 
-	condition, err := newPredicateCond(table, a.cache, predicate)
+	condition, err := newPredicateConditional(table, a.cache, predicate)
 	if err != nil {
-		return newErrorCondition(err)
+		return newErrorConditional(err)
 	}
 	return condition
 }
 
 // FromModel returns a Condition from a model and a list of fields
-func (a api) ConditionFromModel(model Model, fields ...interface{}) ConditionFactory {
+func (a api) ConditionFromModel(model Model, fields ...interface{}) Conditional {
 	tableName, err := a.getTableFromModel(model)
 	if tableName == "" {
-		return newErrorCondition(err)
+		return newErrorConditional(err)
 	}
-	condition, err := newIndexCondition(a.cache.orm, tableName, model, fields...)
+	condition, err := newIndexConditional(a.cache.orm, tableName, model, fields...)
 	if err != nil {
-		return newErrorCondition(err)
+		return newErrorConditional(err)
 	}
 	return condition
 }
@@ -439,7 +439,7 @@ func newAPI(cache *TableCache) API {
 }
 
 // newConditionalAPI returns a new ConditionalAPI to interact with the database
-func newConditionalAPI(cache *TableCache, cond ConditionFactory) ConditionalAPI {
+func newConditionalAPI(cache *TableCache, cond Conditional) ConditionalAPI {
 	return api{
 		cache: cache,
 		cond:  cond,

--- a/client/api.go
+++ b/client/api.go
@@ -26,15 +26,15 @@ type API interface {
 	// Create a Condition from a Function that is used to filter cached data
 	// The function must accept a Model implementation and return a boolean. E.g:
 	// ConditionFromFunc(func(l *LogicalSwitch) bool { return l.Enabled })
-	ConditionFromFunc(predicate interface{}) Condition
+	ConditionFromFunc(predicate interface{}) ConditionFactory
 
 	// Create a Condition from a Model's data. It uses the database indexes
 	// to search the most apropriate field to use for matches and conditions
 	// Optionally, a list of fields can indicate an alternative index
-	ConditionFromModel(Model, ...interface{}) Condition
+	ConditionFromModel(Model, ...interface{}) ConditionFactory
 
 	// Create a ConditionalAPI from a Condition
-	Where(condition Condition) ConditionalAPI
+	Where(condition ConditionFactory) ConditionalAPI
 
 	// Get retrieves a model from the cache
 	// The way the object will be fetch depends on the data contained in the
@@ -112,7 +112,7 @@ var ErrNotFound = errors.New("object not found")
 // Where() can be used to create a ConditionalAPI api
 type api struct {
 	cache *TableCache
-	cond  Condition
+	cond  ConditionFactory
 }
 
 // List populates a slice of Models given as parameter based on the configured Condition
@@ -170,13 +170,13 @@ func (a api) List(result interface{}) error {
 }
 
 // Where returns a conditionalAPI based a Condition
-func (a api) Where(condition Condition) ConditionalAPI {
+func (a api) Where(condition ConditionFactory) ConditionalAPI {
 	return newConditionalAPI(a.cache, condition)
 }
 
 // ConditionFactory interface implementation
 // FromFunc returns a Condition from a function
-func (a api) ConditionFromFunc(predicate interface{}) Condition {
+func (a api) ConditionFromFunc(predicate interface{}) ConditionFactory {
 	table, err := a.getTableFromFunc(predicate)
 	if err != nil {
 		return newErrorCondition(err)
@@ -190,7 +190,7 @@ func (a api) ConditionFromFunc(predicate interface{}) Condition {
 }
 
 // FromModel returns a Condition from a model and a list of fields
-func (a api) ConditionFromModel(model Model, fields ...interface{}) Condition {
+func (a api) ConditionFromModel(model Model, fields ...interface{}) ConditionFactory {
 	tableName, err := a.getTableFromModel(model)
 	if tableName == "" {
 		return newErrorCondition(err)
@@ -439,7 +439,7 @@ func newAPI(cache *TableCache) API {
 }
 
 // newConditionalAPI returns a new ConditionalAPI to interact with the database
-func newConditionalAPI(cache *TableCache, cond Condition) ConditionalAPI {
+func newConditionalAPI(cache *TableCache, cond ConditionFactory) ConditionalAPI {
 	return api{
 		cache: cache,
 		cond:  cond,

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -371,9 +371,9 @@ func TestConditionFromFunc(t *testing.T) {
 			api := newAPI(cache)
 			condition := api.ConditionFromFunc(tt.arg)
 			if tt.err {
-				assert.IsType(t, &errorCondition{}, condition)
+				assert.IsType(t, &errorConditional{}, condition)
 			} else {
-				assert.IsType(t, &predicateCond{}, condition)
+				assert.IsType(t, &predicateConditional{}, condition)
 			}
 		})
 	}
@@ -419,9 +419,9 @@ func TestConditionFromModel(t *testing.T) {
 			api := newAPI(cache)
 			condition := api.ConditionFromModel(tt.model, tt.fields...)
 			if tt.err {
-				assert.IsType(t, &errorCondition{}, condition)
+				assert.IsType(t, &errorConditional{}, condition)
 			} else {
-				assert.IsType(t, &indexCond{}, condition)
+				assert.IsType(t, &indexConditional{}, condition)
 			}
 		})
 	}

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -275,24 +275,6 @@ func TestAPIListFields(t *testing.T) {
 			content: []Model{lspcache[aUUID2]},
 			err:     false,
 		},
-		{
-			name: "List unique by extra field",
-			prepare: func(t *testLogicalSwitchPort) {
-				t.ExternalIds = map[string]string{"unique": "id"}
-			},
-			content: []Model{lspcache[aUUID2]},
-			fields:  []interface{}{&testObj.ExternalIds},
-			err:     false,
-		},
-		{
-			name: "List by extra field",
-			prepare: func(t *testLogicalSwitchPort) {
-				t.Enabled = []bool{true}
-			},
-			content: []Model{lspcache[aUUID0], lspcache[aUUID3]},
-			fields:  []interface{}{&testObj.Enabled},
-			err:     false,
-		},
 	}
 
 	for _, tt := range test {
@@ -301,7 +283,7 @@ func TestAPIListFields(t *testing.T) {
 			// Clean object
 			testObj = testLogicalSwitchPort{}
 			api := newAPI(cache)
-			err := api.Where(api.ConditionFromModel(&testObj, tt.fields...)).List(&result)
+			err := api.Where(api.ConditionFromModel(&testObj)).List(&result)
 			if tt.err {
 				assert.NotNil(t, err)
 			} else {
@@ -320,18 +302,6 @@ func TestAPIListFields(t *testing.T) {
 		}
 
 		err := api.Where(api.ConditionFromModel(&obj)).List(&result)
-		assert.NotNil(t, err)
-	})
-
-	t.Run("ApiListFields: Wrong object field", func(t *testing.T) {
-		var result []testLogicalSwitchPort
-		api := newAPI(cache)
-		obj := testLogicalSwitch{}
-		obj2 := testLogicalSwitch{
-			UUID: aUUID0,
-		}
-
-		err := api.Where(api.ConditionFromModel(&obj, &obj2.UUID)).List(&result)
 		assert.NotNil(t, err)
 	})
 }
@@ -382,10 +352,10 @@ func TestConditionFromFunc(t *testing.T) {
 func TestConditionFromModel(t *testing.T) {
 	var testObj testLogicalSwitch
 	test := []struct {
-		name   string
-		model  Model
-		fields []interface{}
-		err    bool
+		name  string
+		model Model
+		conds []Condition
+		err   bool
 	}{
 		{
 			name:  "wrong model must fail",
@@ -393,12 +363,12 @@ func TestConditionFromModel(t *testing.T) {
 			err:   true,
 		},
 		{
-			name: "wrong fields must fail",
+			name: "wrong condition must fail",
 			model: &struct {
 				a string `ovs:"_uuid"`
 			}{},
-			fields: []interface{}{"foo"},
-			err:    true,
+			conds: []Condition{{Field: "foo"}},
+			err:   true,
 		},
 		{
 			name:  "correct model must succeed",
@@ -406,10 +376,21 @@ func TestConditionFromModel(t *testing.T) {
 			err:   false,
 		},
 		{
-			name:   "correct model with fields must succeed",
-			model:  &testObj,
-			fields: []interface{}{&testObj.Name},
-			err:    false,
+			name:  "correct model with valid condition must succeed",
+			model: &testObj,
+			conds: []Condition{
+				{
+					Field:    &testObj.Name,
+					Function: ovsdb.ConditionEqual,
+					Value:    "foo",
+				},
+				{
+					Field:    &testObj.Ports,
+					Function: ovsdb.ConditionIncludes,
+					Value:    []string{"foo"},
+				},
+			},
+			err: false,
 		},
 	}
 
@@ -417,11 +398,16 @@ func TestConditionFromModel(t *testing.T) {
 		t.Run(fmt.Sprintf("ConditionFromModel: %s", tt.name), func(t *testing.T) {
 			cache := apiTestCache(t)
 			api := newAPI(cache)
-			condition := api.ConditionFromModel(tt.model, tt.fields...)
+			condition := api.ConditionFromModel(tt.model, tt.conds...)
 			if tt.err {
 				assert.IsType(t, &errorConditional{}, condition)
 			} else {
-				assert.IsType(t, &indexConditional{}, condition)
+				if len(tt.conds) > 0 {
+					assert.IsType(t, &explicitConditional{}, condition)
+				} else {
+					assert.IsType(t, &equalityConditional{}, condition)
+				}
+
 			}
 		})
 	}
@@ -810,7 +796,6 @@ func TestAPIUpdate(t *testing.T) {
 		name      string
 		condition func(API) ConditionalAPI
 		prepare   func(t *testLogicalSwitchPort)
-		fields    []interface{}
 		result    []ovsdb.Operation
 		err       bool
 	}{
@@ -825,7 +810,6 @@ func TestAPIUpdate(t *testing.T) {
 				t.Type = "somethingElse"
 				t.Tag = []int{6}
 			},
-			fields: []interface{}{},
 			result: []ovsdb.Operation{
 				{
 					Op:    opUpdate,
@@ -847,7 +831,6 @@ func TestAPIUpdate(t *testing.T) {
 				t.Type = "somethingElse"
 				t.Tag = []int{6}
 			},
-			fields: []interface{}{},
 			result: []ovsdb.Operation{
 				{
 					Op:    opUpdate,
@@ -865,18 +848,47 @@ func TestAPIUpdate(t *testing.T) {
 					Type:    "sometype",
 					Enabled: []bool{true},
 				}
-				return a.Where(a.ConditionFromModel(&t, &t.Type))
+				return a.Where(a.ConditionFromModel(&t, Condition{
+					Field:    &t.Type,
+					Function: ovsdb.ConditionEqual,
+					Value:    "sometype",
+				}))
 			},
 			prepare: func(t *testLogicalSwitchPort) {
 				t.Tag = []int{6}
 			},
-			fields: []interface{}{},
 			result: []ovsdb.Operation{
 				{
 					Op:    opUpdate,
 					Table: "Logical_Switch_Port",
 					Row:   map[string]interface{}{"tag": testOvsSet(t, []int{6})},
 					Where: []ovsdb.Condition{{Column: "type", Function: ovsdb.ConditionEqual, Value: "sometype"}},
+				},
+			},
+			err: false,
+		},
+		{
+			name: "select by field inequality change multiple field",
+			condition: func(a API) ConditionalAPI {
+				t := testLogicalSwitchPort{
+					Type:    "sometype",
+					Enabled: []bool{true},
+				}
+				return a.Where(a.ConditionFromModel(&t, Condition{
+					Field:    &t.Type,
+					Function: ovsdb.ConditionNotEqual,
+					Value:    "sometype",
+				}))
+			},
+			prepare: func(t *testLogicalSwitchPort) {
+				t.Tag = []int{6}
+			},
+			result: []ovsdb.Operation{
+				{
+					Op:    opUpdate,
+					Table: "Logical_Switch_Port",
+					Row:   map[string]interface{}{"tag": testOvsSet(t, []int{6})},
+					Where: []ovsdb.Condition{{Column: "type", Function: ovsdb.ConditionNotEqual, Value: "sometype"}},
 				},
 			},
 			err: false,
@@ -892,7 +904,6 @@ func TestAPIUpdate(t *testing.T) {
 				t.Type = "somethingElse"
 				t.Tag = []int{6}
 			},
-			fields: []interface{}{},
 			result: []ovsdb.Operation{
 				{
 					Op:    opUpdate,
@@ -996,13 +1007,16 @@ func TestAPIDelete(t *testing.T) {
 			err: false,
 		},
 		{
-			name: "select by field",
+			name: "select by field equality",
 			condition: func(a API) ConditionalAPI {
 				t := testLogicalSwitchPort{
-					Type:    "sometype",
 					Enabled: []bool{true},
 				}
-				return a.Where(a.ConditionFromModel(&t, &t.Type))
+				return a.Where(a.ConditionFromModel(&t, Condition{
+					Field:    &t.Type,
+					Function: ovsdb.ConditionEqual,
+					Value:    "sometype",
+				}))
 			},
 			result: []ovsdb.Operation{
 				{

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -196,7 +196,7 @@ func TestAPIListPredicate(t *testing.T) {
 		t.Run(fmt.Sprintf("ApiListPredicate: %s", tt.name), func(t *testing.T) {
 			var result []testLogicalSwitch
 			api := newAPI(cache)
-			cond := api.Where(api.ConditionFromFunc(tt.predicate))
+			cond := api.WhereCache(tt.predicate)
 			err := cond.List(&result)
 			if tt.err {
 				assert.NotNil(t, err)
@@ -283,7 +283,7 @@ func TestAPIListFields(t *testing.T) {
 			// Clean object
 			testObj = testLogicalSwitchPort{}
 			api := newAPI(cache)
-			err := api.Where(api.ConditionFromModel(&testObj)).List(&result)
+			err := api.Where(&testObj).List(&result)
 			if tt.err {
 				assert.NotNil(t, err)
 			} else {
@@ -301,7 +301,7 @@ func TestAPIListFields(t *testing.T) {
 			UUID: aUUID0,
 		}
 
-		err := api.Where(api.ConditionFromModel(&obj)).List(&result)
+		err := api.Where(&obj).List(&result)
 		assert.NotNil(t, err)
 	})
 }
@@ -336,10 +336,10 @@ func TestConditionFromFunc(t *testing.T) {
 	}
 
 	for _, tt := range test {
-		t.Run(fmt.Sprintf("ConditionFromFunc: %s", tt.name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("conditionFromFunc: %s", tt.name), func(t *testing.T) {
 			cache := apiTestCache(t)
-			api := newAPI(cache)
-			condition := api.ConditionFromFunc(tt.arg)
+			apiIface := newAPI(cache)
+			condition := apiIface.(api).conditionFromFunc(tt.arg)
 			if tt.err {
 				assert.IsType(t, &errorConditional{}, condition)
 			} else {
@@ -395,10 +395,10 @@ func TestConditionFromModel(t *testing.T) {
 	}
 
 	for _, tt := range test {
-		t.Run(fmt.Sprintf("ConditionFromModel: %s", tt.name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("conditionFromModel: %s", tt.name), func(t *testing.T) {
 			cache := apiTestCache(t)
-			api := newAPI(cache)
-			condition := api.ConditionFromModel(tt.model, tt.conds...)
+			apiIface := newAPI(cache)
+			condition := apiIface.(api).conditionFromModel(tt.model, tt.conds...)
 			if tt.err {
 				assert.IsType(t, &errorConditional{}, condition)
 			} else {
@@ -646,9 +646,9 @@ func TestAPIMutate(t *testing.T) {
 		{
 			name: "select by UUID addElement to set",
 			condition: func(a API) ConditionalAPI {
-				return a.Where(a.ConditionFromModel(&testLogicalSwitch{
+				return a.Where(&testLogicalSwitch{
 					UUID: aUUID0,
-				}))
+				})
 			},
 			mutations: []Mutation{
 				{
@@ -670,9 +670,9 @@ func TestAPIMutate(t *testing.T) {
 		{
 			name: "select by name delete element from map",
 			condition: func(a API) ConditionalAPI {
-				return a.Where(a.ConditionFromModel(&testLogicalSwitchPort{
+				return a.Where(&testLogicalSwitchPort{
 					Name: "lsp2",
-				}))
+				})
 			},
 			mutations: []Mutation{
 				{
@@ -694,9 +694,9 @@ func TestAPIMutate(t *testing.T) {
 		{
 			name: "select single by predicate name insert element in map",
 			condition: func(a API) ConditionalAPI {
-				return a.Where(a.ConditionFromFunc(func(lsp *testLogicalSwitchPort) bool {
+				return a.WhereCache(func(lsp *testLogicalSwitchPort) bool {
 					return lsp.Name == "lsp2"
-				}))
+				})
 			},
 			mutations: []Mutation{
 				{
@@ -718,9 +718,9 @@ func TestAPIMutate(t *testing.T) {
 		{
 			name: "select many by predicate name insert element in map",
 			condition: func(a API) ConditionalAPI {
-				return a.Where(a.ConditionFromFunc(func(lsp *testLogicalSwitchPort) bool {
+				return a.WhereCache(func(lsp *testLogicalSwitchPort) bool {
 					return lsp.Type == "someType"
-				}))
+				})
 			},
 			mutations: []Mutation{
 				{
@@ -802,9 +802,9 @@ func TestAPIUpdate(t *testing.T) {
 		{
 			name: "select by UUID change multiple field",
 			condition: func(a API) ConditionalAPI {
-				return a.Where(a.ConditionFromModel(&testLogicalSwitch{
+				return a.Where(&testLogicalSwitch{
 					UUID: aUUID0,
-				}))
+				})
 			},
 			prepare: func(t *testLogicalSwitchPort) {
 				t.Type = "somethingElse"
@@ -823,9 +823,9 @@ func TestAPIUpdate(t *testing.T) {
 		{
 			name: "select by index change multiple field",
 			condition: func(a API) ConditionalAPI {
-				return a.Where(a.ConditionFromModel(&testLogicalSwitchPort{
+				return a.Where(&testLogicalSwitchPort{
 					Name: "lsp1",
-				}))
+				})
 			},
 			prepare: func(t *testLogicalSwitchPort) {
 				t.Type = "somethingElse"
@@ -848,11 +848,11 @@ func TestAPIUpdate(t *testing.T) {
 					Type:    "sometype",
 					Enabled: []bool{true},
 				}
-				return a.Where(a.ConditionFromModel(&t, Condition{
+				return a.Where(&t, Condition{
 					Field:    &t.Type,
 					Function: ovsdb.ConditionEqual,
 					Value:    "sometype",
-				}))
+				})
 			},
 			prepare: func(t *testLogicalSwitchPort) {
 				t.Tag = []int{6}
@@ -874,11 +874,11 @@ func TestAPIUpdate(t *testing.T) {
 					Type:    "sometype",
 					Enabled: []bool{true},
 				}
-				return a.Where(a.ConditionFromModel(&t, Condition{
+				return a.Where(&t, Condition{
 					Field:    &t.Type,
 					Function: ovsdb.ConditionNotEqual,
 					Value:    "sometype",
-				}))
+				})
 			},
 			prepare: func(t *testLogicalSwitchPort) {
 				t.Tag = []int{6}
@@ -896,9 +896,9 @@ func TestAPIUpdate(t *testing.T) {
 		{
 			name: "select multiple by predicate change multiple field",
 			condition: func(a API) ConditionalAPI {
-				return a.Where(a.ConditionFromFunc(func(t *testLogicalSwitchPort) bool {
+				return a.WhereCache(func(t *testLogicalSwitchPort) bool {
 					return t.Enabled != nil && t.Enabled[0] == true
-				}))
+				})
 			},
 			prepare: func(t *testLogicalSwitchPort) {
 				t.Type = "somethingElse"
@@ -977,9 +977,9 @@ func TestAPIDelete(t *testing.T) {
 		{
 			name: "select by UUID",
 			condition: func(a API) ConditionalAPI {
-				return a.Where(a.ConditionFromModel(&testLogicalSwitch{
+				return a.Where(&testLogicalSwitch{
 					UUID: aUUID0,
-				}))
+				})
 			},
 			result: []ovsdb.Operation{
 				{
@@ -993,9 +993,9 @@ func TestAPIDelete(t *testing.T) {
 		{
 			name: "select by index",
 			condition: func(a API) ConditionalAPI {
-				return a.Where(a.ConditionFromModel(&testLogicalSwitchPort{
+				return a.Where(&testLogicalSwitchPort{
 					Name: "lsp1",
-				}))
+				})
 			},
 			result: []ovsdb.Operation{
 				{
@@ -1012,11 +1012,11 @@ func TestAPIDelete(t *testing.T) {
 				t := testLogicalSwitchPort{
 					Enabled: []bool{true},
 				}
-				return a.Where(a.ConditionFromModel(&t, Condition{
+				return a.Where(&t, Condition{
 					Field:    &t.Type,
 					Function: ovsdb.ConditionEqual,
 					Value:    "sometype",
-				}))
+				})
 			},
 			result: []ovsdb.Operation{
 				{
@@ -1030,9 +1030,9 @@ func TestAPIDelete(t *testing.T) {
 		{
 			name: "select multiple by predicate",
 			condition: func(a API) ConditionalAPI {
-				return a.Where(a.ConditionFromFunc(func(t *testLogicalSwitchPort) bool {
+				return a.WhereCache(func(t *testLogicalSwitchPort) bool {
 					return t.Enabled != nil && t.Enabled[0] == true
-				}))
+				})
 			},
 			result: []ovsdb.Operation{
 				{

--- a/client/client.go
+++ b/client/client.go
@@ -371,16 +371,16 @@ func (ovs OvsdbClient) List(result interface{}) error {
 }
 
 //Where implements the API interface's Where function
-func (ovs OvsdbClient) Where(condition ConditionFactory) ConditionalAPI {
+func (ovs OvsdbClient) Where(condition Conditional) ConditionalAPI {
 	return ovs.api.Where(condition)
 }
 
 //ConditionFromFunc implements the API interface's ConditionFromFunc function
-func (ovs OvsdbClient) ConditionFromFunc(predicate interface{}) ConditionFactory {
+func (ovs OvsdbClient) ConditionFromFunc(predicate interface{}) Conditional {
 	return ovs.api.ConditionFromFunc(predicate)
 }
 
 //ConditionFromModel implements the API interface's ConditionFromModel function
-func (ovs OvsdbClient) ConditionFromModel(m Model, fields ...interface{}) ConditionFactory {
+func (ovs OvsdbClient) ConditionFromModel(m Model, fields ...interface{}) Conditional {
 	return ovs.api.ConditionFromModel(m, fields...)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -371,16 +371,16 @@ func (ovs OvsdbClient) List(result interface{}) error {
 }
 
 //Where implements the API interface's Where function
-func (ovs OvsdbClient) Where(condition Condition) ConditionalAPI {
+func (ovs OvsdbClient) Where(condition ConditionFactory) ConditionalAPI {
 	return ovs.api.Where(condition)
 }
 
 //ConditionFromFunc implements the API interface's ConditionFromFunc function
-func (ovs OvsdbClient) ConditionFromFunc(predicate interface{}) Condition {
+func (ovs OvsdbClient) ConditionFromFunc(predicate interface{}) ConditionFactory {
 	return ovs.api.ConditionFromFunc(predicate)
 }
 
 //ConditionFromModel implements the API interface's ConditionFromModel function
-func (ovs OvsdbClient) ConditionFromModel(m Model, fields ...interface{}) Condition {
+func (ovs OvsdbClient) ConditionFromModel(m Model, fields ...interface{}) ConditionFactory {
 	return ovs.api.ConditionFromModel(m, fields...)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -371,16 +371,11 @@ func (ovs OvsdbClient) List(result interface{}) error {
 }
 
 //Where implements the API interface's Where function
-func (ovs OvsdbClient) Where(condition Conditional) ConditionalAPI {
-	return ovs.api.Where(condition)
+func (ovs OvsdbClient) Where(m Model, conditions ...Condition) ConditionalAPI {
+	return ovs.api.Where(m, conditions...)
 }
 
-//ConditionFromFunc implements the API interface's ConditionFromFunc function
-func (ovs OvsdbClient) ConditionFromFunc(predicate interface{}) Conditional {
-	return ovs.api.ConditionFromFunc(predicate)
-}
-
-//ConditionFromModel implements the API interface's ConditionFromModel function
-func (ovs OvsdbClient) ConditionFromModel(m Model, conditions ...Condition) Conditional {
-	return ovs.api.ConditionFromModel(m, conditions...)
+//WhereCache implements the API interface's WhereCache function
+func (ovs OvsdbClient) WhereCache(predicate interface{}) ConditionalAPI {
+	return ovs.api.WhereCache(predicate)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -381,6 +381,6 @@ func (ovs OvsdbClient) ConditionFromFunc(predicate interface{}) Conditional {
 }
 
 //ConditionFromModel implements the API interface's ConditionFromModel function
-func (ovs OvsdbClient) ConditionFromModel(m Model, fields ...interface{}) Conditional {
-	return ovs.api.ConditionFromModel(m, fields...)
+func (ovs OvsdbClient) ConditionFromModel(m Model, conditions ...Condition) Conditional {
+	return ovs.api.ConditionFromModel(m, conditions...)
 }

--- a/client/condition.go
+++ b/client/condition.go
@@ -7,9 +7,9 @@ import (
 	"github.com/ovn-org/libovsdb/ovsdb"
 )
 
-// Condition is the interface used by the ConditionalAPI to match on cache objects
+// ConditionFactory is the interface used by the ConditionalAPI to match on cache objects
 // and generate operation conditions
-type Condition interface {
+type ConditionFactory interface {
 	// Generate returns a list of conditions to be used in Operations
 	Generate() ([]ovsdb.Condition, error)
 	// matches returns true if a model matches the condition
@@ -46,7 +46,7 @@ func (c *indexCond) Generate() ([]ovsdb.Condition, error) {
 }
 
 // newIndexCondition creates a new indexCond
-func newIndexCondition(orm *orm, table string, model Model, fields ...interface{}) (Condition, error) {
+func newIndexCondition(orm *orm, table string, model Model, fields ...interface{}) (ConditionFactory, error) {
 	return &indexCond{
 		orm:       orm,
 		tableName: table,
@@ -100,7 +100,7 @@ func (c *predicateCond) Generate() ([]ovsdb.Condition, error) {
 }
 
 // newIndexCondition creates a new predicateCond
-func newPredicateCond(table string, cache *TableCache, predicate interface{}) (Condition, error) {
+func newPredicateCond(table string, cache *TableCache, predicate interface{}) (ConditionFactory, error) {
 	return &predicateCond{
 		tableName: table,
 		predicate: predicate,
@@ -126,7 +126,7 @@ func (e *errorCondition) Generate() ([]ovsdb.Condition, error) {
 	return nil, e.err
 }
 
-func newErrorCondition(err error) Condition {
+func newErrorCondition(err error) ConditionFactory {
 	return &errorCondition{
 		err: fmt.Errorf("conditionerror: %s", err.Error()),
 	}

--- a/client/condition_test.go
+++ b/client/condition_test.go
@@ -1,0 +1,348 @@
+package client
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEqualityConditional(t *testing.T) {
+	cache := apiTestCache(t)
+	lspcacheList := []Model{
+		&testLogicalSwitchPort{
+			UUID:        aUUID0,
+			Name:        "lsp0",
+			ExternalIds: map[string]string{"foo": "bar"},
+			Enabled:     []bool{true},
+		},
+		&testLogicalSwitchPort{
+			UUID:        aUUID1,
+			Name:        "lsp1",
+			ExternalIds: map[string]string{"foo": "baz"},
+			Enabled:     []bool{false},
+		},
+		&testLogicalSwitchPort{
+			UUID:        aUUID2,
+			Name:        "lsp2",
+			ExternalIds: map[string]string{"unique": "id"},
+			Enabled:     []bool{false},
+		},
+		&testLogicalSwitchPort{
+			UUID:        aUUID3,
+			Name:        "lsp3",
+			ExternalIds: map[string]string{"foo": "baz"},
+			Enabled:     []bool{true},
+		},
+	}
+	lspcache := map[string]Model{}
+	for i := range lspcacheList {
+		lspcache[lspcacheList[i].(*testLogicalSwitchPort).UUID] = lspcacheList[i]
+	}
+	cache.cache["Logical_Switch_Port"] = &RowCache{cache: lspcache}
+
+	test := []struct {
+		name      string
+		model     Model
+		condition []ovsdb.Condition
+		matches   map[Model]bool
+		err       bool
+	}{
+		{
+			name:  "by uuid",
+			model: &testLogicalSwitchPort{UUID: aUUID0, Name: "different"},
+			condition: []ovsdb.Condition{
+				{
+					Column:   "_uuid",
+					Function: ovsdb.ConditionEqual,
+					Value:    ovsdb.UUID{GoUUID: aUUID0},
+				}},
+			matches: map[Model]bool{
+				&testLogicalSwitchPort{UUID: aUUID0}:              true,
+				&testLogicalSwitchPort{UUID: aUUID1}:              false,
+				&testLogicalSwitchPort{UUID: aUUID0, Name: "foo"}: true,
+			},
+		},
+		{
+			name:  "by index",
+			model: &testLogicalSwitchPort{Name: "lsp1"},
+			condition: []ovsdb.Condition{
+				{
+					Column:   "name",
+					Function: ovsdb.ConditionEqual,
+					Value:    "lsp1",
+				}},
+			matches: map[Model]bool{
+				&testLogicalSwitchPort{UUID: aUUID1}:               false,
+				&testLogicalSwitchPort{UUID: aUUID1, Name: "lsp1"}: true,
+				&testLogicalSwitchPort{UUID: aUUID0, Name: "lsp1"}: true,
+			},
+		},
+		{
+			name:  "by non index",
+			model: &testLogicalSwitchPort{ExternalIds: map[string]string{"foo": "baz"}},
+			err:   true,
+		},
+	}
+	for _, tt := range test {
+		t.Run(fmt.Sprintf("Equality Conditional: %s", tt.name), func(t *testing.T) {
+			cond, err := newEqualityConditional(cache.orm, "Logical_Switch_Port", tt.model)
+			assert.Nil(t, err)
+			for model, shouldMatch := range tt.matches {
+				matches, err := cond.Matches(model)
+				if tt.err {
+					assert.NotNil(t, err)
+				} else {
+					assert.Nil(t, err)
+					assert.Equalf(t, shouldMatch, matches, fmt.Sprintf("Match on model %#+v should be %v", model, shouldMatch))
+				}
+			}
+			generated, err := cond.Generate()
+			if tt.err {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.ElementsMatch(t, tt.condition, generated)
+			}
+		})
+	}
+}
+
+func TestPredicateConditional(t *testing.T) {
+	cache := apiTestCache(t)
+	lspcacheList := []Model{
+		&testLogicalSwitchPort{
+			UUID:        aUUID0,
+			Name:        "lsp0",
+			ExternalIds: map[string]string{"foo": "bar"},
+			Enabled:     []bool{true},
+		},
+		&testLogicalSwitchPort{
+			UUID:        aUUID1,
+			Name:        "lsp1",
+			ExternalIds: map[string]string{"foo": "baz"},
+			Enabled:     []bool{false},
+		},
+		&testLogicalSwitchPort{
+			UUID:        aUUID2,
+			Name:        "lsp2",
+			ExternalIds: map[string]string{"unique": "id"},
+			Enabled:     []bool{false},
+		},
+		&testLogicalSwitchPort{
+			UUID:        aUUID3,
+			Name:        "lsp3",
+			ExternalIds: map[string]string{"foo": "baz"},
+			Enabled:     []bool{true},
+		},
+	}
+	lspcache := map[string]Model{}
+	for i := range lspcacheList {
+		lspcache[lspcacheList[i].(*testLogicalSwitchPort).UUID] = lspcacheList[i]
+	}
+	cache.cache["Logical_Switch_Port"] = &RowCache{cache: lspcache}
+
+	test := []struct {
+		name      string
+		predicate interface{}
+		condition []ovsdb.Condition
+		matches   map[Model]bool
+		err       bool
+	}{
+		{
+			name: "simple value comparison",
+			predicate: func(lsp *testLogicalSwitchPort) bool {
+				return lsp.UUID == aUUID0
+			},
+			condition: []ovsdb.Condition{
+				{
+					Column:   "_uuid",
+					Function: ovsdb.ConditionEqual,
+					Value:    ovsdb.UUID{GoUUID: aUUID0},
+				}},
+			matches: map[Model]bool{
+				&testLogicalSwitchPort{UUID: aUUID0}:              true,
+				&testLogicalSwitchPort{UUID: aUUID1}:              false,
+				&testLogicalSwitchPort{UUID: aUUID0, Name: "foo"}: true,
+			},
+		},
+		{
+			name: "by random field",
+			predicate: func(lsp *testLogicalSwitchPort) bool {
+				return lsp.Enabled[0] == false
+			},
+			condition: []ovsdb.Condition{
+				{
+					Column:   "_uuid",
+					Function: ovsdb.ConditionEqual,
+					Value:    ovsdb.UUID{GoUUID: aUUID1},
+				},
+				{
+					Column:   "_uuid",
+					Function: ovsdb.ConditionEqual,
+					Value:    ovsdb.UUID{GoUUID: aUUID2},
+				}},
+			matches: map[Model]bool{
+				&testLogicalSwitchPort{UUID: aUUID1, Enabled: []bool{true}}:  false,
+				&testLogicalSwitchPort{UUID: aUUID1, Enabled: []bool{false}}: true,
+			},
+		},
+	}
+	for _, tt := range test {
+		t.Run(fmt.Sprintf("Predicate Conditional: %s", tt.name), func(t *testing.T) {
+			cond, err := newPredicateConditional("Logical_Switch_Port", cache, tt.predicate)
+			assert.Nil(t, err)
+			for model, shouldMatch := range tt.matches {
+				matches, err := cond.Matches(model)
+				if tt.err {
+					assert.NotNil(t, err)
+				} else {
+					assert.Nil(t, err)
+					assert.Equalf(t, shouldMatch, matches, fmt.Sprintf("Match on model %#+v should be %v", model, shouldMatch))
+				}
+			}
+			generated, err := cond.Generate()
+			if tt.err {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.ElementsMatch(t, tt.condition, generated)
+			}
+		})
+	}
+}
+
+func TestExplicitConditional(t *testing.T) {
+	cache := apiTestCache(t)
+	lspcacheList := []Model{
+		&testLogicalSwitchPort{
+			UUID:        aUUID0,
+			Name:        "lsp0",
+			ExternalIds: map[string]string{"foo": "bar"},
+			Enabled:     []bool{true},
+		},
+		&testLogicalSwitchPort{
+			UUID:        aUUID1,
+			Name:        "lsp1",
+			ExternalIds: map[string]string{"foo": "baz"},
+			Enabled:     []bool{false},
+		},
+		&testLogicalSwitchPort{
+			UUID:        aUUID2,
+			Name:        "lsp2",
+			ExternalIds: map[string]string{"unique": "id"},
+			Enabled:     []bool{false},
+		},
+		&testLogicalSwitchPort{
+			UUID:        aUUID3,
+			Name:        "lsp3",
+			ExternalIds: map[string]string{"foo": "baz"},
+			Enabled:     []bool{true},
+		},
+	}
+	lspcache := map[string]Model{}
+	for i := range lspcacheList {
+		lspcache[lspcacheList[i].(*testLogicalSwitchPort).UUID] = lspcacheList[i]
+	}
+	cache.cache["Logical_Switch_Port"] = &RowCache{cache: lspcache}
+
+	testObj := &testLogicalSwitchPort{}
+
+	test := []struct {
+		name   string
+		args   []Condition
+		result []ovsdb.Condition
+		err    bool
+	}{
+		{
+			name: "inequality comparison",
+			args: []Condition{
+				{
+					Field:    &testObj.Name,
+					Function: ovsdb.ConditionNotEqual,
+					Value:    "lsp0",
+				},
+			},
+			result: []ovsdb.Condition{
+				{
+					Column:   "name",
+					Function: ovsdb.ConditionNotEqual,
+					Value:    "lsp0",
+				}},
+		},
+		{
+			name: "map comparison",
+			args: []Condition{
+				{
+					Field:    &testObj.ExternalIds,
+					Function: ovsdb.ConditionIncludes,
+					Value:    map[string]string{"foo": "baz"},
+				},
+			},
+			result: []ovsdb.Condition{
+				{
+					Column:   "external_ids",
+					Function: ovsdb.ConditionIncludes,
+					Value:    testOvsMap(t, map[string]string{"foo": "baz"}),
+				}},
+		},
+		{
+			name: "set comparison",
+			args: []Condition{
+				{
+					Field:    &testObj.Enabled,
+					Function: ovsdb.ConditionEqual,
+					Value:    []bool{true},
+				},
+			},
+			result: []ovsdb.Condition{
+				{
+					Column:   "enabled",
+					Function: ovsdb.ConditionEqual,
+					Value:    testOvsSet(t, []bool{true}),
+				}},
+		},
+		{
+			name: "multiple conditions",
+			args: []Condition{
+				{
+					Field:    &testObj.Enabled,
+					Function: ovsdb.ConditionEqual,
+					Value:    []bool{true},
+				},
+				{
+					Field:    &testObj.Name,
+					Function: ovsdb.ConditionNotEqual,
+					Value:    "foo",
+				},
+			},
+			result: []ovsdb.Condition{
+				{
+					Column:   "enabled",
+					Function: ovsdb.ConditionEqual,
+					Value:    testOvsSet(t, []bool{true}),
+				},
+				{
+					Column:   "name",
+					Function: ovsdb.ConditionNotEqual,
+					Value:    "foo",
+				}},
+		},
+	}
+	for _, tt := range test {
+		t.Run(fmt.Sprintf("Explicit Conditional: %s", tt.name), func(t *testing.T) {
+			cond, err := newExplicitConditional(cache.orm, "Logical_Switch_Port", testObj, tt.args...)
+			assert.Nil(t, err)
+			_, err = cond.Matches(testObj)
+			assert.NotNilf(t, err, "Explicit conditions should fail to match on cache")
+			generated, err := cond.Generate()
+			if tt.err {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.ElementsMatch(t, tt.result, generated)
+			}
+		})
+	}
+}

--- a/client/orm_test.go
+++ b/client/orm_test.go
@@ -580,9 +580,9 @@ func TestORMCondition(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(fmt.Sprintf("newCondition_%s", tt.name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("newEqualityCondition_%s", tt.name), func(t *testing.T) {
 			tt.prepare(&testObj)
-			conds, err := orm.newCondition("TestTable", &testObj, tt.index...)
+			conds, err := orm.newEqualityCondition("TestTable", &testObj, tt.index...)
 			if tt.err {
 				if err == nil {
 					t.Errorf("expected an error but got none")

--- a/client/ovs_integration_test.go
+++ b/client/ovs_integration_test.go
@@ -192,7 +192,7 @@ func TestInsertTransactIntegration(t *testing.T) {
 
 	// Inserting a Bridge row in Bridge table requires mutating the open_vswitch table.
 	ovsRow := ovsType{}
-	mutateOp, err := ovs.Where(ovs.ConditionFromFunc(func(*ovsType) bool { return true })).
+	mutateOp, err := ovs.WhereCache(func(*ovsType) bool { return true }).
 		Mutate(&ovsRow, []Mutation{
 			{
 				Field:   &ovsRow.Bridges,
@@ -245,11 +245,11 @@ func TestDeleteTransactIntegration(t *testing.T) {
 	err = ovs.MonitorAll(nil)
 	assert.Nil(t, err)
 
-	deleteOp, err := ovs.Where(ovs.ConditionFromModel(&bridgeType{Name: bridgeName})).Delete()
+	deleteOp, err := ovs.Where(&bridgeType{Name: bridgeName}).Delete()
 	assert.Nil(t, err)
 
 	ovsRow := ovsType{}
-	mutateOp, err := ovs.Where(ovs.ConditionFromFunc(func(*ovsType) bool { return true })).
+	mutateOp, err := ovs.WhereCache(func(*ovsType) bool { return true }).
 		Mutate(&ovsRow, []Mutation{
 			{
 				Field:   &ovsRow.Bridges,

--- a/cmd/stress/stress.go
+++ b/cmd/stress/stress.go
@@ -105,7 +105,7 @@ func transact(ovs *client.OvsdbClient, operations []ovsdb.Operation) (ok bool, u
 }
 
 func deleteBridge(ovs *client.OvsdbClient, bridge *ormBridge) {
-	deleteOp, err := ovs.Where(ovs.ConditionFromModel(bridge)).Delete()
+	deleteOp, err := ovs.Where(bridge).Delete()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func deleteBridge(ovs *client.OvsdbClient, bridge *ormBridge) {
 		UUID: rootUUID,
 	}
 
-	mutateOp, err := ovs.Where(ovs.ConditionFromModel(&ovsRow)).Mutate(&ovsRow, []client.Mutation{
+	mutateOp, err := ovs.Where(&ovsRow).Mutate(&ovsRow, []client.Mutation{
 		{
 			Field:   &ovsRow.Bridges,
 			Mutator: "delete",
@@ -151,7 +151,7 @@ func createBridge(ovs *client.OvsdbClient, iter int) {
 		log.Fatal(err)
 	}
 	ovsRow := ormOvs{}
-	mutateOp, err := ovs.Where(ovs.ConditionFromModel(&ormOvs{UUID: rootUUID})).Mutate(&ovsRow, []client.Mutation{
+	mutateOp, err := ovs.Where(&ormOvs{UUID: rootUUID}).Mutate(&ovsRow, []client.Mutation{
 		{
 			Field:   &ovsRow.Bridges,
 			Mutator: "insert",

--- a/example/play_with_ovs/play_with_ovs.go
+++ b/example/play_with_ovs/play_with_ovs.go
@@ -71,7 +71,7 @@ func createBridge(ovs *client.OvsdbClient, bridgeName string) {
 	ovsRow := ormOvs{
 		UUID: rootUUID,
 	}
-	mutateOps, err := ovs.Where(ovs.ConditionFromModel(&ovsRow)).Mutate(&ovsRow, []client.Mutation{
+	mutateOps, err := ovs.Where(&ovsRow).Mutate(&ovsRow, []client.Mutation{
 		{
 			Field:   &ovsRow.Bridges,
 			Mutator: "insert",

--- a/ovsdb/bindings.go
+++ b/ovsdb/bindings.go
@@ -294,6 +294,28 @@ func ValidateMutation(column *ColumnSchema, mutator Mutator, value interface{}) 
 	}
 }
 
+func ValidateCondition(column *ColumnSchema, function ConditionFunction, nativeValue interface{}) error {
+	if NativeType(column) != reflect.TypeOf(nativeValue) {
+		return NewErrWrongType(fmt.Sprintf("Condition for column %s", column),
+			NativeType(column).String(), nativeValue)
+	}
+
+	switch column.Type {
+	case TypeSet, TypeMap, TypeBoolean, TypeString, TypeUUID:
+		switch function {
+		case ConditionEqual, ConditionNotEqual, ConditionIncludes, ConditionExcludes:
+			return nil
+		default:
+			return fmt.Errorf("wrong condition function %s for type: %s", function, column.Type)
+		}
+	case TypeInteger, TypeReal:
+		// All functions are valid
+		return nil
+	default:
+		panic("Unsupported Type")
+	}
+}
+
 func isDefaultBaseValue(elem interface{}, etype ExtendedType) bool {
 	value := reflect.ValueOf(elem)
 	if !value.IsValid() {


### PR DESCRIPTION
The idea is to simplify the API making less verbose

Remove the api.ConditionByXXX functions and instead have two ways of creating conditionalAPIs:

**Where(Model, ...Condition)** -> For conditions that will be evaluated in the server.

- An empty list of conditions defaults to index-based model equality

**WhereCache(predicate)** -> For conditions that will be evaluated in the cache using a callback function.

Based on #113 