### PR TITLE
Add interface for libovsdb connection with timeout

### DIFF
--- a/client/ovs_integration_test.go
+++ b/client/ovs_integration_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"os"
 	"testing"
@@ -71,14 +72,14 @@ func TestConnectIntegration(t *testing.T) {
 	go func() {
 		// Use Convenience params. Ignore failure even if any
 
-		_, err := Connect(cfg.Addr, defDB, nil)
+		_, err := Connect(context.Background(), cfg.Addr, defDB, nil)
 		if err != nil {
 			log.Println("Couldnt establish OVSDB connection with Defult params. No big deal")
 		}
 	}()
 
 	go func() {
-		ovs, err := Connect(cfg.Addr, defDB, nil)
+		ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
 		if err != nil {
 			connected <- false
 		} else {
@@ -106,7 +107,7 @@ func TestListDbsIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -141,7 +142,7 @@ func TestGetSchemasIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -169,7 +170,7 @@ func TestInsertTransactIntegration(t *testing.T) {
 	}
 	SetConfig()
 
-	ovs, err := Connect(cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -227,7 +228,7 @@ func TestDeleteTransactIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -272,7 +273,7 @@ func TestMonitorIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -290,7 +291,7 @@ func TestNotifyIntegration(t *testing.T) {
 	}
 	SetConfig()
 
-	ovs, err := Connect(cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -321,7 +322,7 @@ func TestRemoveNotifyIntegration(t *testing.T) {
 	}
 	SetConfig()
 
-	ovs, err := Connect(cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -364,7 +365,7 @@ func TestTableSchemaValidationIntegration(t *testing.T) {
 	}
 	SetConfig()
 
-	ovs, err := Connect(cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -389,7 +390,7 @@ func TestColumnSchemaInRowValidationIntegration(t *testing.T) {
 	}
 	SetConfig()
 
-	ovs, err := Connect(cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -415,7 +416,7 @@ func TestColumnSchemaInMultipleRowsValidationIntegration(t *testing.T) {
 	}
 	SetConfig()
 
-	ovs, err := Connect(cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -447,7 +448,7 @@ func TestColumnSchemaValidationIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -472,7 +473,7 @@ func TestMonitorCancelIntegration(t *testing.T) {
 	}
 	SetConfig()
 
-	ovs, err := Connect(cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -504,7 +505,7 @@ func TestInsertDuplicateTransactIntegration(t *testing.T) {
 	}
 	SetConfig()
 
-	ovs, err := Connect(cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}

--- a/cmd/stress/stress.go
+++ b/cmd/stress/stress.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -45,7 +46,7 @@ var (
 )
 
 func run() {
-	ovs, err := client.Connect(*connection, dbModel, nil)
+	ovs, err := client.Connect(context.Background(), *connection, dbModel, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example/play_with_ovs/play_with_ovs.go
+++ b/example/play_with_ovs/play_with_ovs.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -101,7 +102,7 @@ func main() {
 		log.Fatal("Unable to create DB model ", err)
 	}
 	// By default libovsdb connects to 127.0.0.0:6400.
-	ovs, err := client.Connect(*connection, dbmodel, nil)
+	ovs, err := client.Connect(context.Background(), *connection, dbmodel, nil)
 
 	// If you prefer to connect to OVS in a specific location :
 	// ovs, err := client.Connect("tcp:192.168.56.101:6640", nil)


### PR DESCRIPTION
I am submitting this for now in an attempt to get a discussion going. 

libovsdb does currently not provide an interface for a connection with a specified timeout. Any connection attempted will thus use the default timeout specified by the operating system. Clients using libovsdb could however benefit from being able to specify a timeout, because they implicitly and incorrectly sometimes assume one. For example, go-ovn implicitly and incorrectly assumes that there is a timeout specified, seeing as how it assume that it should be able to retry a failed connection attempt 500 milliseconds later, see: https://github.com/eBay/go-ovn/blob/master/client.go#L360. In the case of go-ovn that will not be the case seeing as how the connection will block for the default timeout set by the operating system. 

The first step is to implement a interface in libovsdb allowing a timeout to be specified, the next would be to have clients modify their usage of that and explicitly set it if they are making assumptions based on it. 

This is a problem which has been seen on clusters using go-ovn / libovsdb, see: https://bugzilla.redhat.com/show_bug.cgi?id=1966280#c2 