### PR TITLE
client: Add options to Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A Open vSwitch Database is modeled using a DBModel which is a created by assigni
 
 Finally, a client object can be created:
 
-    ovs, _ := client.Connect("tcp:172.18.0.4:6641", dbModel, nil)
+    ovs, _ := client.Connect(context.Background(), dbModel, client.WithEndpoint("tcp:172.18.0.4:6641"))
     client.MonitorAll(nil) // Only needed if you want to use the built-in cache
 
 
@@ -238,7 +238,7 @@ In your application, load the DBModel, connect to the server and start interacti
     
     func main() {
         dbModel, _ := generated.FullDatabaseModel()
-        ovs, _ := client.Connect("tcp:localhost:6641", dbModel, nil)
+        ovs, _ := client.Connect(context.Background(), dbModel, client.WithEndpoint("tcp:localhost:6641"))
         ovs.MonitorAll()
 
         // Create a *LogicalRouter, as a pointer to a Model is required by the API

--- a/client/doc.go
+++ b/client/doc.go
@@ -25,7 +25,7 @@ Using it, the libovsdb.client package is able to properly encode and decode OVSD
 and store them in Model instances.
 A client instance is created by simply specifying the connection information and the database model:
 
-     ovs, _ := client.Connect("tcp:172.18.0.4:6641", dbModel, nil)
+     ovs, _ := client.Connect(contect.Background(), dbModel)
 
 Main API
 

--- a/client/options.go
+++ b/client/options.go
@@ -1,0 +1,72 @@
+package client
+
+import (
+	"crypto/tls"
+	"net/url"
+)
+
+const (
+	defaultTCPEndpoint  = "tcp:127.0.0.1:6640"
+	defaultSSLEndpoint  = "ssl:127.0.0.1:6640"
+	defaultUnixEndpoint = "unix:/var/run/openvswitch/ovsdb.sock"
+)
+
+type options struct {
+	endpoints []string
+	tlsConfig *tls.Config
+}
+
+type Option func(o *options) error
+
+func newOptions(opts ...Option) (*options, error) {
+	o := &options{}
+	for _, opt := range opts {
+		if err := opt(o); err != nil {
+			return nil, err
+		}
+	}
+	// if no endpoints are supplied, use the default unix socket
+	if len(o.endpoints) == 0 {
+		o.endpoints = []string{defaultUnixEndpoint}
+	}
+	return o, nil
+}
+
+// WithTLSConfig sets the tls.Config for use by the client
+func WithTLSConfig(cfg *tls.Config) Option {
+	return func(o *options) error {
+		o.tlsConfig = cfg
+		return nil
+	}
+}
+
+// WithEndpoint sets the endpoint to be used by the client
+// It can be used multiple times, and the first endpoint that
+// sucessfully connects will be used:
+func WithEndpoint(endpoint string) Option {
+	return func(o *options) error {
+		ep, err := url.Parse(endpoint)
+		if err != nil {
+			return err
+		}
+		switch ep.Scheme {
+		case UNIX:
+			if len(ep.Path) == 0 {
+				o.endpoints = append(o.endpoints, defaultUnixEndpoint)
+				return nil
+			}
+		case TCP:
+			if len(ep.Opaque) == 0 {
+				o.endpoints = append(o.endpoints, defaultTCPEndpoint)
+				return nil
+			}
+		case SSL:
+			if len(ep.Opaque) == 0 {
+				o.endpoints = append(o.endpoints, defaultSSLEndpoint)
+				return nil
+			}
+		}
+		o.endpoints = append(o.endpoints, endpoint)
+		return nil
+	}
+}

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -1,0 +1,104 @@
+package client
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithTLSConfig(t *testing.T) {
+	config := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+	opts := &options{}
+	fn := WithTLSConfig(config)
+	err := fn(opts)
+	require.Nil(t, err)
+	assert.Equal(t, config, opts.tlsConfig)
+}
+
+func TestNewOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []Option
+		want *options
+	}{
+		{
+			"no endpoints",
+			[]Option{},
+			&options{
+				endpoints: []string{defaultUnixEndpoint},
+			},
+		},
+		{
+			"single endpoints",
+			[]Option{WithEndpoint("ssl:192.168.1.1:6443")},
+			&options{
+				endpoints: []string{"ssl:192.168.1.1:6443"},
+			},
+		},
+		{
+			"multiple endpoints",
+			[]Option{WithEndpoint("ssl:192.168.1.1:6443"), WithEndpoint("ssl:192.168.1.2:6443")},
+			&options{
+				endpoints: []string{"ssl:192.168.1.1:6443", "ssl:192.168.1.2:6443"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newOptions(tt.opts...)
+			require.Nil(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestWithEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		want     []string
+		wantErr  bool
+	}{
+		{
+			"default unix",
+			"unix:",
+			[]string{defaultUnixEndpoint},
+			false,
+		},
+		{
+			"default tcp",
+			"tcp:",
+			[]string{defaultTCPEndpoint},
+			false,
+		},
+		{
+			"default ssl",
+			"ssl:",
+			[]string{defaultSSLEndpoint},
+			false,
+		},
+		{
+			"invalid",
+			"foo : ",
+			nil,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &options{}
+			fn := WithEndpoint(tt.endpoint)
+			err := fn(opts)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.Nil(t, err)
+			}
+			assert.Equal(t, tt.want, opts.endpoints)
+		})
+	}
+}

--- a/client/ovs_integration_test.go
+++ b/client/ovs_integration_test.go
@@ -72,14 +72,14 @@ func TestConnectIntegration(t *testing.T) {
 	go func() {
 		// Use Convenience params. Ignore failure even if any
 
-		_, err := Connect(context.Background(), cfg.Addr, defDB, nil)
+		_, err := Connect(context.Background(), defDB, WithEndpoint(cfg.Addr))
 		if err != nil {
 			log.Println("Couldnt establish OVSDB connection with Defult params. No big deal")
 		}
 	}()
 
 	go func() {
-		ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
+		ovs, err := Connect(context.Background(), defDB, WithEndpoint(cfg.Addr))
 		if err != nil {
 			connected <- false
 		} else {
@@ -107,7 +107,7 @@ func TestListDbsIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), defDB, WithEndpoint(cfg.Addr))
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -142,7 +142,7 @@ func TestGetSchemasIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), defDB, WithEndpoint(cfg.Addr))
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -170,7 +170,7 @@ func TestInsertTransactIntegration(t *testing.T) {
 	}
 	SetConfig()
 
-	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), defDB, WithEndpoint(cfg.Addr))
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -228,7 +228,7 @@ func TestDeleteTransactIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), defDB, WithEndpoint(cfg.Addr))
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -273,7 +273,7 @@ func TestMonitorIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), defDB, WithEndpoint(cfg.Addr))
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -291,7 +291,7 @@ func TestNotifyIntegration(t *testing.T) {
 	}
 	SetConfig()
 
-	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), defDB, WithEndpoint(cfg.Addr))
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -322,7 +322,7 @@ func TestRemoveNotifyIntegration(t *testing.T) {
 	}
 	SetConfig()
 
-	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), defDB, WithEndpoint(cfg.Addr))
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -365,7 +365,7 @@ func TestTableSchemaValidationIntegration(t *testing.T) {
 	}
 	SetConfig()
 
-	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), defDB, WithEndpoint(cfg.Addr))
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -390,7 +390,7 @@ func TestColumnSchemaInRowValidationIntegration(t *testing.T) {
 	}
 	SetConfig()
 
-	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), defDB, WithEndpoint(cfg.Addr))
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -416,7 +416,7 @@ func TestColumnSchemaInMultipleRowsValidationIntegration(t *testing.T) {
 	}
 	SetConfig()
 
-	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), defDB, WithEndpoint(cfg.Addr))
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -448,7 +448,7 @@ func TestColumnSchemaValidationIntegration(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), defDB, WithEndpoint(cfg.Addr))
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -473,7 +473,7 @@ func TestMonitorCancelIntegration(t *testing.T) {
 	}
 	SetConfig()
 
-	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), defDB, WithEndpoint(cfg.Addr))
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -505,7 +505,7 @@ func TestInsertDuplicateTransactIntegration(t *testing.T) {
 	}
 	SetConfig()
 
-	ovs, err := Connect(context.Background(), cfg.Addr, defDB, nil)
+	ovs, err := Connect(context.Background(), defDB, WithEndpoint(cfg.Addr))
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}

--- a/cmd/stress/stress.go
+++ b/cmd/stress/stress.go
@@ -54,7 +54,7 @@ type result struct {
 }
 
 func cleanup(ctx context.Context) {
-	ovs, err := client.Connect(context.Background(), *connection, dbModel, nil)
+	ovs, err := client.Connect(context.Background(), dbModel, client.WithEndpoint(*connection))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -92,7 +92,7 @@ func run(ctx context.Context, resultsChan chan result, wg *sync.WaitGroup) {
 	ready := false
 	var rootUUID string
 
-	ovs, err := client.Connect(context.Background(), *connection, dbModel, nil)
+	ovs, err := client.Connect(context.Background(), dbModel, client.WithEndpoint(*connection))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example/play_with_ovs/play_with_ovs.go
+++ b/example/play_with_ovs/play_with_ovs.go
@@ -101,12 +101,8 @@ func main() {
 	if err != nil {
 		log.Fatal("Unable to create DB model ", err)
 	}
-	// By default libovsdb connects to 127.0.0.0:6400.
-	ovs, err := client.Connect(context.Background(), *connection, dbmodel, nil)
 
-	// If you prefer to connect to OVS in a specific location :
-	// ovs, err := client.Connect("tcp:192.168.56.101:6640", nil)
-
+	ovs, err := client.Connect(context.Background(), dbmodel, client.WithEndpoint(*connection))
 	if err != nil {
 		log.Fatal("Unable to Connect ", err)
 	}

--- a/server/server_integration_test.go
+++ b/server/server_integration_test.go
@@ -82,7 +82,7 @@ func TestClientServerEcho(t *testing.T) {
 		return server.Ready()
 	}, 1*time.Second, 10*time.Millisecond)
 
-	ovs, err := client.Connect(context.Background(), fmt.Sprintf("unix:%s", tmpfile), defDB, nil)
+	ovs, err := client.Connect(context.Background(), defDB, client.WithEndpoint(fmt.Sprintf("unix:%s", tmpfile)))
 	require.Nil(t, err)
 
 	err = ovs.Echo()
@@ -118,7 +118,7 @@ func TestClientServerInsert(t *testing.T) {
 		return server.Ready()
 	}, 1*time.Second, 10*time.Millisecond)
 
-	ovs, err := client.Connect(context.Background(), fmt.Sprintf("unix:%s", tmpfile), defDB, nil)
+	ovs, err := client.Connect(context.Background(), defDB, client.WithEndpoint(fmt.Sprintf("unix:%s", tmpfile)))
 	require.Nil(t, err)
 
 	bridgeRow := &bridgeType{
@@ -167,7 +167,7 @@ func TestClientServerMonitor(t *testing.T) {
 		return server.Ready()
 	}, 1*time.Second, 10*time.Millisecond)
 
-	ovs, err := client.Connect(context.Background(), fmt.Sprintf("unix:%s", tmpfile), defDB, nil)
+	ovs, err := client.Connect(context.Background(), defDB, client.WithEndpoint(fmt.Sprintf("unix:%s", tmpfile)))
 	require.Nil(t, err)
 
 	ovsRow := &ovsType{
@@ -289,7 +289,7 @@ func TestClientServerInsertAndDelete(t *testing.T) {
 		return server.Ready()
 	}, 1*time.Second, 10*time.Millisecond)
 
-	ovs, err := client.Connect(context.Background(), fmt.Sprintf("unix:%s", tmpfile), defDB, nil)
+	ovs, err := client.Connect(context.Background(), defDB, client.WithEndpoint(fmt.Sprintf("unix:%s", tmpfile)))
 	require.Nil(t, err)
 
 	bridgeRow := &bridgeType{


### PR DESCRIPTION
This commit changes the Connect API to accept options.
Initially only WithTLSConfig but this can be easily expanded to include
more options in future without the API needing to change significantly.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>