### PR TITLE
ovsdb: Do not return pointer for OvsMap and OvsSet

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -18,13 +18,13 @@ var (
 	aUUID3 = "2f77b348-9768-4866-b761-89d5177ecda3"
 )
 
-func testOvsSet(t *testing.T, set interface{}) *ovsdb.OvsSet {
+func testOvsSet(t *testing.T, set interface{}) ovsdb.OvsSet {
 	oSet, err := ovsdb.NewOvsSet(set)
 	assert.Nil(t, err)
 	return oSet
 }
 
-func testOvsMap(t *testing.T, set interface{}) *ovsdb.OvsMap {
+func testOvsMap(t *testing.T, set interface{}) ovsdb.OvsMap {
 	oMap, err := ovsdb.NewOvsMap(set)
 	assert.Nil(t, err)
 	return oMap

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -155,7 +155,7 @@ var testSchema = []byte(`{
 func getOvsTestRow(t *testing.T) ovsdb.Row {
 	ovsRow := ovsdb.NewRow()
 	ovsRow["aString"] = aString
-	ovsRow["aSet"] = *testOvsSet(t, aSet)
+	ovsRow["aSet"] = testOvsSet(t, aSet)
 	// Set's can hold the value if they have len == 1
 	ovsRow["aSingleSet"] = aString
 
@@ -163,21 +163,21 @@ func getOvsTestRow(t *testing.T) ovsdb.Row {
 	for _, u := range aUUIDSet {
 		us = append(us, ovsdb.UUID{GoUUID: u})
 	}
-	ovsRow["aUUIDSet"] = *testOvsSet(t, us)
+	ovsRow["aUUIDSet"] = testOvsSet(t, us)
 
 	ovsRow["aUUID"] = ovsdb.UUID{GoUUID: aUUID0}
 
-	ovsRow["aIntSet"] = *testOvsSet(t, aIntSet)
+	ovsRow["aIntSet"] = testOvsSet(t, aIntSet)
 
 	ovsRow["aFloat"] = aFloat
 
-	ovsRow["aFloatSet"] = *testOvsSet(t, aFloatSet)
+	ovsRow["aFloatSet"] = testOvsSet(t, aFloatSet)
 
-	ovsRow["aEmptySet"] = *testOvsSet(t, []string{})
+	ovsRow["aEmptySet"] = testOvsSet(t, []string{})
 
 	ovsRow["aEnum"] = aEnum
 
-	ovsRow["aMap"] = *testOvsMap(t, aMap)
+	ovsRow["aMap"] = testOvsMap(t, aMap)
 
 	return ovsRow
 }
@@ -1016,13 +1016,13 @@ func TestMapperMutation(t *testing.T) {
 	}
 }
 
-func testOvsSet(t *testing.T, set interface{}) *ovsdb.OvsSet {
+func testOvsSet(t *testing.T, set interface{}) ovsdb.OvsSet {
 	oSet, err := ovsdb.NewOvsSet(set)
 	assert.Nil(t, err)
 	return oSet
 }
 
-func testOvsMap(t *testing.T, set interface{}) *ovsdb.OvsMap {
+func testOvsMap(t *testing.T, set interface{}) ovsdb.OvsMap {
 	oMap, err := ovsdb.NewOvsMap(set)
 	assert.Nil(t, err)
 	return oMap

--- a/ovsdb/bindings.go
+++ b/ovsdb/bindings.go
@@ -179,14 +179,14 @@ func NativeToOvs(column *ColumnSchema, rawElem interface{}) (interface{}, error)
 	case TypeUUID:
 		return UUID{GoUUID: rawElem.(string)}, nil
 	case TypeSet:
-		var ovsSet *OvsSet
+		var ovsSet OvsSet
 		if column.TypeObj.Key.Type == TypeUUID {
 			var ovsSlice []interface{}
 			for _, v := range rawElem.([]string) {
 				uuid := UUID{GoUUID: v}
 				ovsSlice = append(ovsSlice, uuid)
 			}
-			ovsSet = &OvsSet{GoSet: ovsSlice}
+			ovsSet = OvsSet{GoSet: ovsSlice}
 
 		} else {
 			var err error

--- a/ovsdb/bindings_common_test.go
+++ b/ovsdb/bindings_common_test.go
@@ -1,1 +1,0 @@
-package ovsdb

--- a/ovsdb/bindings_test.go
+++ b/ovsdb/bindings_test.go
@@ -86,7 +86,7 @@ func getErrTransMaps() []map[string]interface{} {
 		"name":   "Set instead of Atomic Type",
 		"schema": []byte(`{"type":"string"}`),
 		"native": []string{"foo"},
-		"ovs":    *as,
+		"ovs":    as,
 	})
 	transMap = append(transMap, map[string]interface{}{
 		"name": "Wrong Set Type",
@@ -112,7 +112,7 @@ func getErrTransMaps() []map[string]interface{} {
           }
         }`),
 		"native": map[string]string{"foo": "bar"},
-		"ovs":    *s,
+		"ovs":    s,
 	})
 
 	m, _ := NewOvsMap(map[int]string{1: "one", 2: "two"})
@@ -127,7 +127,7 @@ func getErrTransMaps() []map[string]interface{} {
           }
 	}`),
 		"native": map[int]string{1: "one", 2: "two"},
-		"ovs":    *m,
+		"ovs":    m,
 	})
 	return transMap
 }
@@ -192,7 +192,7 @@ func getTransMaps() []map[string]interface{} {
         }`),
 		"native":     aSet,
 		"native2ovs": s,
-		"ovs":        *s,
+		"ovs":        s,
 		"ovs2native": aSet,
 	})
 
@@ -234,7 +234,7 @@ func getTransMaps() []map[string]interface{} {
 	}`),
 		"native":     aUUIDSet,
 		"native2ovs": uss,
-		"ovs":        *uss,
+		"ovs":        uss,
 		"ovs2native": aUUIDSet,
 	})
 
@@ -275,7 +275,7 @@ func getTransMaps() []map[string]interface{} {
         }`),
 		"native":     aIntSet,
 		"native2ovs": is,
-		"ovs":        *is,
+		"ovs":        is,
 		"ovs2native": aIntSet,
 	})
 
@@ -293,7 +293,7 @@ func getTransMaps() []map[string]interface{} {
         }`),
 		"native":     aIntSet,
 		"native2ovs": is,
-		"ovs":        *fs,
+		"ovs":        fs,
 		"ovs2native": aIntSet,
 	})
 
@@ -313,7 +313,7 @@ func getTransMaps() []map[string]interface{} {
         }`),
 		"native":     []int{aInt},
 		"native2ovs": sis,
-		"ovs":        *sis,
+		"ovs":        sis,
 		"ovs2native": []int{aInt},
 	})
 
@@ -331,7 +331,7 @@ func getTransMaps() []map[string]interface{} {
         }`),
 		"native":     []int{aInt},
 		"native2ovs": sis,
-		"ovs":        *sfs,
+		"ovs":        sfs,
 		"ovs2native": []int{aInt},
 	})
 
@@ -349,7 +349,7 @@ func getTransMaps() []map[string]interface{} {
         }`),
 		"native":     aFloatSet,
 		"native2ovs": fs,
-		"ovs":        *fs,
+		"ovs":        fs,
 		"ovs2native": aFloatSet,
 	})
 
@@ -368,7 +368,7 @@ func getTransMaps() []map[string]interface{} {
         }`),
 		"native":     aEmptySet,
 		"native2ovs": es,
-		"ovs":        *es,
+		"ovs":        es,
 		"ovs2native": aEmptySet,
 	})
 
@@ -419,7 +419,7 @@ func getTransMaps() []map[string]interface{} {
 	}`),
 		"native":     aEnumSet,
 		"native2ovs": ens,
-		"ovs":        *ens,
+		"ovs":        ens,
 		"ovs2native": aEnumSet,
 	})
 
@@ -437,13 +437,13 @@ func getTransMaps() []map[string]interface{} {
 	}`),
 		"native":     aMap,
 		"native2ovs": m,
-		"ovs":        *m,
+		"ovs":        m,
 		"ovs2native": aMap,
 	})
 	return transMap
 }
 
-func TestOvsToNative(t *testing.T) {
+func TestOvsToNativeAndNativeToOvs(t *testing.T) {
 	transMaps := getTransMaps()
 	for _, trans := range transMaps {
 		t.Run(fmt.Sprintf("Ovs To Native: %s", trans["name"]), func(t *testing.T) {
@@ -464,26 +464,14 @@ func TestOvsToNative(t *testing.T) {
 					trans["ovs2native"], reflect.TypeOf(trans["ovs2native"]),
 					res, reflect.TypeOf(res))
 			}
-		})
-	}
-}
 
-func TestNativeToOvs(t *testing.T) {
-	transMaps := getTransMaps()
-	for _, trans := range transMaps {
-		t.Run(fmt.Sprintf("Native To Ovs: %s", trans["name"]), func(t *testing.T) {
-			var column ColumnSchema
-			if err := json.Unmarshal(trans["schema"].([]byte), &column); err != nil {
-				t.Fatal(err)
-			}
-
-			res, err := NativeToOvs(&column, trans["native"])
+			ovs, err := NativeToOvs(&column, res)
 			if err != nil {
 				t.Errorf("failed to convert %s: %s", trans, err)
 				t.Logf("Testing %v", string(trans["schema"].([]byte)))
 			}
 
-			if !reflect.DeepEqual(res, trans["native2ovs"]) {
+			if !reflect.DeepEqual(ovs, trans["native2ovs"]) {
 				t.Errorf("fail to convert native2ovs. native: %v(%s). expected %v(%s). got %v (%s)",
 					trans["native"], reflect.TypeOf(trans["native"]),
 					trans["native2ovs"], reflect.TypeOf(trans["native2ovs"]),

--- a/ovsdb/encoding_test.go
+++ b/ovsdb/encoding_test.go
@@ -129,7 +129,7 @@ func TestMap(t *testing.T) {
 		var res OvsMap
 		err = json.Unmarshal(jsonStr, &res)
 		assert.Nil(t, err)
-		assert.Equal(t, *m, res, "they should be equal\n")
+		assert.Equal(t, m, res, "they should be equal\n")
 	}
 }
 

--- a/ovsdb/map.go
+++ b/ovsdb/map.go
@@ -49,10 +49,10 @@ func (o *OvsMap) UnmarshalJSON(b []byte) (err error) {
 }
 
 // NewOvsMap will return an OVSDB style map from a provided Golang Map
-func NewOvsMap(goMap interface{}) (*OvsMap, error) {
+func NewOvsMap(goMap interface{}) (OvsMap, error) {
 	v := reflect.ValueOf(goMap)
 	if v.Kind() != reflect.Map {
-		return nil, fmt.Errorf("ovsmap supports only go map types")
+		return OvsMap{}, fmt.Errorf("ovsmap supports only go map types")
 	}
 
 	genMap := make(map[interface{}]interface{})
@@ -60,5 +60,5 @@ func NewOvsMap(goMap interface{}) (*OvsMap, error) {
 	for _, key := range keys {
 		genMap[key.Interface()] = v.MapIndex(key).Interface()
 	}
-	return &OvsMap{genMap}, nil
+	return OvsMap{genMap}, nil
 }

--- a/ovsdb/schema.go
+++ b/ovsdb/schema.go
@@ -361,11 +361,11 @@ func (b BaseType) MarshalJSON() ([]byte, error) {
 		RefType:    b.refType,
 	}
 	if len(b.Enum) > 0 {
-		var err error
-		j.Enum, err = NewOvsSet(b.Enum)
+		set, err := NewOvsSet(b.Enum)
 		if err != nil {
 			return nil, err
 		}
+		j.Enum = &set
 	}
 	return json.Marshal(j)
 }

--- a/ovsdb/set.go
+++ b/ovsdb/set.go
@@ -18,7 +18,7 @@ type OvsSet struct {
 }
 
 // NewOvsSet creates a new OVSDB style set from a Go interface (object)
-func NewOvsSet(obj interface{}) (*OvsSet, error) {
+func NewOvsSet(obj interface{}) (OvsSet, error) {
 	v := reflect.ValueOf(obj)
 	var ovsSet []interface{}
 	switch v.Kind() {
@@ -34,9 +34,9 @@ func NewOvsSet(obj interface{}) (*OvsSet, error) {
 	case reflect.ValueOf(UUID{}).Kind():
 		ovsSet = append(ovsSet, v.Interface())
 	default:
-		return nil, fmt.Errorf("ovsset supports only go slice/string/numbers/uuid types")
+		return OvsSet{}, fmt.Errorf("ovsset supports only go slice/string/numbers/uuid types")
 	}
-	return &OvsSet{ovsSet}, nil
+	return OvsSet{ovsSet}, nil
 }
 
 // MarshalJSON wil marshal an OVSDB style Set in to a JSON byte array


### PR DESCRIPTION
If I recall, this was because we could return an error in those
functions. However, this means that OvsToNative and NativeToOvs are not
compatible. By returning a struct, not a pointer, everything still works
as expected AND OvsToNative and NativeToOvs become compatible without
having to write additional reflection code to deal with pointers to
structs.

Closes: #162

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>