### PR TITLE
cache: use existing model as "old" in events

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -439,11 +439,7 @@ func (t *TableCache) Populate(tableUpdates ovsdb.TableUpdates) {
 						if err := tCache.update(uuid, newModel); err != nil {
 							panic(err)
 						}
-						oldModel, err := t.CreateModel(table, row.Old, uuid)
-						if err != nil {
-							panic(err)
-						}
-						t.eventProcessor.AddEvent(updateEvent, table, oldModel, newModel)
+						t.eventProcessor.AddEvent(updateEvent, table, existing, newModel)
 					}
 					// no diff
 					continue


### PR DESCRIPTION
RFC specifies that on update notifications, "old" row contains only the
monitored columns whose values have changed.

However, since our Model-based interface contains all the possible
fields, in order for clients to really understand what has changed, we
would have to send the _full_ old version of the model alongside the new
one.

Signed-off-by: Adrian Moreno <amorenoz@redhat.com>