### PR TITLE
Add WhereAll() conditions

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -351,7 +351,7 @@ func (a api) Mutate(model Model, mutationObjs []Mutation) ([]ovsdb.Operation, er
 				Op:        opMutate,
 				Table:     tableName,
 				Mutations: mutations,
-				Where:     []ovsdb.Condition{condition},
+				Where:     condition,
 			},
 		)
 	}
@@ -384,7 +384,7 @@ func (a api) Update(model Model, fields ...interface{}) ([]ovsdb.Operation, erro
 				Op:    opUpdate,
 				Table: table,
 				Row:   row,
-				Where: []ovsdb.Condition{condition},
+				Where: condition,
 			},
 		)
 	}
@@ -404,7 +404,7 @@ func (a api) Delete() ([]ovsdb.Operation, error) {
 			ovsdb.Operation{
 				Op:    opDelete,
 				Table: a.cond.Table(),
-				Where: []ovsdb.Condition{condition},
+				Where: condition,
 			},
 		)
 	}

--- a/client/api.go
+++ b/client/api.go
@@ -23,18 +23,13 @@ type API interface {
 	// If it has a capacity != 0, only 'capacity' elements will be filled in
 	List(result interface{}) error
 
-	// Create a Condition from a Function that is used to filter cached data
+	// Create a Conditional API from a Function that is used to filter cached data
 	// The function must accept a Model implementation and return a boolean. E.g:
 	// ConditionFromFunc(func(l *LogicalSwitch) bool { return l.Enabled })
-	ConditionFromFunc(predicate interface{}) ConditionFactory
+	WhereCache(predicate interface{}) ConditionalAPI
 
-	// Create a Condition from a Model's data. It uses the database indexes
-	// to search the most apropriate field to use for matches and conditions
-	// Optionally, a list of fields can indicate an alternative index
-	ConditionFromModel(Model, ...Condition) ConditionFactory
-
-	// Create a ConditionalAPI from a Condition
-	Where(condition ConditionFactory) ConditionalAPI
+	// Create a ConditionalAPI from a Model's index data or a list of Conditions
+	Where(Model, ...Condition) ConditionalAPI
 
 	// Get retrieves a model from the cache
 	// The way the object will be fetch depends on the data contained in the
@@ -179,14 +174,19 @@ func (a api) List(result interface{}) error {
 	return nil
 }
 
-// Where returns a conditionalAPI based a Condition
-func (a api) Where(condition ConditionFactory) ConditionalAPI {
-	return newConditionalAPI(a.cache, condition)
+// Where returns a conditionalAPI based on a Condition list
+func (a api) Where(model Model, cond ...Condition) ConditionalAPI {
+	return newConditionalAPI(a.cache, a.conditionFromModel(model, cond...))
+}
+
+// Where returns a conditionalAPI based a Predicate
+func (a api) WhereCache(predicate interface{}) ConditionalAPI {
+	return newConditionalAPI(a.cache, a.conditionFromFunc(predicate))
 }
 
 // ConditionFactory interface implementation
 // FromFunc returns a Condition from a function
-func (a api) ConditionFromFunc(predicate interface{}) ConditionFactory {
+func (a api) conditionFromFunc(predicate interface{}) ConditionFactory {
 	table, err := a.getTableFromFunc(predicate)
 	if err != nil {
 		return newErrorConditionFactory(err)
@@ -200,7 +200,7 @@ func (a api) ConditionFromFunc(predicate interface{}) ConditionFactory {
 }
 
 // FromModel returns a Condition from a model and a list of fields
-func (a api) ConditionFromModel(model Model, cond ...Condition) ConditionFactory {
+func (a api) conditionFromModel(model Model, cond ...Condition) ConditionFactory {
 	var condFactory ConditionFactory
 	var err error
 

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -275,24 +275,6 @@ func TestAPIListFields(t *testing.T) {
 			content: []Model{lspcache[aUUID2]},
 			err:     false,
 		},
-		{
-			name: "List unique by extra field",
-			prepare: func(t *testLogicalSwitchPort) {
-				t.ExternalIds = map[string]string{"unique": "id"}
-			},
-			content: []Model{lspcache[aUUID2]},
-			fields:  []interface{}{&testObj.ExternalIds},
-			err:     false,
-		},
-		{
-			name: "List by extra field",
-			prepare: func(t *testLogicalSwitchPort) {
-				t.Enabled = []bool{true}
-			},
-			content: []Model{lspcache[aUUID0], lspcache[aUUID3]},
-			fields:  []interface{}{&testObj.Enabled},
-			err:     false,
-		},
 	}
 
 	for _, tt := range test {
@@ -301,7 +283,7 @@ func TestAPIListFields(t *testing.T) {
 			// Clean object
 			testObj = testLogicalSwitchPort{}
 			api := newAPI(cache)
-			err := api.Where(api.ConditionFromModel(&testObj, tt.fields...)).List(&result)
+			err := api.Where(api.ConditionFromModel(&testObj)).List(&result)
 			if tt.err {
 				assert.NotNil(t, err)
 			} else {
@@ -320,18 +302,6 @@ func TestAPIListFields(t *testing.T) {
 		}
 
 		err := api.Where(api.ConditionFromModel(&obj)).List(&result)
-		assert.NotNil(t, err)
-	})
-
-	t.Run("ApiListFields: Wrong object field", func(t *testing.T) {
-		var result []testLogicalSwitchPort
-		api := newAPI(cache)
-		obj := testLogicalSwitch{}
-		obj2 := testLogicalSwitch{
-			UUID: aUUID0,
-		}
-
-		err := api.Where(api.ConditionFromModel(&obj, &obj2.UUID)).List(&result)
 		assert.NotNil(t, err)
 	})
 }
@@ -382,10 +352,10 @@ func TestConditionFromFunc(t *testing.T) {
 func TestConditionFromModel(t *testing.T) {
 	var testObj testLogicalSwitch
 	test := []struct {
-		name   string
-		model  Model
-		fields []interface{}
-		err    bool
+		name  string
+		model Model
+		conds []Condition
+		err   bool
 	}{
 		{
 			name:  "wrong model must fail",
@@ -393,12 +363,12 @@ func TestConditionFromModel(t *testing.T) {
 			err:   true,
 		},
 		{
-			name: "wrong fields must fail",
+			name: "wrong condition must fail",
 			model: &struct {
 				a string `ovs:"_uuid"`
 			}{},
-			fields: []interface{}{"foo"},
-			err:    true,
+			conds: []Condition{{Field: "foo"}},
+			err:   true,
 		},
 		{
 			name:  "correct model must succeed",
@@ -406,10 +376,21 @@ func TestConditionFromModel(t *testing.T) {
 			err:   false,
 		},
 		{
-			name:   "correct model with fields must succeed",
-			model:  &testObj,
-			fields: []interface{}{&testObj.Name},
-			err:    false,
+			name:  "correct model with valid condition must succeed",
+			model: &testObj,
+			conds: []Condition{
+				{
+					Field:    &testObj.Name,
+					Function: ovsdb.ConditionEqual,
+					Value:    "foo",
+				},
+				{
+					Field:    &testObj.Ports,
+					Function: ovsdb.ConditionIncludes,
+					Value:    []string{"foo"},
+				},
+			},
+			err: false,
 		},
 	}
 
@@ -417,11 +398,16 @@ func TestConditionFromModel(t *testing.T) {
 		t.Run(fmt.Sprintf("ConditionFromModel: %s", tt.name), func(t *testing.T) {
 			cache := apiTestCache(t)
 			api := newAPI(cache)
-			condition := api.ConditionFromModel(tt.model, tt.fields...)
+			condition := api.ConditionFromModel(tt.model, tt.conds...)
 			if tt.err {
 				assert.IsType(t, &errorConditionFactory{}, condition)
 			} else {
-				assert.IsType(t, &indexCondFactory{}, condition)
+				if len(tt.conds) > 0 {
+					assert.IsType(t, &explicitCondFactory{}, condition)
+				} else {
+					assert.IsType(t, &equalityCondFactory{}, condition)
+				}
+
 			}
 		})
 	}
@@ -810,7 +796,6 @@ func TestAPIUpdate(t *testing.T) {
 		name      string
 		condition func(API) ConditionalAPI
 		prepare   func(t *testLogicalSwitchPort)
-		fields    []interface{}
 		result    []ovsdb.Operation
 		err       bool
 	}{
@@ -825,7 +810,6 @@ func TestAPIUpdate(t *testing.T) {
 				t.Type = "somethingElse"
 				t.Tag = []int{6}
 			},
-			fields: []interface{}{},
 			result: []ovsdb.Operation{
 				{
 					Op:    opUpdate,
@@ -847,7 +831,6 @@ func TestAPIUpdate(t *testing.T) {
 				t.Type = "somethingElse"
 				t.Tag = []int{6}
 			},
-			fields: []interface{}{},
 			result: []ovsdb.Operation{
 				{
 					Op:    opUpdate,
@@ -865,18 +848,47 @@ func TestAPIUpdate(t *testing.T) {
 					Type:    "sometype",
 					Enabled: []bool{true},
 				}
-				return a.Where(a.ConditionFromModel(&t, &t.Type))
+				return a.Where(a.ConditionFromModel(&t, Condition{
+					Field:    &t.Type,
+					Function: ovsdb.ConditionEqual,
+					Value:    "sometype",
+				}))
 			},
 			prepare: func(t *testLogicalSwitchPort) {
 				t.Tag = []int{6}
 			},
-			fields: []interface{}{},
 			result: []ovsdb.Operation{
 				{
 					Op:    opUpdate,
 					Table: "Logical_Switch_Port",
 					Row:   map[string]interface{}{"tag": testOvsSet(t, []int{6})},
 					Where: []ovsdb.Condition{{Column: "type", Function: ovsdb.ConditionEqual, Value: "sometype"}},
+				},
+			},
+			err: false,
+		},
+		{
+			name: "select by field inequality change multiple field",
+			condition: func(a API) ConditionalAPI {
+				t := testLogicalSwitchPort{
+					Type:    "sometype",
+					Enabled: []bool{true},
+				}
+				return a.Where(a.ConditionFromModel(&t, Condition{
+					Field:    &t.Type,
+					Function: ovsdb.ConditionNotEqual,
+					Value:    "sometype",
+				}))
+			},
+			prepare: func(t *testLogicalSwitchPort) {
+				t.Tag = []int{6}
+			},
+			result: []ovsdb.Operation{
+				{
+					Op:    opUpdate,
+					Table: "Logical_Switch_Port",
+					Row:   map[string]interface{}{"tag": testOvsSet(t, []int{6})},
+					Where: []ovsdb.Condition{{Column: "type", Function: ovsdb.ConditionNotEqual, Value: "sometype"}},
 				},
 			},
 			err: false,
@@ -892,7 +904,6 @@ func TestAPIUpdate(t *testing.T) {
 				t.Type = "somethingElse"
 				t.Tag = []int{6}
 			},
-			fields: []interface{}{},
 			result: []ovsdb.Operation{
 				{
 					Op:    opUpdate,
@@ -996,13 +1007,16 @@ func TestAPIDelete(t *testing.T) {
 			err: false,
 		},
 		{
-			name: "select by field",
+			name: "select by field equality",
 			condition: func(a API) ConditionalAPI {
 				t := testLogicalSwitchPort{
-					Type:    "sometype",
 					Enabled: []bool{true},
 				}
-				return a.Where(a.ConditionFromModel(&t, &t.Type))
+				return a.Where(a.ConditionFromModel(&t, Condition{
+					Field:    &t.Type,
+					Function: ovsdb.ConditionEqual,
+					Value:    "sometype",
+				}))
 			},
 			result: []ovsdb.Operation{
 				{

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -371,9 +371,9 @@ func TestConditionFromFunc(t *testing.T) {
 			api := newAPI(cache)
 			condition := api.ConditionFromFunc(tt.arg)
 			if tt.err {
-				assert.IsType(t, &errorCondition{}, condition)
+				assert.IsType(t, &errorConditionFactory{}, condition)
 			} else {
-				assert.IsType(t, &predicateCond{}, condition)
+				assert.IsType(t, &predicateCondFactory{}, condition)
 			}
 		})
 	}
@@ -419,9 +419,9 @@ func TestConditionFromModel(t *testing.T) {
 			api := newAPI(cache)
 			condition := api.ConditionFromModel(tt.model, tt.fields...)
 			if tt.err {
-				assert.IsType(t, &errorCondition{}, condition)
+				assert.IsType(t, &errorConditionFactory{}, condition)
 			} else {
-				assert.IsType(t, &indexCond{}, condition)
+				assert.IsType(t, &indexCondFactory{}, condition)
 			}
 		})
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -381,6 +381,6 @@ func (ovs OvsdbClient) ConditionFromFunc(predicate interface{}) ConditionFactory
 }
 
 //ConditionFromModel implements the API interface's ConditionFromModel function
-func (ovs OvsdbClient) ConditionFromModel(m Model, fields ...interface{}) ConditionFactory {
-	return ovs.api.ConditionFromModel(m, fields...)
+func (ovs OvsdbClient) ConditionFromModel(m Model, conditions ...Condition) ConditionFactory {
+	return ovs.api.ConditionFromModel(m, conditions...)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -371,16 +371,16 @@ func (ovs OvsdbClient) List(result interface{}) error {
 }
 
 //Where implements the API interface's Where function
-func (ovs OvsdbClient) Where(condition Condition) ConditionalAPI {
+func (ovs OvsdbClient) Where(condition ConditionFactory) ConditionalAPI {
 	return ovs.api.Where(condition)
 }
 
 //ConditionFromFunc implements the API interface's ConditionFromFunc function
-func (ovs OvsdbClient) ConditionFromFunc(predicate interface{}) Condition {
+func (ovs OvsdbClient) ConditionFromFunc(predicate interface{}) ConditionFactory {
 	return ovs.api.ConditionFromFunc(predicate)
 }
 
 //ConditionFromModel implements the API interface's ConditionFromModel function
-func (ovs OvsdbClient) ConditionFromModel(m Model, fields ...interface{}) Condition {
+func (ovs OvsdbClient) ConditionFromModel(m Model, fields ...interface{}) ConditionFactory {
 	return ovs.api.ConditionFromModel(m, fields...)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -371,16 +371,11 @@ func (ovs OvsdbClient) List(result interface{}) error {
 }
 
 //Where implements the API interface's Where function
-func (ovs OvsdbClient) Where(condition ConditionFactory) ConditionalAPI {
-	return ovs.api.Where(condition)
+func (ovs OvsdbClient) Where(m Model, conditions ...Condition) ConditionalAPI {
+	return ovs.api.Where(m, conditions...)
 }
 
-//ConditionFromFunc implements the API interface's ConditionFromFunc function
-func (ovs OvsdbClient) ConditionFromFunc(predicate interface{}) ConditionFactory {
-	return ovs.api.ConditionFromFunc(predicate)
-}
-
-//ConditionFromModel implements the API interface's ConditionFromModel function
-func (ovs OvsdbClient) ConditionFromModel(m Model, conditions ...Condition) ConditionFactory {
-	return ovs.api.ConditionFromModel(m, conditions...)
+//WhereCache implements the API interface's WhereCache function
+func (ovs OvsdbClient) WhereCache(predicate interface{}) ConditionalAPI {
+	return ovs.api.WhereCache(predicate)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -375,6 +375,11 @@ func (ovs OvsdbClient) Where(m Model, conditions ...Condition) ConditionalAPI {
 	return ovs.api.Where(m, conditions...)
 }
 
+//WhereAll implements the API interface's WhereAll function
+func (ovs OvsdbClient) WhereAll(m Model, conditions ...Condition) ConditionalAPI {
+	return ovs.api.WhereAll(m, conditions...)
+}
+
 //WhereCache implements the API interface's WhereCache function
 func (ovs OvsdbClient) WhereCache(predicate interface{}) ConditionalAPI {
 	return ovs.api.WhereCache(predicate)

--- a/client/condition_test.go
+++ b/client/condition_test.go
@@ -1,0 +1,348 @@
+package client
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEqualityCondFactory(t *testing.T) {
+	cache := apiTestCache(t)
+	lspcacheList := []Model{
+		&testLogicalSwitchPort{
+			UUID:        aUUID0,
+			Name:        "lsp0",
+			ExternalIds: map[string]string{"foo": "bar"},
+			Enabled:     []bool{true},
+		},
+		&testLogicalSwitchPort{
+			UUID:        aUUID1,
+			Name:        "lsp1",
+			ExternalIds: map[string]string{"foo": "baz"},
+			Enabled:     []bool{false},
+		},
+		&testLogicalSwitchPort{
+			UUID:        aUUID2,
+			Name:        "lsp2",
+			ExternalIds: map[string]string{"unique": "id"},
+			Enabled:     []bool{false},
+		},
+		&testLogicalSwitchPort{
+			UUID:        aUUID3,
+			Name:        "lsp3",
+			ExternalIds: map[string]string{"foo": "baz"},
+			Enabled:     []bool{true},
+		},
+	}
+	lspcache := map[string]Model{}
+	for i := range lspcacheList {
+		lspcache[lspcacheList[i].(*testLogicalSwitchPort).UUID] = lspcacheList[i]
+	}
+	cache.cache["Logical_Switch_Port"] = &RowCache{cache: lspcache}
+
+	test := []struct {
+		name      string
+		model     Model
+		condition []ovsdb.Condition
+		matches   map[Model]bool
+		err       bool
+	}{
+		{
+			name:  "by uuid",
+			model: &testLogicalSwitchPort{UUID: aUUID0, Name: "different"},
+			condition: []ovsdb.Condition{
+				{
+					Column:   "_uuid",
+					Function: ovsdb.ConditionEqual,
+					Value:    ovsdb.UUID{GoUUID: aUUID0},
+				}},
+			matches: map[Model]bool{
+				&testLogicalSwitchPort{UUID: aUUID0}:              true,
+				&testLogicalSwitchPort{UUID: aUUID1}:              false,
+				&testLogicalSwitchPort{UUID: aUUID0, Name: "foo"}: true,
+			},
+		},
+		{
+			name:  "by index",
+			model: &testLogicalSwitchPort{Name: "lsp1"},
+			condition: []ovsdb.Condition{
+				{
+					Column:   "name",
+					Function: ovsdb.ConditionEqual,
+					Value:    "lsp1",
+				}},
+			matches: map[Model]bool{
+				&testLogicalSwitchPort{UUID: aUUID1}:               false,
+				&testLogicalSwitchPort{UUID: aUUID1, Name: "lsp1"}: true,
+				&testLogicalSwitchPort{UUID: aUUID0, Name: "lsp1"}: true,
+			},
+		},
+		{
+			name:  "by non index",
+			model: &testLogicalSwitchPort{ExternalIds: map[string]string{"foo": "baz"}},
+			err:   true,
+		},
+	}
+	for _, tt := range test {
+		t.Run(fmt.Sprintf("Equality Condition: %s", tt.name), func(t *testing.T) {
+			cond, err := newEqualityConditionFactory(cache.orm, "Logical_Switch_Port", tt.model)
+			assert.Nil(t, err)
+			for model, shouldMatch := range tt.matches {
+				matches, err := cond.Matches(model)
+				if tt.err {
+					assert.NotNil(t, err)
+				} else {
+					assert.Nil(t, err)
+					assert.Equalf(t, shouldMatch, matches, fmt.Sprintf("Match on model %#+v should be %v", model, shouldMatch))
+				}
+			}
+			generated, err := cond.Generate()
+			if tt.err {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.ElementsMatch(t, tt.condition, generated)
+			}
+		})
+	}
+}
+
+func TestPredicateCondFactory(t *testing.T) {
+	cache := apiTestCache(t)
+	lspcacheList := []Model{
+		&testLogicalSwitchPort{
+			UUID:        aUUID0,
+			Name:        "lsp0",
+			ExternalIds: map[string]string{"foo": "bar"},
+			Enabled:     []bool{true},
+		},
+		&testLogicalSwitchPort{
+			UUID:        aUUID1,
+			Name:        "lsp1",
+			ExternalIds: map[string]string{"foo": "baz"},
+			Enabled:     []bool{false},
+		},
+		&testLogicalSwitchPort{
+			UUID:        aUUID2,
+			Name:        "lsp2",
+			ExternalIds: map[string]string{"unique": "id"},
+			Enabled:     []bool{false},
+		},
+		&testLogicalSwitchPort{
+			UUID:        aUUID3,
+			Name:        "lsp3",
+			ExternalIds: map[string]string{"foo": "baz"},
+			Enabled:     []bool{true},
+		},
+	}
+	lspcache := map[string]Model{}
+	for i := range lspcacheList {
+		lspcache[lspcacheList[i].(*testLogicalSwitchPort).UUID] = lspcacheList[i]
+	}
+	cache.cache["Logical_Switch_Port"] = &RowCache{cache: lspcache}
+
+	test := []struct {
+		name      string
+		predicate interface{}
+		condition []ovsdb.Condition
+		matches   map[Model]bool
+		err       bool
+	}{
+		{
+			name: "simple value comparison",
+			predicate: func(lsp *testLogicalSwitchPort) bool {
+				return lsp.UUID == aUUID0
+			},
+			condition: []ovsdb.Condition{
+				{
+					Column:   "_uuid",
+					Function: ovsdb.ConditionEqual,
+					Value:    ovsdb.UUID{GoUUID: aUUID0},
+				}},
+			matches: map[Model]bool{
+				&testLogicalSwitchPort{UUID: aUUID0}:              true,
+				&testLogicalSwitchPort{UUID: aUUID1}:              false,
+				&testLogicalSwitchPort{UUID: aUUID0, Name: "foo"}: true,
+			},
+		},
+		{
+			name: "by random field",
+			predicate: func(lsp *testLogicalSwitchPort) bool {
+				return lsp.Enabled[0] == false
+			},
+			condition: []ovsdb.Condition{
+				{
+					Column:   "_uuid",
+					Function: ovsdb.ConditionEqual,
+					Value:    ovsdb.UUID{GoUUID: aUUID1},
+				},
+				{
+					Column:   "_uuid",
+					Function: ovsdb.ConditionEqual,
+					Value:    ovsdb.UUID{GoUUID: aUUID2},
+				}},
+			matches: map[Model]bool{
+				&testLogicalSwitchPort{UUID: aUUID1, Enabled: []bool{true}}:  false,
+				&testLogicalSwitchPort{UUID: aUUID1, Enabled: []bool{false}}: true,
+			},
+		},
+	}
+	for _, tt := range test {
+		t.Run(fmt.Sprintf("Predicate Condition: %s", tt.name), func(t *testing.T) {
+			cond, err := newPredicateConditionFactory("Logical_Switch_Port", cache, tt.predicate)
+			assert.Nil(t, err)
+			for model, shouldMatch := range tt.matches {
+				matches, err := cond.Matches(model)
+				if tt.err {
+					assert.NotNil(t, err)
+				} else {
+					assert.Nil(t, err)
+					assert.Equalf(t, shouldMatch, matches, fmt.Sprintf("Match on model %#+v should be %v", model, shouldMatch))
+				}
+			}
+			generated, err := cond.Generate()
+			if tt.err {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.ElementsMatch(t, tt.condition, generated)
+			}
+		})
+	}
+}
+
+func TestExplicitCondFactory(t *testing.T) {
+	cache := apiTestCache(t)
+	lspcacheList := []Model{
+		&testLogicalSwitchPort{
+			UUID:        aUUID0,
+			Name:        "lsp0",
+			ExternalIds: map[string]string{"foo": "bar"},
+			Enabled:     []bool{true},
+		},
+		&testLogicalSwitchPort{
+			UUID:        aUUID1,
+			Name:        "lsp1",
+			ExternalIds: map[string]string{"foo": "baz"},
+			Enabled:     []bool{false},
+		},
+		&testLogicalSwitchPort{
+			UUID:        aUUID2,
+			Name:        "lsp2",
+			ExternalIds: map[string]string{"unique": "id"},
+			Enabled:     []bool{false},
+		},
+		&testLogicalSwitchPort{
+			UUID:        aUUID3,
+			Name:        "lsp3",
+			ExternalIds: map[string]string{"foo": "baz"},
+			Enabled:     []bool{true},
+		},
+	}
+	lspcache := map[string]Model{}
+	for i := range lspcacheList {
+		lspcache[lspcacheList[i].(*testLogicalSwitchPort).UUID] = lspcacheList[i]
+	}
+	cache.cache["Logical_Switch_Port"] = &RowCache{cache: lspcache}
+
+	testObj := &testLogicalSwitchPort{}
+
+	test := []struct {
+		name   string
+		args   []Condition
+		result []ovsdb.Condition
+		err    bool
+	}{
+		{
+			name: "inequality comparison",
+			args: []Condition{
+				{
+					Field:    &testObj.Name,
+					Function: ovsdb.ConditionNotEqual,
+					Value:    "lsp0",
+				},
+			},
+			result: []ovsdb.Condition{
+				{
+					Column:   "name",
+					Function: ovsdb.ConditionNotEqual,
+					Value:    "lsp0",
+				}},
+		},
+		{
+			name: "map comparison",
+			args: []Condition{
+				{
+					Field:    &testObj.ExternalIds,
+					Function: ovsdb.ConditionIncludes,
+					Value:    map[string]string{"foo": "baz"},
+				},
+			},
+			result: []ovsdb.Condition{
+				{
+					Column:   "external_ids",
+					Function: ovsdb.ConditionIncludes,
+					Value:    testOvsMap(t, map[string]string{"foo": "baz"}),
+				}},
+		},
+		{
+			name: "set comparison",
+			args: []Condition{
+				{
+					Field:    &testObj.Enabled,
+					Function: ovsdb.ConditionEqual,
+					Value:    []bool{true},
+				},
+			},
+			result: []ovsdb.Condition{
+				{
+					Column:   "enabled",
+					Function: ovsdb.ConditionEqual,
+					Value:    testOvsSet(t, []bool{true}),
+				}},
+		},
+		{
+			name: "multiple conditions",
+			args: []Condition{
+				{
+					Field:    &testObj.Enabled,
+					Function: ovsdb.ConditionEqual,
+					Value:    []bool{true},
+				},
+				{
+					Field:    &testObj.Name,
+					Function: ovsdb.ConditionNotEqual,
+					Value:    "foo",
+				},
+			},
+			result: []ovsdb.Condition{
+				{
+					Column:   "enabled",
+					Function: ovsdb.ConditionEqual,
+					Value:    testOvsSet(t, []bool{true}),
+				},
+				{
+					Column:   "name",
+					Function: ovsdb.ConditionNotEqual,
+					Value:    "foo",
+				}},
+		},
+	}
+	for _, tt := range test {
+		t.Run(fmt.Sprintf("Explicit Condition: %s", tt.name), func(t *testing.T) {
+			cond, err := newExplicitConditionFactory(cache.orm, "Logical_Switch_Port", testObj, tt.args...)
+			assert.Nil(t, err)
+			_, err = cond.Matches(testObj)
+			assert.NotNilf(t, err, "Explicit conditions should fail to match on cache")
+			generated, err := cond.Generate()
+			if tt.err {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.ElementsMatch(t, tt.result, generated)
+			}
+		})
+	}
+}

--- a/client/condition_test.go
+++ b/client/condition_test.go
@@ -45,19 +45,20 @@ func TestEqualityCondFactory(t *testing.T) {
 	test := []struct {
 		name      string
 		model     Model
-		condition []ovsdb.Condition
+		condition [][]ovsdb.Condition
 		matches   map[Model]bool
 		err       bool
 	}{
 		{
 			name:  "by uuid",
 			model: &testLogicalSwitchPort{UUID: aUUID0, Name: "different"},
-			condition: []ovsdb.Condition{
+			condition: [][]ovsdb.Condition{
 				{
-					Column:   "_uuid",
-					Function: ovsdb.ConditionEqual,
-					Value:    ovsdb.UUID{GoUUID: aUUID0},
-				}},
+					{
+						Column:   "_uuid",
+						Function: ovsdb.ConditionEqual,
+						Value:    ovsdb.UUID{GoUUID: aUUID0},
+					}}},
 			matches: map[Model]bool{
 				&testLogicalSwitchPort{UUID: aUUID0}:              true,
 				&testLogicalSwitchPort{UUID: aUUID1}:              false,
@@ -67,12 +68,13 @@ func TestEqualityCondFactory(t *testing.T) {
 		{
 			name:  "by index",
 			model: &testLogicalSwitchPort{Name: "lsp1"},
-			condition: []ovsdb.Condition{
+			condition: [][]ovsdb.Condition{
 				{
-					Column:   "name",
-					Function: ovsdb.ConditionEqual,
-					Value:    "lsp1",
-				}},
+					{
+						Column:   "name",
+						Function: ovsdb.ConditionEqual,
+						Value:    "lsp1",
+					}}},
 			matches: map[Model]bool{
 				&testLogicalSwitchPort{UUID: aUUID1}:               false,
 				&testLogicalSwitchPort{UUID: aUUID1, Name: "lsp1"}: true,
@@ -146,7 +148,7 @@ func TestPredicateCondFactory(t *testing.T) {
 	test := []struct {
 		name      string
 		predicate interface{}
-		condition []ovsdb.Condition
+		condition [][]ovsdb.Condition
 		matches   map[Model]bool
 		err       bool
 	}{
@@ -155,12 +157,13 @@ func TestPredicateCondFactory(t *testing.T) {
 			predicate: func(lsp *testLogicalSwitchPort) bool {
 				return lsp.UUID == aUUID0
 			},
-			condition: []ovsdb.Condition{
+			condition: [][]ovsdb.Condition{
 				{
-					Column:   "_uuid",
-					Function: ovsdb.ConditionEqual,
-					Value:    ovsdb.UUID{GoUUID: aUUID0},
-				}},
+					{
+						Column:   "_uuid",
+						Function: ovsdb.ConditionEqual,
+						Value:    ovsdb.UUID{GoUUID: aUUID0},
+					}}},
 			matches: map[Model]bool{
 				&testLogicalSwitchPort{UUID: aUUID0}:              true,
 				&testLogicalSwitchPort{UUID: aUUID1}:              false,
@@ -172,17 +175,19 @@ func TestPredicateCondFactory(t *testing.T) {
 			predicate: func(lsp *testLogicalSwitchPort) bool {
 				return lsp.Enabled[0] == false
 			},
-			condition: []ovsdb.Condition{
+			condition: [][]ovsdb.Condition{
 				{
-					Column:   "_uuid",
-					Function: ovsdb.ConditionEqual,
-					Value:    ovsdb.UUID{GoUUID: aUUID1},
-				},
+					{
+						Column:   "_uuid",
+						Function: ovsdb.ConditionEqual,
+						Value:    ovsdb.UUID{GoUUID: aUUID1},
+					}},
 				{
-					Column:   "_uuid",
-					Function: ovsdb.ConditionEqual,
-					Value:    ovsdb.UUID{GoUUID: aUUID2},
-				}},
+					{
+						Column:   "_uuid",
+						Function: ovsdb.ConditionEqual,
+						Value:    ovsdb.UUID{GoUUID: aUUID2},
+					}}},
 			matches: map[Model]bool{
 				&testLogicalSwitchPort{UUID: aUUID1, Enabled: []bool{true}}:  false,
 				&testLogicalSwitchPort{UUID: aUUID1, Enabled: []bool{false}}: true,
@@ -252,7 +257,7 @@ func TestExplicitCondFactory(t *testing.T) {
 	test := []struct {
 		name   string
 		args   []Condition
-		result []ovsdb.Condition
+		result [][]ovsdb.Condition
 		err    bool
 	}{
 		{
@@ -264,12 +269,13 @@ func TestExplicitCondFactory(t *testing.T) {
 					Value:    "lsp0",
 				},
 			},
-			result: []ovsdb.Condition{
+			result: [][]ovsdb.Condition{
 				{
-					Column:   "name",
-					Function: ovsdb.ConditionNotEqual,
-					Value:    "lsp0",
-				}},
+					{
+						Column:   "name",
+						Function: ovsdb.ConditionNotEqual,
+						Value:    "lsp0",
+					}}},
 		},
 		{
 			name: "map comparison",
@@ -280,12 +286,13 @@ func TestExplicitCondFactory(t *testing.T) {
 					Value:    map[string]string{"foo": "baz"},
 				},
 			},
-			result: []ovsdb.Condition{
+			result: [][]ovsdb.Condition{
 				{
-					Column:   "external_ids",
-					Function: ovsdb.ConditionIncludes,
-					Value:    testOvsMap(t, map[string]string{"foo": "baz"}),
-				}},
+					{
+						Column:   "external_ids",
+						Function: ovsdb.ConditionIncludes,
+						Value:    testOvsMap(t, map[string]string{"foo": "baz"}),
+					}}},
 		},
 		{
 			name: "set comparison",
@@ -296,12 +303,13 @@ func TestExplicitCondFactory(t *testing.T) {
 					Value:    []bool{true},
 				},
 			},
-			result: []ovsdb.Condition{
+			result: [][]ovsdb.Condition{
 				{
-					Column:   "enabled",
-					Function: ovsdb.ConditionEqual,
-					Value:    testOvsSet(t, []bool{true}),
-				}},
+					{
+						Column:   "enabled",
+						Function: ovsdb.ConditionEqual,
+						Value:    testOvsSet(t, []bool{true}),
+					}}},
 		},
 		{
 			name: "multiple conditions",
@@ -317,17 +325,19 @@ func TestExplicitCondFactory(t *testing.T) {
 					Value:    "foo",
 				},
 			},
-			result: []ovsdb.Condition{
+			result: [][]ovsdb.Condition{
 				{
-					Column:   "enabled",
-					Function: ovsdb.ConditionEqual,
-					Value:    testOvsSet(t, []bool{true}),
-				},
+					{
+						Column:   "enabled",
+						Function: ovsdb.ConditionEqual,
+						Value:    testOvsSet(t, []bool{true}),
+					}},
 				{
-					Column:   "name",
-					Function: ovsdb.ConditionNotEqual,
-					Value:    "foo",
-				}},
+					{
+						Column:   "name",
+						Function: ovsdb.ConditionNotEqual,
+						Value:    "foo",
+					}}},
 		},
 	}
 	for _, tt := range test {

--- a/client/orm_test.go
+++ b/client/orm_test.go
@@ -580,9 +580,9 @@ func TestORMCondition(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(fmt.Sprintf("newCondition_%s", tt.name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("newEqualityCondition_%s", tt.name), func(t *testing.T) {
 			tt.prepare(&testObj)
-			conds, err := orm.newCondition("TestTable", &testObj, tt.index...)
+			conds, err := orm.newEqualityCondition("TestTable", &testObj, tt.index...)
 			if tt.err {
 				if err == nil {
 					t.Errorf("expected an error but got none")

--- a/client/ovs_integration_test.go
+++ b/client/ovs_integration_test.go
@@ -192,7 +192,7 @@ func TestInsertTransactIntegration(t *testing.T) {
 
 	// Inserting a Bridge row in Bridge table requires mutating the open_vswitch table.
 	ovsRow := ovsType{}
-	mutateOp, err := ovs.Where(ovs.ConditionFromFunc(func(*ovsType) bool { return true })).
+	mutateOp, err := ovs.WhereCache(func(*ovsType) bool { return true }).
 		Mutate(&ovsRow, []Mutation{
 			{
 				Field:   &ovsRow.Bridges,
@@ -245,11 +245,11 @@ func TestDeleteTransactIntegration(t *testing.T) {
 	err = ovs.MonitorAll(nil)
 	assert.Nil(t, err)
 
-	deleteOp, err := ovs.Where(ovs.ConditionFromModel(&bridgeType{Name: bridgeName})).Delete()
+	deleteOp, err := ovs.Where(&bridgeType{Name: bridgeName}).Delete()
 	assert.Nil(t, err)
 
 	ovsRow := ovsType{}
-	mutateOp, err := ovs.Where(ovs.ConditionFromFunc(func(*ovsType) bool { return true })).
+	mutateOp, err := ovs.WhereCache(func(*ovsType) bool { return true }).
 		Mutate(&ovsRow, []Mutation{
 			{
 				Field:   &ovsRow.Bridges,

--- a/cmd/stress/stress.go
+++ b/cmd/stress/stress.go
@@ -105,7 +105,7 @@ func transact(ovs *client.OvsdbClient, operations []ovsdb.Operation) (ok bool, u
 }
 
 func deleteBridge(ovs *client.OvsdbClient, bridge *ormBridge) {
-	deleteOp, err := ovs.Where(ovs.ConditionFromModel(bridge)).Delete()
+	deleteOp, err := ovs.Where(bridge).Delete()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func deleteBridge(ovs *client.OvsdbClient, bridge *ormBridge) {
 		UUID: rootUUID,
 	}
 
-	mutateOp, err := ovs.Where(ovs.ConditionFromModel(&ovsRow)).Mutate(&ovsRow, []client.Mutation{
+	mutateOp, err := ovs.Where(&ovsRow).Mutate(&ovsRow, []client.Mutation{
 		{
 			Field:   &ovsRow.Bridges,
 			Mutator: "delete",
@@ -151,7 +151,7 @@ func createBridge(ovs *client.OvsdbClient, iter int) {
 		log.Fatal(err)
 	}
 	ovsRow := ormOvs{}
-	mutateOp, err := ovs.Where(ovs.ConditionFromModel(&ormOvs{UUID: rootUUID})).Mutate(&ovsRow, []client.Mutation{
+	mutateOp, err := ovs.Where(&ormOvs{UUID: rootUUID}).Mutate(&ovsRow, []client.Mutation{
 		{
 			Field:   &ovsRow.Bridges,
 			Mutator: "insert",

--- a/example/play_with_ovs/play_with_ovs.go
+++ b/example/play_with_ovs/play_with_ovs.go
@@ -71,7 +71,7 @@ func createBridge(ovs *client.OvsdbClient, bridgeName string) {
 	ovsRow := ormOvs{
 		UUID: rootUUID,
 	}
-	mutateOps, err := ovs.Where(ovs.ConditionFromModel(&ovsRow)).Mutate(&ovsRow, []client.Mutation{
+	mutateOps, err := ovs.Where(&ovsRow).Mutate(&ovsRow, []client.Mutation{
 		{
 			Field:   &ovsRow.Bridges,
 			Mutator: "insert",

--- a/ovsdb/bindings.go
+++ b/ovsdb/bindings.go
@@ -294,6 +294,28 @@ func ValidateMutation(column *ColumnSchema, mutator Mutator, value interface{}) 
 	}
 }
 
+func ValidateCondition(column *ColumnSchema, function ConditionFunction, nativeValue interface{}) error {
+	if NativeType(column) != reflect.TypeOf(nativeValue) {
+		return NewErrWrongType(fmt.Sprintf("Condition for column %s", column),
+			NativeType(column).String(), nativeValue)
+	}
+
+	switch column.Type {
+	case TypeSet, TypeMap, TypeBoolean, TypeString, TypeUUID:
+		switch function {
+		case ConditionEqual, ConditionNotEqual, ConditionIncludes, ConditionExcludes:
+			return nil
+		default:
+			return fmt.Errorf("wrong condition function %s for type: %s", function, column.Type)
+		}
+	case TypeInteger, TypeReal:
+		// All functions are valid
+		return nil
+	default:
+		panic("Unsupported Type")
+	}
+}
+
 func isDefaultBaseValue(elem interface{}, etype ExtendedType) bool {
 	value := reflect.ValueOf(elem)
 	if !value.IsValid() {


### PR DESCRIPTION
`WhereAll` uses the condition list to generate a single operation that matches all of the conditions where as `Where` is left with the old behavior, i.e: generate N operations where each operation match a single condition.

The logical semantics for conditions is therefore:
Where() -> OR
WhereAll() -> AND

Examples:

```
// Delete a single a port whose name is "foo" AND is enabled
lsp := &LogicalSwitchPort{}
client.WhereAll(&lsp,
    Condition {
        Field: &lsp.Name,
        Function: ovsdb.ConditionEqual,
        Value: "foo",
    }, Condition {
        Field: &lsp.Enabled:
        Function: ovsdb.ConditionEqual,
        Value: []bool{true},
    }).Delete()

// Delete all ports that are enabled OR are named "foo"
client.Where(&lsp,
    Condition {
        Field: &lsp.Name,
        Function: ovsdb.ConditionEqual,
        Value: "foo",
    }, Condition {
        Field: &lsp.Enabled:
        Function: ovsdb.ConditionEqual,
        Value: []bool{true},
    }).Delete()

```


Based on #114 and #113 