### PR TITLE
cache: Move cache to its own package

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,21 +75,23 @@ The table is infered from the type that the function accepts as only argument.
 
 This package is divided into several subpackages. Documentation for each subpackage is available at [pkg.go.dev][doc]:
 
-* **client**: ovsdb client, cache and API [![godoc for libovsdb/client][clientbadge]][clientdoc]
+* **client**: ovsdb client and API [![godoc for libovsdb/client][clientbadge]][clientdoc]
 * **mapper**: mapping from tagged structs to ovsdb types [![godoc for libovsdb/mapper][mapperbadge]][mapperdoc]
 * **model**: model and database model used for mapping [![godoc for libovsdb/model][modelbadge]][modeldoc]
 * **ovsdb**: low level OVS types [![godoc for libovsdb/ovsdb][ovsdbbadge]][ovsdbdoc]
+* **cache**: model-based cache [![godoc for libovsdb/cache][cachebadge]][cachedoc]
 
 [doc]: https://pkg.go.dev/
 [clientbadge]: https://pkg.go.dev/badge/github.com/ovn-org/libovsdb/client
 [mapperbadge]: https://pkg.go.dev/badge/github.com/ovn-org/libovsdb/mapper
 [modelbadge]: https://pkg.go.dev/badge/github.com/ovn-org/libovsdb/model
 [ovsdbbadge]: https://pkg.go.dev/badge/github.com/ovn-org/libovsdb/ovsdb
+[cachebadge]: https://pkg.go.dev/badge/github.com/ovn-org/libovsdb/cache
 [clientdoc]: https://pkg.go.dev/github.com/ovn-org/libovsdb/client
 [mapperdoc]: https://pkg.go.dev/github.com/ovn-org/libovsdb/mapper
 [modeldoc]: https://pkg.go.dev/github.com/ovn-org/libovsdb/model
 [ovsdbdoc]: https://pkg.go.dev/github.com/ovn-org/libovsdb/ovsdb
-
+[cachedoc]: https://pkg.go.dev/github.com/ovn-org/libovsdb/cache
 
 ## Quick API Examples
 
@@ -175,7 +177,7 @@ They can also be created based on a list of Conditions:
 
 You can also register a notification handler to get notified every time an element is added, deleted or updated from the database.
 
-    handler := &client.EventHandlerFuncs{
+    handler := &cache.EventHandlerFuncs{
         AddFunc: func(table string, model model.Model) {
             if table == "Logical_Switch" {
                 fmt.Printf("A new switch named %s was added!!\n!", model.(*MyLogicalSwitch).Name)

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,4 +1,4 @@
-package client
+package cache
 
 import (
 	"testing"
@@ -228,7 +228,7 @@ func TestTableCache_Table(t *testing.T) {
 		{
 			"returns nil for an empty table",
 			fields{
-				cache: map[string]*RowCache{"bar": newRowCache()},
+				cache: map[string]*RowCache{"bar": NewRowCache(nil)},
 			},
 			args{
 				"foo",
@@ -238,12 +238,12 @@ func TestTableCache_Table(t *testing.T) {
 		{
 			"returns nil for an empty table",
 			fields{
-				cache: map[string]*RowCache{"bar": newRowCache()},
+				cache: map[string]*RowCache{"bar": NewRowCache(nil)},
 			},
 			args{
 				"bar",
 			},
-			newRowCache(),
+			NewRowCache(nil),
 		},
 	}
 	for _, tt := range tests {
@@ -268,7 +268,7 @@ func TestTableCache_Tables(t *testing.T) {
 	}{
 		{
 			"returns a table that exists",
-			fields{cache: map[string]*RowCache{"test1": newRowCache(), "test2": newRowCache(), "test3": newRowCache()}},
+			fields{cache: map[string]*RowCache{"test1": NewRowCache(nil), "test2": NewRowCache(nil), "test3": NewRowCache(nil)}},
 			[]string{"test1", "test2", "test3"},
 		},
 		{
@@ -307,7 +307,7 @@ func TestTableCache_populate(t *testing.T) {
 	     }
 	`), &schema)
 	assert.Nil(t, err)
-	tc, err := newTableCache(&schema, db)
+	tc, err := NewTableCache(&schema, db)
 	assert.Nil(t, err)
 
 	testRow := ovsdb.Row(map[string]interface{}{"_uuid": "test", "foo": "bar"})
@@ -320,9 +320,9 @@ func TestTableCache_populate(t *testing.T) {
 			},
 		},
 	}
-	tc.populate(updates)
+	tc.Populate(updates)
 
-	got := tc.cache["Open_vSwitch"].cache["test"]
+	got := tc.Table("Open_vSwitch").Row("test")
 	assert.Equal(t, testRowModel, got)
 
 	t.Log("Update")
@@ -332,7 +332,7 @@ func TestTableCache_populate(t *testing.T) {
 		Old: &testRow,
 		New: &updatedRow,
 	}
-	tc.populate(updates)
+	tc.Populate(updates)
 
 	got = tc.cache["Open_vSwitch"].cache["test"]
 	assert.Equal(t, updatedRowModel, got)
@@ -343,7 +343,7 @@ func TestTableCache_populate(t *testing.T) {
 		New: nil,
 	}
 
-	tc.populate(updates)
+	tc.Populate(updates)
 
 	_, ok := tc.cache["Open_vSwitch"].cache["test"]
 	assert.False(t, ok)

--- a/cache/doc.go
+++ b/cache/doc.go
@@ -1,0 +1,16 @@
+/*
+Package cache provides a cache of model.Model elements that can be used in an OVSDB client or server.
+
+The cache can be accessed using a simple API:
+
+    cache.Table("Open_vSwitch").Row("<ovs-uuid>")
+
+It implements the ovsdb.NotificationHandler interface
+such that it can be populated automatically by
+update notifications
+
+It also contains an eventProcessor where callers
+may registers functions that will get called on
+every Add/Update/Delete event.
+*/
+package cache

--- a/client/api_test_model.go
+++ b/client/api_test_model.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/ovn-org/libovsdb/cache"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/stretchr/testify/assert"
@@ -152,13 +153,13 @@ func (*testLogicalSwitchPort) Table() string {
 	return "Logical_Switch_Port"
 }
 
-func apiTestCache(t *testing.T) *TableCache {
+func apiTestCache(t *testing.T) *cache.TableCache {
 	var schema ovsdb.DatabaseSchema
 	err := json.Unmarshal(apiTestSchema, &schema)
 	assert.Nil(t, err)
 	db, err := model.NewDBModel("OVN_NorthBound", map[string]model.Model{"Logical_Switch": &testLogicalSwitch{}, "Logical_Switch_Port": &testLogicalSwitchPort{}})
 	assert.Nil(t, err)
-	cache, err := newTableCache(&schema, db)
+	cache, err := cache.NewTableCache(&schema, db)
 	assert.Nil(t, err)
 	return cache
 }

--- a/client/client.go
+++ b/client/client.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cenkalti/rpc2"
 	"github.com/cenkalti/rpc2/jsonrpc"
+	"github.com/ovn-org/libovsdb/cache"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
 )
@@ -22,7 +23,7 @@ type OvsdbClient struct {
 	Schema        ovsdb.DatabaseSchema
 	handlers      []ovsdb.NotificationHandler
 	handlersMutex *sync.Mutex
-	Cache         *TableCache
+	Cache         *cache.TableCache
 	stopCh        chan struct{}
 	api           API
 }
@@ -129,7 +130,7 @@ func newRPC2Client(conn net.Conn, database *model.DBModel) (*OvsdbClient, error)
 
 	if err == nil {
 		ovs.Schema = *schema
-		if cache, err := newTableCache(schema, database); err == nil {
+		if cache, err := cache.NewTableCache(schema, database); err == nil {
 			ovs.Cache = cache
 			ovs.Register(ovs.Cache)
 			ovs.api = newAPI(ovs.Cache)
@@ -298,7 +299,7 @@ func (ovs OvsdbClient) Monitor(jsonContext interface{}, requests map[string]ovsd
 	if err != nil {
 		return err
 	}
-	ovs.Cache.populate(reply)
+	ovs.Cache.Populate(reply)
 	return nil
 }
 

--- a/client/condition.go
+++ b/client/condition.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/ovn-org/libovsdb/cache"
 	"github.com/ovn-org/libovsdb/mapper"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
@@ -123,7 +124,7 @@ func newExplicitConditional(mapper *mapper.Mapper, table string, all bool, model
 type predicateConditional struct {
 	tableName string
 	predicate interface{}
-	cache     *TableCache
+	cache     *cache.TableCache
 }
 
 // matches returns the result of the execution of the predicate
@@ -152,7 +153,7 @@ func (c *predicateConditional) Generate() ([][]ovsdb.Condition, error) {
 			return nil, err
 		}
 		if match {
-			elemCond, err := c.cache.mapper.NewEqualityCondition(c.tableName, elem)
+			elemCond, err := c.cache.Mapper().NewEqualityCondition(c.tableName, elem)
 			if err != nil {
 				return nil, err
 			}
@@ -163,7 +164,7 @@ func (c *predicateConditional) Generate() ([][]ovsdb.Condition, error) {
 }
 
 // newPredicateConditional creates a new predicateConditional
-func newPredicateConditional(table string, cache *TableCache, predicate interface{}) (Conditional, error) {
+func newPredicateConditional(table string, cache *cache.TableCache, predicate interface{}) (Conditional, error) {
 	return &predicateConditional{
 		tableName: table,
 		predicate: predicate,

--- a/client/condition_test.go
+++ b/client/condition_test.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ovn-org/libovsdb/cache"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestEqualityConditional(t *testing.T) {
-	cache := apiTestCache(t)
+	tcache := apiTestCache(t)
 	lspcacheList := []model.Model{
 		&testLogicalSwitchPort{
 			UUID:        aUUID0,
@@ -41,7 +42,7 @@ func TestEqualityConditional(t *testing.T) {
 	for i := range lspcacheList {
 		lspcache[lspcacheList[i].(*testLogicalSwitchPort).UUID] = lspcacheList[i]
 	}
-	cache.cache["Logical_Switch_Port"] = &RowCache{cache: lspcache}
+	tcache.Set("Logical_Switch_Port", cache.NewRowCache(lspcache))
 
 	test := []struct {
 		name      string
@@ -125,7 +126,7 @@ func TestEqualityConditional(t *testing.T) {
 	}
 	for _, tt := range test {
 		t.Run(fmt.Sprintf("Equality Conditional: %s", tt.name), func(t *testing.T) {
-			cond, err := newEqualityConditional(cache.mapper, "Logical_Switch_Port", tt.all, tt.model)
+			cond, err := newEqualityConditional(tcache.Mapper(), "Logical_Switch_Port", tt.all, tt.model)
 			assert.Nil(t, err)
 			for model, shouldMatch := range tt.matches {
 				matches, err := cond.Matches(model)
@@ -148,7 +149,7 @@ func TestEqualityConditional(t *testing.T) {
 }
 
 func TestPredicateConditional(t *testing.T) {
-	cache := apiTestCache(t)
+	tcache := apiTestCache(t)
 	lspcacheList := []model.Model{
 		&testLogicalSwitchPort{
 			UUID:        aUUID0,
@@ -179,7 +180,7 @@ func TestPredicateConditional(t *testing.T) {
 	for i := range lspcacheList {
 		lspcache[lspcacheList[i].(*testLogicalSwitchPort).UUID] = lspcacheList[i]
 	}
-	cache.cache["Logical_Switch_Port"] = &RowCache{cache: lspcache}
+	tcache.Set("Logical_Switch_Port", cache.NewRowCache(lspcache))
 
 	test := []struct {
 		name      string
@@ -232,7 +233,7 @@ func TestPredicateConditional(t *testing.T) {
 	}
 	for _, tt := range test {
 		t.Run(fmt.Sprintf("Predicate Conditional: %s", tt.name), func(t *testing.T) {
-			cond, err := newPredicateConditional("Logical_Switch_Port", cache, tt.predicate)
+			cond, err := newPredicateConditional("Logical_Switch_Port", tcache, tt.predicate)
 			assert.Nil(t, err)
 			for model, shouldMatch := range tt.matches {
 				matches, err := cond.Matches(model)
@@ -255,7 +256,7 @@ func TestPredicateConditional(t *testing.T) {
 }
 
 func TestExplicitConditional(t *testing.T) {
-	cache := apiTestCache(t)
+	tcache := apiTestCache(t)
 	lspcacheList := []model.Model{
 		&testLogicalSwitchPort{
 			UUID:        aUUID0,
@@ -286,7 +287,7 @@ func TestExplicitConditional(t *testing.T) {
 	for i := range lspcacheList {
 		lspcache[lspcacheList[i].(*testLogicalSwitchPort).UUID] = lspcacheList[i]
 	}
-	cache.cache["Logical_Switch_Port"] = &RowCache{cache: lspcache}
+	tcache.Set("Logical_Switch_Port", cache.NewRowCache(lspcache))
 
 	testObj := &testLogicalSwitchPort{}
 
@@ -424,7 +425,7 @@ func TestExplicitConditional(t *testing.T) {
 	}
 	for _, tt := range test {
 		t.Run(fmt.Sprintf("Explicit Conditional: %s", tt.name), func(t *testing.T) {
-			cond, err := newExplicitConditional(cache.mapper, "Logical_Switch_Port", tt.all, testObj, tt.args...)
+			cond, err := newExplicitConditional(tcache.Mapper(), "Logical_Switch_Port", tt.all, testObj, tt.args...)
 			assert.Nil(t, err)
 			_, err = cond.Matches(testObj)
 			assert.NotNilf(t, err, "Explicit conditions should fail to match on cache")

--- a/cmd/stress/stress.go
+++ b/cmd/stress/stress.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"runtime/pprof"
 
+	"github.com/ovn-org/libovsdb/cache"
 	"github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
@@ -50,7 +51,7 @@ func run() {
 	}
 	defer ovs.Disconnect()
 	ovs.Cache.AddEventHandler(
-		&client.EventHandlerFuncs{
+		&cache.EventHandlerFuncs{
 			AddFunc: func(table string, model model.Model) {
 				if ready && table == "Bridge" {
 					insertions++

--- a/example/play_with_ovs/play_with_ovs.go
+++ b/example/play_with_ovs/play_with_ovs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/ovn-org/libovsdb/cache"
 	"github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
@@ -109,7 +110,7 @@ func main() {
 		log.Fatal("Unable to Connect ", err)
 	}
 
-	ovs.Cache.AddEventHandler(&client.EventHandlerFuncs{
+	ovs.Cache.AddEventHandler(&cache.EventHandlerFuncs{
 		AddFunc: func(table string, model model.Model) {
 			if table == bridgeTable {
 				update <- model


### PR DESCRIPTION
While working on the server it occurred to me that I could
re-use the cache implementation as it already contains both
a DBModel and Mapper. Therefore I've moved cache in to it's
own package.

This also adds a `Set()` API to the Table and RowCache elements.
It makes it easier to write tests that pre-populate cache entries this way.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>