### PR TITLE
Makefile: Reorder local targets so build is before lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 all: test
 
-local: install-deps fmt lint build-local test-local bench-local
+local: install-deps build-local fmt lint test-local bench-local
 
 prebuild-local:
 	@echo "+ $@"


### PR DESCRIPTION
Signed-off-by: Dave Tucker <dave@dtucker.co.uk>