### PR TITLE
Model-based Monitor API

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -304,6 +304,9 @@ func (a api) Mutate(model model.Model, mutationObjs ...model.Mutation) ([]ovsdb.
 	}
 
 	tableName := a.cache.DBModel().FindTable(reflect.ValueOf(model).Type())
+	if tableName == "" {
+		return nil, fmt.Errorf("table not found for object")
+	}
 	table := a.cache.Mapper().Schema.Table(tableName)
 	if table == nil {
 		return nil, fmt.Errorf("schema error: table not found in Database Model for type %s", reflect.TypeOf(model))

--- a/client/ovs_integration_test.go
+++ b/client/ovs_integration_test.go
@@ -486,7 +486,10 @@ func TestMonitorCancelIntegration(t *testing.T) {
 		Select:  ovsdb.NewDefaultMonitorSelect(),
 	}
 
-	err = ovs.Monitor(monitorID, requests)
+	err = ovs.Monitor(monitorID,
+		ovs.NewTableMonitor(&ovsType{}),
+		ovs.NewTableMonitor(&bridgeType{}),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/example/play_with_ovs/play_with_ovs.go
+++ b/example/play_with_ovs/play_with_ovs.go
@@ -114,8 +114,10 @@ func main() {
 			}
 		},
 	})
-
-	err = ovs.MonitorAll("")
+	err = ovs.Monitor("play_with_ovs",
+		ovs.NewTableMonitor(&OpenvSwitch{}),
+		ovs.NewTableMonitor(&Bridge{}),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/mapper/info.go
+++ b/mapper/info.go
@@ -47,11 +47,11 @@ func (i *Info) SetField(column string, value interface{}) error {
 	return nil
 }
 
-// ColumnByPtr returns the column name that corresponds to the field by the field's pminter
+// ColumnByPtr returns the column name that corresponds to the field by the field's pointer
 func (i *Info) ColumnByPtr(fieldPtr interface{}) (string, error) {
 	fieldPtrVal := reflect.ValueOf(fieldPtr)
 	if fieldPtrVal.Kind() != reflect.Ptr {
-		return "", ovsdb.NewErrWrongType("ColumnByPminter", "pminter to a field in the struct", fieldPtr)
+		return "", ovsdb.NewErrWrongType("ColumnByPointer", "pointer to a field in the struct", fieldPtr)
 	}
 	offset := fieldPtrVal.Pointer() - reflect.ValueOf(i.obj).Pointer()
 	objType := reflect.TypeOf(i.obj).Elem()
@@ -64,7 +64,7 @@ func (i *Info) ColumnByPtr(fieldPtr interface{}) (string, error) {
 			return column, nil
 		}
 	}
-	return "", fmt.Errorf("field pminter does not correspond to orm struct")
+	return "", fmt.Errorf("field pointer does not correspond to orm struct")
 }
 
 // getValidIndexes inspects the object and returns the a list of indexes (set of columns) for witch
@@ -104,11 +104,11 @@ OUTER:
 func NewInfo(table *ovsdb.TableSchema, obj interface{}) (*Info, error) {
 	objPtrVal := reflect.ValueOf(obj)
 	if objPtrVal.Type().Kind() != reflect.Ptr {
-		return nil, ovsdb.NewErrWrongType("NewMapperInfo", "pminter to a struct", obj)
+		return nil, ovsdb.NewErrWrongType("NewMapperInfo", "pointer to a struct", obj)
 	}
 	objVal := reflect.Indirect(objPtrVal)
 	if objVal.Kind() != reflect.Struct {
-		return nil, ovsdb.NewErrWrongType("NewMapperInfo", "pminter to a struct", obj)
+		return nil, ovsdb.NewErrWrongType("NewMapperInfo", "pointer to a struct", obj)
 	}
 	objType := objVal.Type()
 

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -394,3 +394,29 @@ func (m Mapper) equalIndexes(table *ovsdb.TableSchema, one, other interface{}, i
 	}
 	return false, nil
 }
+
+// NewMonitorRequest returns a monitor request for the provided tableName
+// If fields is provided, the request will be constrained to the provided columns
+// If no fields are provided, all columns will be used
+func (m *Mapper) NewMonitorRequest(tableName string, data interface{}, fields []interface{}) (*ovsdb.MonitorRequest, error) {
+	var columns []string
+	schema := m.Schema.Tables[tableName]
+	info, err := NewInfo(&schema, data)
+	if err != nil {
+		return nil, err
+	}
+	if len(fields) > 0 {
+		for _, f := range fields {
+			column, err := info.ColumnByPtr(f)
+			if err != nil {
+				return nil, err
+			}
+			columns = append(columns, column)
+		}
+	} else {
+		for c := range info.table.Columns {
+			columns = append(columns, c)
+		}
+	}
+	return &ovsdb.MonitorRequest{Columns: columns, Select: ovsdb.NewDefaultMonitorSelect()}, nil
+}

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -1026,4 +1027,69 @@ func testOvsMap(t *testing.T, set interface{}) *ovsdb.OvsMap {
 	oMap, err := ovsdb.NewOvsMap(set)
 	assert.Nil(t, err)
 	return oMap
+}
+
+func TestNewMonitorRequest(t *testing.T) {
+	var testSchema = []byte(`{
+  "cksum": "223619766 22548",
+  "name": "TestSchema",
+  "tables": {
+    "TestTable": {
+      "indexes": [["name"],["composed_1","composed_2"]],
+      "columns": {
+        "name": {
+          "type": "string"
+        },
+        "composed_1": {
+          "type": {
+            "key": "string"
+          }
+        },
+        "composed_2": {
+          "type": {
+            "key": "string"
+          }
+        },
+        "int1": {
+          "type": {
+            "key": "integer"
+          }
+        },
+        "int2": {
+          "type": {
+            "key": "integer"
+          }
+        },
+        "config": {
+          "type": {
+            "key": "string",
+            "max": "unlimited",
+            "min": 0,
+            "value": "string"
+          }
+	}
+      }
+    }
+  }
+}`)
+	type testType struct {
+		ID     string            `ovsdb:"_uuid"`
+		MyName string            `ovsdb:"name"`
+		Config map[string]string `ovsdb:"config"`
+		Comp1  string            `ovsdb:"composed_1"`
+		Comp2  string            `ovsdb:"composed_2"`
+		Int1   int               `ovsdb:"int1"`
+		Int2   int               `ovsdb:"int2"`
+	}
+	var schema ovsdb.DatabaseSchema
+	err := json.Unmarshal(testSchema, &schema)
+	require.NoError(t, err)
+	mapper := NewMapper(&schema)
+	testTable := &testType{}
+	mr, err := mapper.NewMonitorRequest("TestTable", testTable, nil)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, mr.Columns, []string{"name", "config", "composed_1", "composed_2", "int1", "int2"})
+	mr2, err := mapper.NewMonitorRequest("TestTable", testTable, []interface{}{&testTable.Int1, &testTable.MyName})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, mr2.Columns, []string{"int1", "name"})
 }


### PR DESCRIPTION
Specifying a custom Monitor is harder now we have models as it requires
the user to know the names of the Table and Fields they are interested
in. We already have this data in the model.

This commit changes the API to make it easier.

For example:

```
err = ovs.Monitor("play_with_ovs",
	ovs.NewTableMonitor(&OpenvSwitch{}),
	ovs.NewTableMonitor(&Bridge{}),
)
```

You can optionally provide pointers to the fields in a model to monitor
only those columns.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>