### PR TITLE
Add Stronger Types for Enums and Improve Set Encoding

### DIFF
--- a/client/api_test_model.go
+++ b/client/api_test_model.go
@@ -131,21 +131,21 @@ func (*testLogicalSwitch) Table() string {
 //LogicalSwitchPort struct defines an object in Logical_Switch_Port table
 type testLogicalSwitchPort struct {
 	UUID             string            `ovsdb:"_uuid"`
-	Up               []bool            `ovsdb:"up"`
-	Dhcpv4Options    []string          `ovsdb:"dhcpv4_options"`
+	Up               *bool             `ovsdb:"up"`
+	Dhcpv4Options    *string           `ovsdb:"dhcpv4_options"`
 	Name             string            `ovsdb:"name"`
-	DynamicAddresses []string          `ovsdb:"dynamic_addresses"`
-	HaChassisGroup   []string          `ovsdb:"ha_chassis_group"`
+	DynamicAddresses *string           `ovsdb:"dynamic_addresses"`
+	HaChassisGroup   *string           `ovsdb:"ha_chassis_group"`
 	Options          map[string]string `ovsdb:"options"`
-	Enabled          []bool            `ovsdb:"enabled"`
+	Enabled          *bool             `ovsdb:"enabled"`
 	Addresses        []string          `ovsdb:"addresses"`
-	Dhcpv6Options    []string          `ovsdb:"dhcpv6_options"`
-	TagRequest       []int             `ovsdb:"tag_request"`
-	Tag              []int             `ovsdb:"tag"`
+	Dhcpv6Options    *string           `ovsdb:"dhcpv6_options"`
+	TagRequest       *int              `ovsdb:"tag_request"`
+	Tag              *int              `ovsdb:"tag"`
 	PortSecurity     []string          `ovsdb:"port_security"`
 	ExternalIds      map[string]string `ovsdb:"external_ids"`
 	Type             string            `ovsdb:"type"`
-	ParentName       []string          `ovsdb:"parent_name"`
+	ParentName       *string           `ovsdb:"parent_name"`
 }
 
 // Table returns the table name. It's part of the Model interface

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -40,26 +40,26 @@ const (
 // Bridge defines an object in Bridge table
 type Bridge struct {
 	UUID                string            `ovsdb:"_uuid"`
-	AutoAttach          []string          `ovsdb:"auto_attach"`
+	AutoAttach          *string           `ovsdb:"auto_attach"`
 	Controller          []string          `ovsdb:"controller"`
-	DatapathID          []string          `ovsdb:"datapath_id"`
+	DatapathID          *string           `ovsdb:"datapath_id"`
 	DatapathType        string            `ovsdb:"datapath_type"`
 	DatapathVersion     string            `ovsdb:"datapath_version"`
 	ExternalIDs         map[string]string `ovsdb:"external_ids"`
-	FailMode            []BridgeFailMode  `ovsdb:"fail_mode"`
-	FloodVLANs          []int             `ovsdb:"flood_vlans"`
+	FailMode            *BridgeFailMode   `ovsdb:"fail_mode"`
+	FloodVLANs          [4096]int         `ovsdb:"flood_vlans"`
 	FlowTables          map[int]string    `ovsdb:"flow_tables"`
-	IPFIX               []string          `ovsdb:"ipfix"`
+	IPFIX               *string           `ovsdb:"ipfix"`
 	McastSnoopingEnable bool              `ovsdb:"mcast_snooping_enable"`
 	Mirrors             []string          `ovsdb:"mirrors"`
 	Name                string            `ovsdb:"name"`
-	Netflow             []string          `ovsdb:"netflow"`
+	Netflow             *string           `ovsdb:"netflow"`
 	OtherConfig         map[string]string `ovsdb:"other_config"`
 	Ports               []string          `ovsdb:"ports"`
 	Protocols           []BridgeProtocols `ovsdb:"protocols"`
 	RSTPEnable          bool              `ovsdb:"rstp_enable"`
 	RSTPStatus          map[string]string `ovsdb:"rstp_status"`
-	Sflow               []string          `ovsdb:"sflow"`
+	Sflow               *string           `ovsdb:"sflow"`
 	Status              map[string]string `ovsdb:"status"`
 	STPEnable           bool              `ovsdb:"stp_enable"`
 }
@@ -71,19 +71,19 @@ type OpenvSwitch struct {
 	CurCfg          int               `ovsdb:"cur_cfg"`
 	DatapathTypes   []string          `ovsdb:"datapath_types"`
 	Datapaths       map[string]string `ovsdb:"datapaths"`
-	DbVersion       []string          `ovsdb:"db_version"`
+	DbVersion       *string           `ovsdb:"db_version"`
 	DpdkInitialized bool              `ovsdb:"dpdk_initialized"`
-	DpdkVersion     []string          `ovsdb:"dpdk_version"`
+	DpdkVersion     *string           `ovsdb:"dpdk_version"`
 	ExternalIDs     map[string]string `ovsdb:"external_ids"`
 	IfaceTypes      []string          `ovsdb:"iface_types"`
 	ManagerOptions  []string          `ovsdb:"manager_options"`
 	NextCfg         int               `ovsdb:"next_cfg"`
 	OtherConfig     map[string]string `ovsdb:"other_config"`
-	OVSVersion      []string          `ovsdb:"ovs_version"`
-	SSL             []string          `ovsdb:"ssl"`
+	OVSVersion      *string           `ovsdb:"ovs_version"`
+	SSL             *string           `ovsdb:"ssl"`
 	Statistics      map[string]string `ovsdb:"statistics"`
-	SystemType      []string          `ovsdb:"system_type"`
-	SystemVersion   []string          `ovsdb:"system_version"`
+	SystemType      *string           `ovsdb:"system_type"`
+	SystemVersion   *string           `ovsdb:"system_version"`
 }
 
 var defDB, _ = model.NewDBModel("Open_vSwitch",

--- a/client/condition_test.go
+++ b/client/condition_test.go
@@ -16,25 +16,25 @@ func TestEqualityConditional(t *testing.T) {
 			UUID:        aUUID0,
 			Name:        "lsp0",
 			ExternalIds: map[string]string{"foo": "bar"},
-			Enabled:     []bool{true},
+			Enabled:     &trueVal,
 		},
 		&testLogicalSwitchPort{
 			UUID:        aUUID1,
 			Name:        "lsp1",
 			ExternalIds: map[string]string{"foo": "baz"},
-			Enabled:     []bool{false},
+			Enabled:     &falseVal,
 		},
 		&testLogicalSwitchPort{
 			UUID:        aUUID2,
 			Name:        "lsp2",
 			ExternalIds: map[string]string{"unique": "id"},
-			Enabled:     []bool{false},
+			Enabled:     &falseVal,
 		},
 		&testLogicalSwitchPort{
 			UUID:        aUUID3,
 			Name:        "lsp3",
 			ExternalIds: map[string]string{"foo": "baz"},
-			Enabled:     []bool{true},
+			Enabled:     &trueVal,
 		},
 	}
 	lspcache := map[string]model.Model{}
@@ -156,25 +156,25 @@ func TestPredicateConditional(t *testing.T) {
 			UUID:        aUUID0,
 			Name:        "lsp0",
 			ExternalIds: map[string]string{"foo": "bar"},
-			Enabled:     []bool{true},
+			Enabled:     &trueVal,
 		},
 		&testLogicalSwitchPort{
 			UUID:        aUUID1,
 			Name:        "lsp1",
 			ExternalIds: map[string]string{"foo": "baz"},
-			Enabled:     []bool{false},
+			Enabled:     &falseVal,
 		},
 		&testLogicalSwitchPort{
 			UUID:        aUUID2,
 			Name:        "lsp2",
 			ExternalIds: map[string]string{"unique": "id"},
-			Enabled:     []bool{false},
+			Enabled:     &falseVal,
 		},
 		&testLogicalSwitchPort{
 			UUID:        aUUID3,
 			Name:        "lsp3",
 			ExternalIds: map[string]string{"foo": "baz"},
-			Enabled:     []bool{true},
+			Enabled:     &trueVal,
 		},
 	}
 	lspcache := map[string]model.Model{}
@@ -214,7 +214,7 @@ func TestPredicateConditional(t *testing.T) {
 		{
 			name: "by random field",
 			predicate: func(lsp *testLogicalSwitchPort) bool {
-				return lsp.Enabled[0] == false
+				return lsp.Enabled != nil && *lsp.Enabled == false
 			},
 			condition: [][]ovsdb.Condition{
 				{
@@ -230,8 +230,8 @@ func TestPredicateConditional(t *testing.T) {
 						Value:    ovsdb.UUID{GoUUID: aUUID2},
 					}}},
 			matches: map[model.Model]bool{
-				&testLogicalSwitchPort{UUID: aUUID1, Enabled: []bool{true}}:  false,
-				&testLogicalSwitchPort{UUID: aUUID1, Enabled: []bool{false}}: true,
+				&testLogicalSwitchPort{UUID: aUUID1, Enabled: &trueVal}:  false,
+				&testLogicalSwitchPort{UUID: aUUID1, Enabled: &falseVal}: true,
 			},
 		},
 	}
@@ -265,25 +265,25 @@ func TestExplicitConditional(t *testing.T) {
 			UUID:        aUUID0,
 			Name:        "lsp0",
 			ExternalIds: map[string]string{"foo": "bar"},
-			Enabled:     []bool{true},
+			Enabled:     &trueVal,
 		},
 		&testLogicalSwitchPort{
 			UUID:        aUUID1,
 			Name:        "lsp1",
 			ExternalIds: map[string]string{"foo": "baz"},
-			Enabled:     []bool{false},
+			Enabled:     &falseVal,
 		},
 		&testLogicalSwitchPort{
 			UUID:        aUUID2,
 			Name:        "lsp2",
 			ExternalIds: map[string]string{"unique": "id"},
-			Enabled:     []bool{false},
+			Enabled:     &falseVal,
 		},
 		&testLogicalSwitchPort{
 			UUID:        aUUID3,
 			Name:        "lsp3",
 			ExternalIds: map[string]string{"foo": "baz"},
-			Enabled:     []bool{true},
+			Enabled:     &trueVal,
 		},
 	}
 	lspcache := map[string]model.Model{}
@@ -362,7 +362,7 @@ func TestExplicitConditional(t *testing.T) {
 				{
 					Field:    &testObj.Enabled,
 					Function: ovsdb.ConditionEqual,
-					Value:    []bool{true},
+					Value:    &trueVal,
 				},
 			},
 			result: [][]ovsdb.Condition{
@@ -370,7 +370,7 @@ func TestExplicitConditional(t *testing.T) {
 					{
 						Column:   "enabled",
 						Function: ovsdb.ConditionEqual,
-						Value:    testOvsSet(t, []bool{true}),
+						Value:    testOvsSet(t, &trueVal),
 					}}},
 		},
 		{
@@ -379,7 +379,7 @@ func TestExplicitConditional(t *testing.T) {
 				{
 					Field:    &testObj.Enabled,
 					Function: ovsdb.ConditionEqual,
-					Value:    []bool{true},
+					Value:    &trueVal,
 				},
 				{
 					Field:    &testObj.Name,
@@ -392,7 +392,7 @@ func TestExplicitConditional(t *testing.T) {
 					{
 						Column:   "enabled",
 						Function: ovsdb.ConditionEqual,
-						Value:    testOvsSet(t, []bool{true}),
+						Value:    testOvsSet(t, &trueVal),
 					}},
 				{
 					{
@@ -407,7 +407,7 @@ func TestExplicitConditional(t *testing.T) {
 				{
 					Field:    &testObj.Enabled,
 					Function: ovsdb.ConditionEqual,
-					Value:    []bool{true},
+					Value:    &trueVal,
 				},
 				{
 					Field:    &testObj.Name,
@@ -419,7 +419,7 @@ func TestExplicitConditional(t *testing.T) {
 				{
 					Column:   "enabled",
 					Function: ovsdb.ConditionEqual,
-					Value:    testOvsSet(t, []bool{true}),
+					Value:    testOvsSet(t, &trueVal),
 				},
 				{
 					Column:   "name",

--- a/mapper/info_test.go
+++ b/mapper/info_test.go
@@ -10,25 +10,57 @@ import (
 )
 
 var sampleTable = []byte(`{
-      "columns": {
+    "columns": {
         "aString": {
-          "type": "string"
+            "type": "string"
         },
         "aInteger": {
-          "type": "integer"
+            "type": "integer"
         },
         "aSet": {
-          "type": {
-            "key": "string",
-            "max": "unlimited",
-            "min": 0
-          }
+            "type": {
+                "key": "string",
+                "max": "unlimited",
+                "min": 0
+            }
         },
         "aMap": {
-          "type": {
-            "key": "string",
-            "value": "string"
-          }
+            "type": {
+                "key": "string",
+                "value": "string"
+            }
+        },
+        "aEnum": {
+            "type": {
+                "key": {
+                    "enum": [
+                        "set",
+                        [
+                            "enum1",
+                            "enum2",
+                            "enum3"
+                        ]
+                    ],
+                    "type": "string"
+                }
+            }
+        },
+        "aEnumSet": {
+            "type": {
+                "key": {
+                    "enum": [
+                        "set",
+                        [
+                            "enum1",
+                            "enum2",
+                            "enum3"
+                        ]
+                    ],
+                    "type": "string"
+                },
+                "max": "unlimited",
+                "min": 0
+            }
         }
     }
 }`)
@@ -73,11 +105,19 @@ func TestNewMapperInfo(t *testing.T) {
 }
 
 func TestMapperInfoSet(t *testing.T) {
+	type enum string
+	const (
+		enum1 enum = "one"
+		enum2 enum = "two"
+		enum3 enum = "three"
+	)
 	type obj struct {
-		Ostring string            `ovsdb:"aString"`
-		Oint    int               `ovsdb:"aInteger"`
-		Oset    []string          `ovsdb:"aSet"`
-		Omap    map[string]string `ovsdb:"aMap"`
+		Ostring  string            `ovsdb:"aString"`
+		Oint     int               `ovsdb:"aInteger"`
+		Oset     []string          `ovsdb:"aSet"`
+		Omap     map[string]string `ovsdb:"aMap"`
+		Oenum    enum              `ovsdb:"aEnum"`
+		OenumSet []enum            `ovsdb:"aEnumSet"`
 	}
 
 	type test struct {
@@ -127,12 +167,28 @@ func TestMapperInfoSet(t *testing.T) {
 			err:    false,
 		},
 		{
-			name:   "un-assignable",
+			name:   "unassignable",
 			table:  sampleTable,
 			obj:    &obj{},
 			field:  []string{"foo"},
 			column: "aMap",
 			err:    true,
+		},
+		{
+			name:   "enum",
+			table:  sampleTable,
+			obj:    &obj{},
+			field:  enum1,
+			column: "aEnum",
+			err:    false,
+		},
+		{
+			name:   "enumSet",
+			table:  sampleTable,
+			obj:    &obj{},
+			field:  []enum{enum2, enum3},
+			column: "aEnumSet",
+			err:    false,
 		},
 	}
 	for _, tt := range tests {

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -33,7 +33,7 @@ var (
 	}
 	aFloat = 42.00
 
-	aFloatSet = []float64{
+	aFloatSet = [10]float64{
 		3.0,
 		2.0,
 		42.0,
@@ -77,7 +77,8 @@ var testSchema = []byte(`{
               "refType": "weak",
               "type": "uuid"
             },
-            "min": 0
+            "min": 0,
+			"max": "unlimited"
           }
         },
         "aUUID": {
@@ -187,12 +188,12 @@ func TestMapperGetData(t *testing.T) {
 	type ormTestType struct {
 		AString             string            `ovsdb:"aString"`
 		ASet                []string          `ovsdb:"aSet"`
-		ASingleSet          []string          `ovsdb:"aSingleSet"`
+		ASingleSet          *string           `ovsdb:"aSingleSet"`
 		AUUIDSet            []string          `ovsdb:"aUUIDSet"`
 		AUUID               string            `ovsdb:"aUUID"`
 		AIntSet             []int             `ovsdb:"aIntSet"`
 		AFloat              float64           `ovsdb:"aFloat"`
-		AFloatSet           []float64         `ovsdb:"aFloatSet"`
+		AFloatSet           [10]float64       `ovsdb:"aFloatSet"`
 		YetAnotherStringSet []string          `ovsdb:"aEmptySet"`
 		AEnum               string            `ovsdb:"aEnum"`
 		AMap                map[string]string `ovsdb:"aMap"`
@@ -202,7 +203,7 @@ func TestMapperGetData(t *testing.T) {
 	var expected = ormTestType{
 		AString:             aString,
 		ASet:                aSet,
-		ASingleSet:          []string{aString},
+		ASingleSet:          &aString,
 		AUUIDSet:            aUUIDSet,
 		AUUID:               aUUID0,
 		AIntSet:             aIntSet,
@@ -304,7 +305,7 @@ func TestMapperNewRow(t *testing.T) {
 	}, {
 		name: "aFloatSet",
 		objInput: &struct {
-			MyFloatSet []float64 `ovsdb:"aFloatSet"`
+			MyFloatSet [10]float64 `ovsdb:"aFloatSet"`
 		}{
 			MyFloatSet: aFloatSet,
 		},
@@ -880,7 +881,8 @@ func TestMapperMutation(t *testing.T) {
         "set": {
           "type": {
             "key": "string",
-            "min": 0
+            "min": 0,
+			"max": "unlimited"
           }
         },
         "map": {

--- a/modelgen/table.go
+++ b/modelgen/table.go
@@ -51,7 +51,7 @@ func NewTableTemplate() *template.Template {
 {{ if index . "Enums" }}
 type (
 {{ range index . "Enums" }}
-{{ .Alias }} = {{ .Type }}
+{{ .Alias }} {{ .Type }}
 {{- end }}
 )
 

--- a/modelgen/table_test.go
+++ b/modelgen/table_test.go
@@ -58,7 +58,7 @@ type (
 	AtomicTableProtocol  string
 )
 
-const (
+var (
 	AtomicTableEventTypeEmptyLbBackends AtomicTableEventType = "empty_lb_backends"
 	AtomicTableProtocolTCP              AtomicTableProtocol  = "tcp"
 	AtomicTableProtocolUDP              AtomicTableProtocol  = "udp"
@@ -67,12 +67,12 @@ const (
 
 // AtomicTable defines an object in atomicTable table
 type AtomicTable struct {
-	UUID      string                ` + "`" + `ovsdb:"_uuid"` + "`" + `
-	EventType AtomicTableEventType  ` + "`" + `ovsdb:"event_type"` + "`" + `
-	Float     float64               ` + "`" + `ovsdb:"float"` + "`" + `
-	Int       int                   ` + "`" + `ovsdb:"int"` + "`" + `
-	Protocol  []AtomicTableProtocol ` + "`" + `ovsdb:"protocol"` + "`" + `
-	Str       string                ` + "`" + `ovsdb:"str"` + "`" + `
+	UUID      string               ` + "`" + `ovsdb:"_uuid"` + "`" + `
+	EventType AtomicTableEventType ` + "`" + `ovsdb:"event_type"` + "`" + `
+	Float     float64              ` + "`" + `ovsdb:"float"` + "`" + `
+	Int       int                  ` + "`" + `ovsdb:"int"` + "`" + `
+	Protocol  *AtomicTableProtocol ` + "`" + `ovsdb:"protocol"` + "`" + `
+	Str       string               ` + "`" + `ovsdb:"str"` + "`" + `
 }
 `,
 		},
@@ -88,12 +88,12 @@ package test
 
 // AtomicTable defines an object in atomicTable table
 type AtomicTable struct {
-	UUID      string   ` + "`" + `ovsdb:"_uuid"` + "`" + `
-	EventType string   ` + "`" + `ovsdb:"event_type"` + "`" + `
-	Float     float64  ` + "`" + `ovsdb:"float"` + "`" + `
-	Int       int      ` + "`" + `ovsdb:"int"` + "`" + `
-	Protocol  []string ` + "`" + `ovsdb:"protocol"` + "`" + `
-	Str       string   ` + "`" + `ovsdb:"str"` + "`" + `
+	UUID      string  ` + "`" + `ovsdb:"_uuid"` + "`" + `
+	EventType string  ` + "`" + `ovsdb:"event_type"` + "`" + `
+	Float     float64 ` + "`" + `ovsdb:"float"` + "`" + `
+	Int       int     ` + "`" + `ovsdb:"int"` + "`" + `
+	Protocol  *string ` + "`" + `ovsdb:"protocol"` + "`" + `
+	Str       string  ` + "`" + `ovsdb:"str"` + "`" + `
 }
 `,
 		},
@@ -118,7 +118,7 @@ type (
 	AtomicTableProtocol  string
 )
 
-const (
+var (
 	AtomicTableEventTypeEmptyLbBackends AtomicTableEventType = "empty_lb_backends"
 	AtomicTableProtocolTCP              AtomicTableProtocol  = "tcp"
 	AtomicTableProtocolUDP              AtomicTableProtocol  = "udp"
@@ -127,18 +127,18 @@ const (
 
 // AtomicTable defines an object in atomicTable table
 type AtomicTable struct {
-	UUID      string                ` + "`" + `ovsdb:"_uuid"` + "`" + `
-	EventType AtomicTableEventType  ` + "`" + `ovsdb:"event_type"` + "`" + `
-	Float     float64               ` + "`" + `ovsdb:"float"` + "`" + `
-	Int       int                   ` + "`" + `ovsdb:"int"` + "`" + `
-	Protocol  []AtomicTableProtocol ` + "`" + `ovsdb:"protocol"` + "`" + `
-	Str       string                ` + "`" + `ovsdb:"str"` + "`" + `
+	UUID      string               ` + "`" + `ovsdb:"_uuid"` + "`" + `
+	EventType AtomicTableEventType ` + "`" + `ovsdb:"event_type"` + "`" + `
+	Float     float64              ` + "`" + `ovsdb:"float"` + "`" + `
+	Int       int                  ` + "`" + `ovsdb:"int"` + "`" + `
+	Protocol  *AtomicTableProtocol ` + "`" + `ovsdb:"protocol"` + "`" + `
+	Str       string               ` + "`" + `ovsdb:"str"` + "`" + `
 
 	OtherUUID      string
 	OtherEventType string
 	OtherFloat     float64
 	OtherInt       int
-	OtherProtocol  []string
+	OtherProtocol  *string
 	OtherStr       string
 }
 `,
@@ -167,7 +167,7 @@ type (
 	AtomicTableProtocol  string
 )
 
-const (
+var (
 	AtomicTableEventTypeEmptyLbBackends AtomicTableEventType = "empty_lb_backends"
 	AtomicTableProtocolTCP              AtomicTableProtocol  = "tcp"
 	AtomicTableProtocolUDP              AtomicTableProtocol  = "udp"
@@ -176,12 +176,12 @@ const (
 
 // AtomicTable defines an object in atomicTable table
 type AtomicTable struct {
-	UUID      string                ` + "`" + `ovsdb:"_uuid"` + "`" + `
-	EventType AtomicTableEventType  ` + "`" + `ovsdb:"event_type"` + "`" + `
-	Float     float64               ` + "`" + `ovsdb:"float"` + "`" + `
-	Int       int                   ` + "`" + `ovsdb:"int"` + "`" + `
-	Protocol  []AtomicTableProtocol ` + "`" + `ovsdb:"protocol"` + "`" + `
-	Str       string                ` + "`" + `ovsdb:"str"` + "`" + `
+	UUID      string               ` + "`" + `ovsdb:"_uuid"` + "`" + `
+	EventType AtomicTableEventType ` + "`" + `ovsdb:"event_type"` + "`" + `
+	Float     float64              ` + "`" + `ovsdb:"float"` + "`" + `
+	Int       int                  ` + "`" + `ovsdb:"int"` + "`" + `
+	Protocol  *AtomicTableProtocol ` + "`" + `ovsdb:"protocol"` + "`" + `
+	Str       string               ` + "`" + `ovsdb:"str"` + "`" + `
 }
 
 func TestFunc() string {

--- a/modelgen/table_test.go
+++ b/modelgen/table_test.go
@@ -54,8 +54,8 @@ func TestNewTableTemplate(t *testing.T) {
 package test
 
 type (
-	AtomicTableEventType = string
-	AtomicTableProtocol  = string
+	AtomicTableEventType string
+	AtomicTableProtocol  string
 )
 
 const (
@@ -114,8 +114,8 @@ type AtomicTable struct {
 package test
 
 type (
-	AtomicTableEventType = string
-	AtomicTableProtocol  = string
+	AtomicTableEventType string
+	AtomicTableProtocol  string
 )
 
 const (
@@ -163,8 +163,8 @@ func {{ index . "TestName" }} () string {
 package test
 
 type (
-	AtomicTableEventType = string
-	AtomicTableProtocol  = string
+	AtomicTableEventType string
+	AtomicTableProtocol  string
 )
 
 const (

--- a/ovsdb/notation_test.go
+++ b/ovsdb/notation_test.go
@@ -86,11 +86,10 @@ func TestValidateOvsSet(t *testing.T) {
 		t.Error("Expected: ", expected, "Got", string(data))
 	}
 	// Negative condition test
-	integer := 5
-	_, err = NewOvsSet(&integer)
+	oSet, err = NewOvsSet(struct{ foo string }{})
 	if err == nil {
 		t.Error("OvsSet must fail for anything other than Slices and atomic types")
-		t.Error("Expected: ", expected, "Got", string(data))
+		t.Error("Got", oSet)
 	}
 }
 

--- a/test/ovs/ovs_integration_test.go
+++ b/test/ovs/ovs_integration_test.go
@@ -55,8 +55,8 @@ func (suite *OVSIntegrationSuite) SetupSuite() {
 	suite.resource, err = suite.pool.RunWithOptions(options, hostConfig)
 	require.NoError(suite.T(), err)
 
-	// set expiry to 30 seconds so containers are cleaned up on test panic
-	err = suite.resource.Expire(30)
+	// set expiry to 60 seconds so containers are cleaned up on test panic
+	err = suite.resource.Expire(60)
 	require.NoError(suite.T(), err)
 
 	// let the container start before we attempt connection
@@ -104,14 +104,22 @@ func TestOVSIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(OVSIntegrationSuite))
 }
 
+type BridgeFailMode string
+
+var (
+	BridgeFailModeStandalone BridgeFailMode = "standalone"
+	BridgeFailModeSecure     BridgeFailMode = "secure"
+)
+
 // bridgeType is the simplified ORM model of the Bridge table
 type bridgeType struct {
-	UUID        string            `ovsdb:"_uuid"`
-	Name        string            `ovsdb:"name"`
-	OtherConfig map[string]string `ovsdb:"other_config"`
-	ExternalIds map[string]string `ovsdb:"external_ids"`
-	Ports       []string          `ovsdb:"ports"`
-	Status      map[string]string `ovsdb:"status"`
+	UUID           string            `ovsdb:"_uuid"`
+	Name           string            `ovsdb:"name"`
+	OtherConfig    map[string]string `ovsdb:"other_config"`
+	ExternalIds    map[string]string `ovsdb:"external_ids"`
+	Ports          []string          `ovsdb:"ports"`
+	Status         map[string]string `ovsdb:"status"`
+	BridgeFailMode *BridgeFailMode   `ovsdb:"fail_mode"`
 }
 
 // ovsType is the simplified ORM model of the Bridge table


### PR DESCRIPTION
This PR:

- Adds stronger typing for Enums
- Encodes sets with min 0, max 1 as pointers
- Encodes sets where max is not limited an array
- Updates Modelgen

These changes are together, as it was an optional (min 0, max 1) enum that prompted this discussion in the first place.

In the generated code, enum constants can no lionger be constant, but must instead be `var` because we can't take a `const string` by address for use in structs with `*string` fields (or `* AnEnumType` fields).

Closes: #154
Closes: #191