### PR TITLE
Make Connect() Part of the Client. Make Client an interface.

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -313,11 +313,14 @@ func (e *EventHandlerFuncs) OnDelete(table string, row model.Model) {
 
 // TableCache contains a collection of RowCaches, hashed by name,
 // and an array of EventHandlers that respond to cache updates
+// It implements the ovsdb.NotifcationHandler interface so it may
+// handle update notifications
 type TableCache struct {
 	cache          map[string]*RowCache
 	eventProcessor *eventProcessor
 	mapper         *mapper.Mapper
 	dbModel        *model.DBModel
+	ovsdb.NotificationHandler
 }
 
 // Data is the type for data that can be prepoulated in the cache

--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -19,28 +20,6 @@ import (
 	"github.com/ovn-org/libovsdb/ovsdb"
 )
 
-// OvsdbClient is an OVSDB client
-type OvsdbClient struct {
-	rpcClient     *rpc2.Client
-	dbModel       *model.DBModel
-	Schema        ovsdb.DatabaseSchema
-	handlers      []ovsdb.NotificationHandler
-	handlersMutex *sync.Mutex
-	Cache         *cache.TableCache
-	stopCh        chan struct{}
-	api           API
-}
-
-func newOvsdbClient(dbModel *model.DBModel) *OvsdbClient {
-	// Cache initialization is delayed because we first need to obtain the schema
-	ovs := &OvsdbClient{
-		dbModel:       dbModel,
-		handlersMutex: &sync.Mutex{},
-		stopCh:        make(chan struct{}),
-	}
-	return ovs
-}
-
 // Constants defined for libovsdb
 const (
 	SSL  = "ssl"
@@ -48,24 +27,81 @@ const (
 	UNIX = "unix"
 )
 
-// Connect to an OVSDB Server using the provided endpoint in OVSDB Connection Format
-// For more details, see the ovsdb(7) man page
+// ErrNotConnected is an error returned when the client is not connected
+var ErrNotConnected = errors.New("not connected")
+
+// Client represents an OVSDB Client Connection
+// It provides all the necessary functionality to Connect to a server,
+// perform transactions, and build your own replica of the database with
+// Monitor or MonitorAll. It also provides a Cache that is populated from OVSDB
+// update notifications.
+type Client interface {
+	Connect(context.Context) error
+	Disconnect()
+	Schema() *ovsdb.DatabaseSchema
+	Cache() *cache.TableCache
+	SetOption(Option) error
+	Echo() error
+	Transact(...ovsdb.Operation) ([]ovsdb.OperationResult, error)
+	Monitor(jsonContext interface{}, t ...TableMonitor) error
+	MonitorAll(jsonContext interface{}) error
+	MonitorCancel(jsonContext interface{}) error
+	NewTableMonitor(m model.Model, fields ...interface{}) TableMonitor
+	API
+}
+
+// ovsdbClient is an OVSDB client
+type ovsdbClient struct {
+	options   *options
+	rpcClient *rpc2.Client
+	dbModel   *model.DBModel
+	schema    *ovsdb.DatabaseSchema
+	cache     *cache.TableCache
+	stopCh    chan struct{}
+	connected bool
+	api       API
+	mutex     sync.Mutex
+}
+
+// NewOVSDBClient creates a new OVSDB Client with the provided
+// database model. The client can be configured using one or more Option(s),
+// like WithTLSConfig. If no WithEndpoint option is supplied, the default of
+// unix:/var/run/openvswitch/ovsdb.sock is used
+func NewOVSDBClient(databaseModel *model.DBModel, opts ...Option) (Client, error) {
+	return newOVSDBClient(databaseModel, opts...)
+}
+
+// newOVSDBClient creates a new ovsdbClient
+func newOVSDBClient(databaseModel *model.DBModel, opts ...Option) (*ovsdbClient, error) {
+	ovs := &ovsdbClient{
+		dbModel: databaseModel,
+	}
+	var err error
+	ovs.options, err = newOptions(opts...)
+	if err != nil {
+		return nil, err
+	}
+	return ovs, nil
+}
+
+// Connect opens a connection to an OVSDB Server using the
+// endpoint provided when the Client was created.
 // The connection can be configured using one or more Option(s), like WithTLSConfig
 // If no WithEndpoint option is supplied, the default of unix:/var/run/openvswitch/ovsdb.sock is used
-func Connect(ctx context.Context, database *model.DBModel, opts ...Option) (*OvsdbClient, error) {
+func (o *ovsdbClient) Connect(ctx context.Context) error {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+	if o.connected {
+		return nil
+	}
 	var c net.Conn
 	var dialer net.Dialer
 	var err error
 	var u *url.URL
-
-	options, err := newOptions(opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, endpoint := range options.endpoints {
+	connected := false
+	for _, endpoint := range o.options.endpoints {
 		if u, err = url.Parse(endpoint); err != nil {
-			return nil, err
+			return err
 		}
 		switch u.Scheme {
 		case UNIX:
@@ -74,123 +110,122 @@ func Connect(ctx context.Context, database *model.DBModel, opts ...Option) (*Ovs
 			c, err = dialer.DialContext(ctx, u.Scheme, u.Opaque)
 		case SSL:
 			dialer := tls.Dialer{
-				Config: options.tlsConfig,
+				Config: o.options.tlsConfig,
 			}
 			c, err = dialer.DialContext(ctx, "tcp", u.Opaque)
 		default:
 			err = fmt.Errorf("unknown network protocol %s", u.Scheme)
 		}
 		if err == nil {
-			return newRPC2Client(c, database)
+			connected = true
+			break
 		}
 	}
-	return nil, fmt.Errorf("failed to connect to endpoints %q: %v", options.endpoints, err)
+	if !connected {
+		// FIXME: This only emits the error from the last attempted connection
+		return fmt.Errorf("failed to connect to endpoints %q: %v", o.options.endpoints, err)
+	}
+	if err := o.createRPC2Client(c); err != nil {
+		return err
+	}
+	o.connected = true
+	return nil
 }
 
-func newRPC2Client(conn net.Conn, database *model.DBModel) (*OvsdbClient, error) {
-	ovs := newOvsdbClient(database)
-	ovs.rpcClient = rpc2.NewClientWithCodec(jsonrpc.NewJSONCodec(conn))
-	ovs.rpcClient.SetBlocking(true)
-	ovs.rpcClient.Handle("echo", func(_ *rpc2.Client, args []interface{}, reply *[]interface{}) error {
-		return ovs.echo(args, reply)
+// createRPC2Client creates an rpcClient using the provided connection
+// It is also responsible for setting up go routines for handling disconnect notification
+// and cache population
+func (o *ovsdbClient) createRPC2Client(conn net.Conn) error {
+	o.stopCh = make(chan struct{})
+	o.rpcClient = rpc2.NewClientWithCodec(jsonrpc.NewJSONCodec(conn))
+	o.rpcClient.SetBlocking(true)
+	o.rpcClient.Handle("echo", func(_ *rpc2.Client, args []interface{}, reply *[]interface{}) error {
+		return o.echo(args, reply)
 	})
-	ovs.rpcClient.Handle("update", func(_ *rpc2.Client, args []json.RawMessage, reply *[]interface{}) error {
-		return ovs.update(args, reply)
+	o.rpcClient.Handle("update", func(_ *rpc2.Client, args []json.RawMessage, reply *[]interface{}) error {
+		return o.update(args, reply)
 	})
-	go ovs.rpcClient.Run()
-	go ovs.handleDisconnectNotification()
+	go o.rpcClient.Run()
 
-	dbs, err := ovs.ListDbs()
+	dbs, err := o.listDbs()
 	if err != nil {
-		ovs.rpcClient.Close()
-		return nil, err
+		o.rpcClient.Close()
+		return err
 	}
 
 	found := false
 	for _, db := range dbs {
-		if db == database.Name() {
+		if db == o.dbModel.Name() {
 			found = true
 			break
 		}
 	}
 	if !found {
-		ovs.rpcClient.Close()
-		return nil, fmt.Errorf("target database not found")
+		o.rpcClient.Close()
+		return fmt.Errorf("target database not found")
 	}
 
-	schema, err := ovs.GetSchema(database.Name())
-	errors := database.Validate(schema)
+	schema, err := o.getSchema(o.dbModel.Name())
+	errors := o.dbModel.Validate(schema)
 	if len(errors) > 0 {
 		var combined []string
 		for _, err := range errors {
 			combined = append(combined, err.Error())
 		}
-		return nil, fmt.Errorf("database validation error (%d): %s", len(errors),
+		return fmt.Errorf("database validation error (%d): %s", len(errors),
 			strings.Join(combined, ". "))
 	}
 
 	if err == nil {
-		ovs.Schema = *schema
-		if cache, err := cache.NewTableCache(schema, database, nil); err == nil {
-			ovs.Cache = cache
-			ovs.Register(ovs.Cache)
-			ovs.api = newAPI(ovs.Cache)
+		o.schema = schema
+		if cache, err := cache.NewTableCache(schema, o.dbModel, nil); err == nil {
+			o.cache = cache
+			o.api = newAPI(o.cache)
 		} else {
-			ovs.rpcClient.Close()
-			return nil, err
+			o.rpcClient.Close()
+			return err
 		}
 	} else {
-		ovs.rpcClient.Close()
-		return nil, err
-	}
-
-	go ovs.Cache.Run(ovs.stopCh)
-
-	return ovs, nil
-}
-
-// Register registers the supplied NotificationHandler to receive OVSDB Notifications
-func (ovs *OvsdbClient) Register(handler ovsdb.NotificationHandler) {
-	ovs.handlersMutex.Lock()
-	defer ovs.handlersMutex.Unlock()
-	ovs.handlers = append(ovs.handlers, handler)
-}
-
-//Get Handler by index
-func getHandlerIndex(handler ovsdb.NotificationHandler, handlers []ovsdb.NotificationHandler) (int, error) {
-	for i, h := range handlers {
-		if reflect.DeepEqual(h, handler) {
-			return i, nil
-		}
-	}
-	return -1, fmt.Errorf("handler not found")
-}
-
-// Unregister the supplied NotificationHandler to not receive OVSDB Notifications anymore
-func (ovs *OvsdbClient) Unregister(handler ovsdb.NotificationHandler) error {
-	ovs.handlersMutex.Lock()
-	defer ovs.handlersMutex.Unlock()
-	i, err := getHandlerIndex(handler, ovs.handlers)
-	if err != nil {
+		o.rpcClient.Close()
 		return err
 	}
-	ovs.handlers = append(ovs.handlers[:i], ovs.handlers[i+1:]...)
+
+	go o.cache.Run(o.stopCh)
+	go o.handleDisconnectNotification()
+
 	return nil
 }
 
-// RFC 7047 : Section 4.1.6 : Echo
-func (ovs *OvsdbClient) echo(args []interface{}, reply *[]interface{}) error {
-	*reply = args
-	ovs.handlersMutex.Lock()
-	defer ovs.handlersMutex.Unlock()
-	for _, handler := range ovs.handlers {
-		handler.Echo(nil)
+// Schema returns the DatabaseSchema that is being used by the client
+// it will be nil until a connection has been established
+func (o *ovsdbClient) Schema() *ovsdb.DatabaseSchema {
+	return o.schema
+}
+
+// Cache returns the TableCache that is populated from
+// ovsdb update notifications. It will be nil until a connection
+// has been established, and empty unless you call Monitor
+func (o *ovsdbClient) Cache() *cache.TableCache {
+	return o.cache
+}
+
+// SetOption sets a new value for an option.
+// It may only be called when the client is not connected
+func (o *ovsdbClient) SetOption(opt Option) error {
+	if o.connected {
+		return fmt.Errorf("cannot set option when client is connected")
 	}
+	return opt(o.options)
+}
+
+// RFC 7047 : Section 4.1.6 : Echo
+func (o *ovsdbClient) echo(args []interface{}, reply *[]interface{}) error {
+	*reply = args
 	return nil
 }
 
 // RFC 7047 : Update Notification Section 4.1.6
-func (ovs *OvsdbClient) update(args []json.RawMessage, reply *[]interface{}) error {
+func (o *ovsdbClient) update(args []json.RawMessage, reply *[]interface{}) error {
 	var value string
 	if len(args) > 2 {
 		return fmt.Errorf("update requires exactly 2 args")
@@ -205,50 +240,48 @@ func (ovs *OvsdbClient) update(args []json.RawMessage, reply *[]interface{}) err
 		return err
 	}
 	// Update the local DB cache with the tableUpdates
-	ovs.handlersMutex.Lock()
-	defer ovs.handlersMutex.Unlock()
-	for _, handler := range ovs.handlers {
-		handler.Update(value, updates)
-	}
+	o.cache.Update(value, updates)
 	*reply = []interface{}{}
 	return nil
 }
 
-// GetSchema returns the schema in use for the provided database name
+// getSchema returns the schema in use for the provided database name
 // RFC 7047 : get_schema
-func (ovs OvsdbClient) GetSchema(dbName string) (*ovsdb.DatabaseSchema, error) {
+func (o *ovsdbClient) getSchema(dbName string) (*ovsdb.DatabaseSchema, error) {
 	args := ovsdb.NewGetSchemaArgs(dbName)
 	var reply ovsdb.DatabaseSchema
-	err := ovs.rpcClient.Call("get_schema", args, &reply)
+	err := o.rpcClient.Call("get_schema", args, &reply)
 	if err != nil {
 		return nil, err
 	}
-	ovs.Schema = reply
 	return &reply, err
 }
 
-// ListDbs returns the list of databases on the server
+// listDbs returns the list of databases on the server
 // RFC 7047 : list_dbs
-func (ovs OvsdbClient) ListDbs() ([]string, error) {
+func (o *ovsdbClient) listDbs() ([]string, error) {
 	var dbs []string
-	err := ovs.rpcClient.Call("list_dbs", nil, &dbs)
+	err := o.rpcClient.Call("list_dbs", nil, &dbs)
 	if err != nil {
 		return nil, fmt.Errorf("listdbs failure - %v", err)
 	}
 	return dbs, err
 }
 
-// Transact performs the provided Operation's on the database
+// Transact performs the provided Operations on the database
 // RFC 7047 : transact
-func (ovs OvsdbClient) Transact(operation ...ovsdb.Operation) ([]ovsdb.OperationResult, error) {
+func (o *ovsdbClient) Transact(operation ...ovsdb.Operation) ([]ovsdb.OperationResult, error) {
+	if !o.connected {
+		return nil, ErrNotConnected
+	}
 	var reply []ovsdb.OperationResult
 
-	if ok := ovs.Schema.ValidateOperations(operation...); !ok {
+	if ok := o.schema.ValidateOperations(operation...); !ok {
 		return nil, fmt.Errorf("validation failed for the operation")
 	}
 
-	args := ovsdb.NewTransactArgs(ovs.Schema.Name, operation...)
-	err := ovs.rpcClient.Call("transact", args, &reply)
+	args := ovsdb.NewTransactArgs(o.schema.Name, operation...)
+	err := o.rpcClient.Call("transact", args, &reply)
 	if err != nil {
 		return nil, err
 	}
@@ -256,22 +289,28 @@ func (ovs OvsdbClient) Transact(operation ...ovsdb.Operation) ([]ovsdb.Operation
 }
 
 // MonitorAll is a convenience method to monitor every table/column
-func (ovs OvsdbClient) MonitorAll(jsonContext interface{}) error {
+func (o *ovsdbClient) MonitorAll(jsonContext interface{}) error {
+	if !o.connected {
+		return ErrNotConnected
+	}
 	var options []TableMonitor
-	for name := range ovs.dbModel.Types() {
+	for name := range o.dbModel.Types() {
 		options = append(options, TableMonitor{Table: name})
 	}
-	return ovs.Monitor(jsonContext, options...)
+	return o.Monitor(jsonContext, options...)
 }
 
 // MonitorCancel will request cancel a previously issued monitor request
 // RFC 7047 : monitor_cancel
-func (ovs OvsdbClient) MonitorCancel(jsonContext interface{}) error {
+func (o *ovsdbClient) MonitorCancel(jsonContext interface{}) error {
+	if !o.connected {
+		return ErrNotConnected
+	}
 	var reply ovsdb.OperationResult
 
 	args := ovsdb.NewMonitorCancelArgs(jsonContext)
 
-	err := ovs.rpcClient.Call("monitor_cancel", args, &reply)
+	err := o.rpcClient.Call("monitor_cancel", args, &reply)
 	if err != nil {
 		return err
 	}
@@ -292,8 +331,8 @@ type TableMonitor struct {
 	Error error
 }
 
-func (ovs *OvsdbClient) NewTableMonitor(m model.Model, fields ...interface{}) TableMonitor {
-	tableName := ovs.dbModel.FindTable(reflect.TypeOf(m))
+func (o *ovsdbClient) NewTableMonitor(m model.Model, fields ...interface{}) TableMonitor {
+	tableName := o.dbModel.FindTable(reflect.TypeOf(m))
 	if tableName == "" {
 		return TableMonitor{
 			Error: fmt.Errorf("object of type %s is not part of the DBModel", reflect.TypeOf(m)),
@@ -309,13 +348,16 @@ func (ovs *OvsdbClient) NewTableMonitor(m model.Model, fields ...interface{}) Ta
 // and populate the cache with them. Subsequent updates will be processed
 // by the Update Notifications
 // RFC 7047 : monitor
-func (ovs OvsdbClient) Monitor(jsonContext interface{}, options ...TableMonitor) error {
+func (o *ovsdbClient) Monitor(jsonContext interface{}, options ...TableMonitor) error {
+	if !o.connected {
+		return ErrNotConnected
+	}
 	if len(options) == 0 {
 		return fmt.Errorf("no monitor options provided")
 	}
 	var reply ovsdb.TableUpdates
-	mapper := mapper.NewMapper(&ovs.Schema)
-	typeMap := ovs.dbModel.Types()
+	mapper := mapper.NewMapper(o.schema)
+	typeMap := o.dbModel.Types()
 	requests := make(map[string]ovsdb.MonitorRequest)
 	for _, o := range options {
 		if o.Error != nil {
@@ -331,20 +373,23 @@ func (ovs OvsdbClient) Monitor(jsonContext interface{}, options ...TableMonitor)
 		}
 		requests[o.Table] = *request
 	}
-	args := ovsdb.NewMonitorArgs(ovs.Schema.Name, jsonContext, requests)
-	err := ovs.rpcClient.Call("monitor", args, &reply)
+	args := ovsdb.NewMonitorArgs(o.schema.Name, jsonContext, requests)
+	err := o.rpcClient.Call("monitor", args, &reply)
 	if err != nil {
 		return err
 	}
-	ovs.Cache.Populate(reply)
+	o.cache.Populate(reply)
 	return nil
 }
 
 // Echo tests the liveness of the OVSDB connetion
-func (ovs *OvsdbClient) Echo() error {
+func (o *ovsdbClient) Echo() error {
+	if !o.connected {
+		return ErrNotConnected
+	}
 	args := ovsdb.NewEchoArgs()
 	var reply []interface{}
-	err := ovs.rpcClient.Call("echo", args, &reply)
+	err := o.rpcClient.Call("echo", args, &reply)
 	if err != nil {
 		return err
 	}
@@ -354,59 +399,58 @@ func (ovs *OvsdbClient) Echo() error {
 	return nil
 }
 
-func (ovs *OvsdbClient) clearConnection() {
-	for _, handler := range ovs.handlers {
-		if handler != nil {
-			handler.Disconnected()
-		}
+func (o *ovsdbClient) handleDisconnectNotification() {
+	// this will block until Connect() has released the lock via defer
+	o.mutex.Lock()
+	// we continue to hold the lock until the client has disconnected
+	// this prevents another call to Connect() changing the rpcClient
+	// while we're still listening for disconnects
+	defer o.mutex.Unlock()
+	<-o.rpcClient.DisconnectNotify()
+	close(o.stopCh)
+	o.rpcClient = nil
+	o.cache = nil
+}
+
+// Disconnect will close the connection to the OVSDB server
+func (o *ovsdbClient) Disconnect() {
+	if !o.connected {
+		return
 	}
-}
-
-func (ovs *OvsdbClient) handleDisconnectNotification() {
-	disconnected := ovs.rpcClient.DisconnectNotify()
-	<-disconnected
-	ovs.clearConnection()
-}
-
-// Disconnect will close the OVSDB connection
-func (ovs OvsdbClient) Disconnect() {
-	close(ovs.stopCh)
-	ovs.rpcClient.Close()
+	o.connected = false
+	o.rpcClient.Close()
 }
 
 // Client API interface wrapper functions
 // We add this wrapper to allow users to access the API directly on the
 // client object
 
-// Ensure client implements API
-var _ API = OvsdbClient{}
-
 //Get implements the API interface's Get function
-func (ovs OvsdbClient) Get(model model.Model) error {
-	return ovs.api.Get(model)
+func (o *ovsdbClient) Get(model model.Model) error {
+	return o.api.Get(model)
 }
 
 //Create implements the API interface's Create function
-func (ovs OvsdbClient) Create(models ...model.Model) ([]ovsdb.Operation, error) {
-	return ovs.api.Create(models...)
+func (o *ovsdbClient) Create(models ...model.Model) ([]ovsdb.Operation, error) {
+	return o.api.Create(models...)
 }
 
 //List implements the API interface's List function
-func (ovs OvsdbClient) List(result interface{}) error {
-	return ovs.api.List(result)
+func (o *ovsdbClient) List(result interface{}) error {
+	return o.api.List(result)
 }
 
 //Where implements the API interface's Where function
-func (ovs OvsdbClient) Where(m model.Model, conditions ...model.Condition) ConditionalAPI {
-	return ovs.api.Where(m, conditions...)
+func (o *ovsdbClient) Where(m model.Model, conditions ...model.Condition) ConditionalAPI {
+	return o.api.Where(m, conditions...)
 }
 
 //WhereAll implements the API interface's WhereAll function
-func (ovs OvsdbClient) WhereAll(m model.Model, conditions ...model.Condition) ConditionalAPI {
-	return ovs.api.WhereAll(m, conditions...)
+func (o *ovsdbClient) WhereAll(m model.Model, conditions ...model.Condition) ConditionalAPI {
+	return o.api.WhereAll(m, conditions...)
 }
 
 //WhereCache implements the API interface's WhereCache function
-func (ovs OvsdbClient) WhereCache(predicate interface{}) ConditionalAPI {
-	return ovs.api.WhereCache(predicate)
+func (o *ovsdbClient) WhereCache(predicate interface{}) ConditionalAPI {
+	return o.api.WhereCache(predicate)
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"reflect"
 	"strings"
-	"sync"
 	"testing"
 
+	"github.com/ovn-org/libovsdb/cache"
+	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -17,6 +19,454 @@ var (
 	aUUID2 = "2f77b348-9768-4866-b761-89d5177ecda2"
 	aUUID3 = "2f77b348-9768-4866-b761-89d5177ecda3"
 )
+
+type (
+	BridgeFailMode  = string
+	BridgeProtocols = string
+)
+
+const (
+	BridgeFailModeStandalone  BridgeFailMode  = "standalone"
+	BridgeFailModeSecure      BridgeFailMode  = "secure"
+	BridgeProtocolsOpenflow10 BridgeProtocols = "OpenFlow10"
+	BridgeProtocolsOpenflow11 BridgeProtocols = "OpenFlow11"
+	BridgeProtocolsOpenflow12 BridgeProtocols = "OpenFlow12"
+	BridgeProtocolsOpenflow13 BridgeProtocols = "OpenFlow13"
+	BridgeProtocolsOpenflow14 BridgeProtocols = "OpenFlow14"
+	BridgeProtocolsOpenflow15 BridgeProtocols = "OpenFlow15"
+)
+
+// Bridge defines an object in Bridge table
+type Bridge struct {
+	UUID                string            `ovsdb:"_uuid"`
+	AutoAttach          []string          `ovsdb:"auto_attach"`
+	Controller          []string          `ovsdb:"controller"`
+	DatapathID          []string          `ovsdb:"datapath_id"`
+	DatapathType        string            `ovsdb:"datapath_type"`
+	DatapathVersion     string            `ovsdb:"datapath_version"`
+	ExternalIDs         map[string]string `ovsdb:"external_ids"`
+	FailMode            []BridgeFailMode  `ovsdb:"fail_mode"`
+	FloodVLANs          []int             `ovsdb:"flood_vlans"`
+	FlowTables          map[int]string    `ovsdb:"flow_tables"`
+	IPFIX               []string          `ovsdb:"ipfix"`
+	McastSnoopingEnable bool              `ovsdb:"mcast_snooping_enable"`
+	Mirrors             []string          `ovsdb:"mirrors"`
+	Name                string            `ovsdb:"name"`
+	Netflow             []string          `ovsdb:"netflow"`
+	OtherConfig         map[string]string `ovsdb:"other_config"`
+	Ports               []string          `ovsdb:"ports"`
+	Protocols           []BridgeProtocols `ovsdb:"protocols"`
+	RSTPEnable          bool              `ovsdb:"rstp_enable"`
+	RSTPStatus          map[string]string `ovsdb:"rstp_status"`
+	Sflow               []string          `ovsdb:"sflow"`
+	Status              map[string]string `ovsdb:"status"`
+	STPEnable           bool              `ovsdb:"stp_enable"`
+}
+
+// OpenvSwitch defines an object in Open_vSwitch table
+type OpenvSwitch struct {
+	UUID            string            `ovsdb:"_uuid"`
+	Bridges         []string          `ovsdb:"bridges"`
+	CurCfg          int               `ovsdb:"cur_cfg"`
+	DatapathTypes   []string          `ovsdb:"datapath_types"`
+	Datapaths       map[string]string `ovsdb:"datapaths"`
+	DbVersion       []string          `ovsdb:"db_version"`
+	DpdkInitialized bool              `ovsdb:"dpdk_initialized"`
+	DpdkVersion     []string          `ovsdb:"dpdk_version"`
+	ExternalIDs     map[string]string `ovsdb:"external_ids"`
+	IfaceTypes      []string          `ovsdb:"iface_types"`
+	ManagerOptions  []string          `ovsdb:"manager_options"`
+	NextCfg         int               `ovsdb:"next_cfg"`
+	OtherConfig     map[string]string `ovsdb:"other_config"`
+	OVSVersion      []string          `ovsdb:"ovs_version"`
+	SSL             []string          `ovsdb:"ssl"`
+	Statistics      map[string]string `ovsdb:"statistics"`
+	SystemType      []string          `ovsdb:"system_type"`
+	SystemVersion   []string          `ovsdb:"system_version"`
+}
+
+var schema = `{
+	"name": "Open_vSwitch",
+	"version": "8.2.0",
+	"tables": {
+	  "Bridge": {
+		"columns": {
+		  "auto_attach": {
+			"type": {
+			  "key": {
+				"type": "uuid",
+				"refTable": "AutoAttach"
+			  },
+			  "min": 0,
+			  "max": 1
+			}
+		  },
+		  "controller": {
+			"type": {
+			  "key": {
+				"type": "uuid",
+				"refTable": "Controller"
+			  },
+			  "min": 0,
+			  "max": "unlimited"
+			}
+		  },
+		  "datapath_id": {
+			"type": {
+			  "key": {
+				"type": "string"
+			  },
+			  "min": 0,
+			  "max": 1
+			},
+			"ephemeral": true
+		  },
+		  "datapath_type": {
+			"type": "string"
+		  },
+		  "datapath_version": {
+			"type": "string"
+		  },
+		  "external_ids": {
+			"type": {
+			  "key": {
+				"type": "string"
+			  },
+			  "value": {
+				"type": "string"
+			  },
+			  "min": 0,
+			  "max": "unlimited"
+			}
+		  },
+		  "fail_mode": {
+			"type": {
+			  "key": {
+				"type": "string",
+				"enum": [
+				  "set",
+				  [
+					"standalone",
+					"secure"
+				  ]
+				]
+			  },
+			  "min": 0,
+			  "max": 1
+			}
+		  },
+		  "flood_vlans": {
+			"type": {
+			  "key": {
+				"type": "integer",
+				"minInteger": 0,
+				"maxInteger": 4095
+			  },
+			  "min": 0,
+			  "max": 4096
+			}
+		  },
+		  "flow_tables": {
+			"type": {
+			  "key": {
+				"type": "integer",
+				"minInteger": 0,
+				"maxInteger": 254
+			  },
+			  "value": {
+				"type": "uuid",
+				"refTable": "Flow_Table"
+			  },
+			  "min": 0,
+			  "max": "unlimited"
+			}
+		  },
+		  "ipfix": {
+			"type": {
+			  "key": {
+				"type": "uuid",
+				"refTable": "IPFIX"
+			  },
+			  "min": 0,
+			  "max": 1
+			}
+		  },
+		  "mcast_snooping_enable": {
+			"type": "boolean"
+		  },
+		  "mirrors": {
+			"type": {
+			  "key": {
+				"type": "uuid",
+				"refTable": "Mirror"
+			  },
+			  "min": 0,
+			  "max": "unlimited"
+			}
+		  },
+		  "name": {
+			"type": "string",
+			"mutable": false
+		  },
+		  "netflow": {
+			"type": {
+			  "key": {
+				"type": "uuid",
+				"refTable": "NetFlow"
+			  },
+			  "min": 0,
+			  "max": 1
+			}
+		  },
+		  "other_config": {
+			"type": {
+			  "key": {
+				"type": "string"
+			  },
+			  "value": {
+				"type": "string"
+			  },
+			  "min": 0,
+			  "max": "unlimited"
+			}
+		  },
+		  "ports": {
+			"type": {
+			  "key": {
+				"type": "uuid",
+				"refTable": "Port"
+			  },
+			  "min": 0,
+			  "max": "unlimited"
+			}
+		  },
+		  "protocols": {
+			"type": {
+			  "key": {
+				"type": "string",
+				"enum": [
+				  "set",
+				  [
+					"OpenFlow10",
+					"OpenFlow11",
+					"OpenFlow12",
+					"OpenFlow13",
+					"OpenFlow14",
+					"OpenFlow15"
+				  ]
+				]
+			  },
+			  "min": 0,
+			  "max": "unlimited"
+			}
+		  },
+		  "rstp_enable": {
+			"type": "boolean"
+		  },
+		  "rstp_status": {
+			"type": {
+			  "key": {
+				"type": "string"
+			  },
+			  "value": {
+				"type": "string"
+			  },
+			  "min": 0,
+			  "max": "unlimited"
+			},
+			"ephemeral": true
+		  },
+		  "sflow": {
+			"type": {
+			  "key": {
+				"type": "uuid",
+				"refTable": "sFlow"
+			  },
+			  "min": 0,
+			  "max": 1
+			}
+		  },
+		  "status": {
+			"type": {
+			  "key": {
+				"type": "string"
+			  },
+			  "value": {
+				"type": "string"
+			  },
+			  "min": 0,
+			  "max": "unlimited"
+			},
+			"ephemeral": true
+		  },
+		  "stp_enable": {
+			"type": "boolean"
+		  }
+		},
+		"indexes": [
+		  [
+			"name"
+		  ]
+		]
+	  },
+	  "Open_vSwitch": {
+		"columns": {
+		  "bridges": {
+			"type": {
+			  "key": {
+				"type": "uuid",
+				"refTable": "Bridge"
+			  },
+			  "min": 0,
+			  "max": "unlimited"
+			}
+		  },
+		  "cur_cfg": {
+			"type": "integer"
+		  },
+		  "datapath_types": {
+			"type": {
+			  "key": {
+				"type": "string"
+			  },
+			  "min": 0,
+			  "max": "unlimited"
+			}
+		  },
+		  "datapaths": {
+			"type": {
+			  "key": {
+				"type": "string"
+			  },
+			  "value": {
+				"type": "uuid",
+				"refTable": "Datapath"
+			  },
+			  "min": 0,
+			  "max": "unlimited"
+			}
+		  },
+		  "db_version": {
+			"type": {
+			  "key": {
+				"type": "string"
+			  },
+			  "min": 0,
+			  "max": 1
+			}
+		  },
+		  "dpdk_initialized": {
+			"type": "boolean"
+		  },
+		  "dpdk_version": {
+			"type": {
+			  "key": {
+				"type": "string"
+			  },
+			  "min": 0,
+			  "max": 1
+			}
+		  },
+		  "external_ids": {
+			"type": {
+			  "key": {
+				"type": "string"
+			  },
+			  "value": {
+				"type": "string"
+			  },
+			  "min": 0,
+			  "max": "unlimited"
+			}
+		  },
+		  "iface_types": {
+			"type": {
+			  "key": {
+				"type": "string"
+			  },
+			  "min": 0,
+			  "max": "unlimited"
+			}
+		  },
+		  "manager_options": {
+			"type": {
+			  "key": {
+				"type": "uuid",
+				"refTable": "Manager"
+			  },
+			  "min": 0,
+			  "max": "unlimited"
+			}
+		  },
+		  "next_cfg": {
+			"type": "integer"
+		  },
+		  "other_config": {
+			"type": {
+			  "key": {
+				"type": "string"
+			  },
+			  "value": {
+				"type": "string"
+			  },
+			  "min": 0,
+			  "max": "unlimited"
+			}
+		  },
+		  "ovs_version": {
+			"type": {
+			  "key": {
+				"type": "string"
+			  },
+			  "min": 0,
+			  "max": 1
+			}
+		  },
+		  "ssl": {
+			"type": {
+			  "key": {
+				"type": "uuid",
+				"refTable": "SSL"
+			  },
+			  "min": 0,
+			  "max": 1
+			}
+		  },
+		  "statistics": {
+			"type": {
+			  "key": {
+				"type": "string"
+			  },
+			  "value": {
+				"type": "string"
+			  },
+			  "min": 0,
+			  "max": "unlimited"
+			},
+			"ephemeral": true
+		  },
+		  "system_type": {
+			"type": {
+			  "key": {
+				"type": "string"
+			  },
+			  "min": 0,
+			  "max": 1
+			}
+		  },
+		  "system_version": {
+			"type": {
+			  "key": {
+				"type": "string"
+			  },
+			  "min": 0,
+			  "max": 1
+			}
+		  }
+		}
+	  }
+	}
+  }`
 
 func testOvsSet(t *testing.T, set interface{}) ovsdb.OvsSet {
 	oSet, err := ovsdb.NewOvsSet(set)
@@ -30,11 +480,7 @@ func testOvsMap(t *testing.T, set interface{}) ovsdb.OvsMap {
 	return oMap
 }
 
-func updateBenchmark(updates []byte, b *testing.B) {
-	ovs := OvsdbClient{
-		handlers:      []ovsdb.NotificationHandler{},
-		handlersMutex: &sync.Mutex{},
-	}
+func updateBenchmark(ovs *ovsdbClient, updates []byte, b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		params := []json.RawMessage{[]byte(`"v1"`), updates}
 		var reply []interface{}
@@ -73,8 +519,12 @@ func newBridgeRow(name string) string {
 }
 
 func newOvsRow(bridges ...string) string {
+	bridgeUUIDs := []string{}
+	for _, b := range bridges {
+		bridgeUUIDs = append(bridgeUUIDs, `[ "uuid", "`+b+`" ]`)
+	}
 	return `{
-		"bridges": [ "set", ["` + strings.Join(bridges, `","`) + `"]],
+		"bridges": [ "set", [` + strings.Join(bridgeUUIDs, `,`) + `]],
 		"cur_cfg": 0,
 		"datapath_types": [ "set", [] ],
 		"datapaths": [ "map", [] ],
@@ -83,7 +533,7 @@ func newOvsRow(bridges ...string) string {
 		"dpdk_version":     [ "set", [] ],
 		"external_ids":     [ "map", [["system-id","829f8534-94a8-468e-9176-132738cf260a"]]],
 		"iface_types":      [ "set", [] ],
-		"manager_options":  "6e4cd5fc-f51a-462a-b3d6-a696af6d7a84",
+		"manager_options":  ["uuid", "6e4cd5fc-f51a-462a-b3d6-a696af6d7a84"],
 		"next_cfg":         0,
 		"other_config":     [ "map", [] ],
 		"ovs_version":      "2.15.90",
@@ -95,87 +545,145 @@ func newOvsRow(bridges ...string) string {
 }
 
 func BenchmarkUpdate1(b *testing.B) {
+	ovs, err := newOVSDBClient(defDB)
+	require.NoError(b, err)
+	var s ovsdb.DatabaseSchema
+	err = json.Unmarshal([]byte(schema), &s)
+	require.NoError(b, err)
+	dbModel, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+		"Bridge":       &Bridge{},
+		"Open_vSwitch": &OpenvSwitch{},
+	})
+	require.NoError(b, err)
+	ovs.cache, err = cache.NewTableCache(&s, dbModel, nil)
+	require.NoError(b, err)
 	update := []byte(`{
 		"Open_vSwitch": {
-			"ovs": ` + newOvsRow("foo") + `
+			"ovs": {"new": ` + newOvsRow("foo") + `}
 		},
 		"Bridge": {
-			"foo": ` + newBridgeRow("foo") + `
+			"foo": {"new": ` + newBridgeRow("foo") + `}
 		}
 	}`)
-	updateBenchmark(update, b)
+	updateBenchmark(ovs, update, b)
 }
 
 func BenchmarkUpdate2(b *testing.B) {
+	ovs, err := newOVSDBClient(defDB)
+	require.NoError(b, err)
+	var s ovsdb.DatabaseSchema
+	err = json.Unmarshal([]byte(schema), &s)
+	require.NoError(b, err)
+	dbModel, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+		"Bridge":       &Bridge{},
+		"Open_vSwitch": &OpenvSwitch{},
+	})
+	require.NoError(b, err)
+	ovs.cache, err = cache.NewTableCache(&s, dbModel, nil)
+	require.NoError(b, err)
 	update := []byte(`{
 		"Open_vSwitch": {
-			"ovs": ` + newOvsRow("foo", "bar") + `
+			"ovs": {"new": ` + newOvsRow("foo", "bar") + `}
 		},
 		"Bridge": {
-			"foo": ` + newBridgeRow("foo") + `,
-			"bar": ` + newBridgeRow("bar") + `
+			"foo": {"new": ` + newBridgeRow("foo") + `},
+			"bar": {"new": ` + newBridgeRow("bar") + `}
 		}
 	}`)
-	updateBenchmark(update, b)
+	updateBenchmark(ovs, update, b)
 }
 
 func BenchmarkUpdate3(b *testing.B) {
+	ovs, err := newOVSDBClient(defDB)
+	require.NoError(b, err)
+	var s ovsdb.DatabaseSchema
+	err = json.Unmarshal([]byte(schema), &s)
+	require.NoError(b, err)
+	dbModel, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+		"Bridge":       &Bridge{},
+		"Open_vSwitch": &OpenvSwitch{},
+	})
+	require.NoError(b, err)
+	ovs.cache, err = cache.NewTableCache(&s, dbModel, nil)
+	require.NoError(b, err)
 	update := []byte(`{
 		"Open_vSwitch": {
-			"ovs": ` + newOvsRow("foo", "bar", "baz") + `
+			"ovs": {"new": ` + newOvsRow("foo", "bar", "baz") + `}
 		},
 		"Bridge": {
-			"foo": ` + newBridgeRow("foo") + `,
-			"bar": ` + newBridgeRow("bar") + `,
-			"baz": ` + newBridgeRow("baz") + `
+			"foo": {"new": ` + newBridgeRow("foo") + `},
+			"bar": {"new": ` + newBridgeRow("bar") + `},
+			"baz": {"new": ` + newBridgeRow("baz") + `}
 		}
 	}`)
-	updateBenchmark(update, b)
+	updateBenchmark(ovs, update, b)
 }
 
 func BenchmarkUpdate5(b *testing.B) {
+	ovs, err := newOVSDBClient(defDB)
+	require.NoError(b, err)
+	var s ovsdb.DatabaseSchema
+	err = json.Unmarshal([]byte(schema), &s)
+	require.NoError(b, err)
+	dbModel, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+		"Bridge":       &Bridge{},
+		"Open_vSwitch": &OpenvSwitch{},
+	})
+	require.NoError(b, err)
+	ovs.cache, err = cache.NewTableCache(&s, dbModel, nil)
+	require.NoError(b, err)
 	update := []byte(`{
 		"Open_vSwitch": {
-			"ovs": ` + newOvsRow("foo", "bar", "baz", "quux", "foofoo") + `
+			"ovs": {"new": ` + newOvsRow("foo", "bar", "baz", "quux", "foofoo") + `}
 		},
 		"Bridge": {
-			"foo": ` + newBridgeRow("foo") + `,
-			"bar": ` + newBridgeRow("bar") + `,
-			"baz": ` + newBridgeRow("baz") + `,
-			"quux": ` + newBridgeRow("quux") + `,
-			"foofoo": ` + newBridgeRow("foofoo") + `
+			"foo": {"new": ` + newBridgeRow("foo") + `},
+			"bar": {"new": ` + newBridgeRow("bar") + `},
+			"baz": {"new": ` + newBridgeRow("baz") + `},
+			"quux": {"new": ` + newBridgeRow("quux") + `},
+			"foofoo": {"new": ` + newBridgeRow("foofoo") + `}
 		}
 	}`)
-	updateBenchmark(update, b)
+	updateBenchmark(ovs, update, b)
 }
 
 func BenchmarkUpdate8(b *testing.B) {
+	ovs, err := newOVSDBClient(defDB)
+	require.NoError(b, err)
+	var s ovsdb.DatabaseSchema
+	err = json.Unmarshal([]byte(schema), &s)
+	require.NoError(b, err)
+	dbModel, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+		"Bridge":       &Bridge{},
+		"Open_vSwitch": &OpenvSwitch{},
+	})
+	require.NoError(b, err)
+	ovs.cache, err = cache.NewTableCache(&s, dbModel, nil)
+	require.NoError(b, err)
 	update := []byte(`{
 		"Open_vSwitch": {
-			"ovs": ` + newOvsRow("foo", "bar", "baz", "quux", "foofoo", "foobar", "foobaz", "fooquux") + `
+			"ovs": {"new": ` + newOvsRow("foo", "bar", "baz", "quux", "foofoo", "foobar", "foobaz", "fooquux") + `}
 		},
 		"Bridge": {
-			"foo": ` + newBridgeRow("foo") + `,
-			"bar": ` + newBridgeRow("bar") + `,
-			"baz": ` + newBridgeRow("baz") + `,
-			"quux": ` + newBridgeRow("quux") + `,
-			"foofoo": ` + newBridgeRow("foofoo") + `,
-			"foobar": ` + newBridgeRow("foobar") + `,
-			"foobaz": ` + newBridgeRow("foobaz") + `,
-			"fooquux": ` + newBridgeRow("fooquux") + `
+			"foo": {"new": ` + newBridgeRow("foo") + `},
+			"bar": {"new": ` + newBridgeRow("bar") + `},
+			"baz": {"new": ` + newBridgeRow("baz") + `},
+			"quux": {"new": ` + newBridgeRow("quux") + `},
+			"foofoo": {"new": ` + newBridgeRow("foofoo") + `},
+			"foobar": {"new": ` + newBridgeRow("foobar") + `},
+			"foobaz": {"new": ` + newBridgeRow("foobaz") + `},
+			"fooquux": {"new": ` + newBridgeRow("fooquux") + `}
 		}
 	}`)
-	updateBenchmark(update, b)
+	updateBenchmark(ovs, update, b)
 }
 
 func TestEcho(t *testing.T) {
 	req := []interface{}{"hi"}
 	var reply []interface{}
-	ovs := OvsdbClient{
-		handlers:      []ovsdb.NotificationHandler{},
-		handlersMutex: &sync.Mutex{},
-	}
-	err := ovs.echo(req, &reply)
+	ovs, err := newOVSDBClient(defDB)
+	require.NoError(t, err)
+	err = ovs.echo(req, &reply)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -185,22 +693,91 @@ func TestEcho(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	ovs := OvsdbClient{
-		handlers:      []ovsdb.NotificationHandler{},
-		handlersMutex: &sync.Mutex{},
-	}
+	ovs, err := newOVSDBClient(defDB)
+	require.NoError(t, err)
+	var s ovsdb.DatabaseSchema
+	err = json.Unmarshal([]byte(schema), &s)
+	require.NoError(t, err)
+	dbModel, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+		"Bridge":       &Bridge{},
+		"Open_vSwitch": &OpenvSwitch{},
+	})
+	require.NoError(t, err)
+	ovs.cache, err = cache.NewTableCache(&s, dbModel, nil)
+	require.NoError(t, err)
 	var reply []interface{}
-	validUpdate := ovsdb.TableUpdates{
-		"table": {
-			"uuid": &ovsdb.RowUpdate{},
+	update := []byte(`{
+		"Open_vSwitch": {
+			"ovs": {"new": ` + newOvsRow("foo") + `}
 		},
-	}
-	b, err := json.Marshal(validUpdate)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = ovs.update([]json.RawMessage{[]byte(`"hello"`), b}, &reply)
+		"Bridge": {
+			"foo": {"new": ` + newBridgeRow("foo") + `}
+		}
+	}`)
+	params := []json.RawMessage{[]byte(`"v1"`), update}
+	err = ovs.update(params, &reply)
 	if err != nil {
 		t.Error(err)
 	}
+}
+
+func TestOperationWhenNotConnected(t *testing.T) {
+	ovs, err := newOVSDBClient(defDB)
+	require.NoError(t, err)
+	tests := []struct {
+		name string
+		fn   func() error
+	}{
+		{
+			"echo",
+			func() error {
+				return ovs.Echo()
+			},
+		},
+		{
+			"transact",
+			func() error {
+				_, err := ovs.Transact(ovsdb.Operation{})
+				return err
+			},
+		},
+		{
+			"monitor",
+			func() error {
+				return ovs.Monitor("")
+			},
+		},
+		{
+			"monitor all",
+			func() error {
+				return ovs.MonitorAll("")
+			},
+		},
+		{
+			"monitor cancel",
+			func() error {
+				return ovs.MonitorCancel("")
+			},
+		},
+	}
+	for _, tt := range tests {
+		err := tt.fn()
+		assert.EqualError(t, err, ErrNotConnected.Error())
+	}
+}
+
+func TestSetOption(t *testing.T) {
+	o, err := newOVSDBClient(defDB)
+	require.NoError(t, err)
+
+	o.options, err = newOptions()
+	require.NoError(t, err)
+
+	err = o.SetOption(WithEndpoint("tcp::6640"))
+	require.NoError(t, err)
+
+	o.connected = true
+
+	err = o.SetOption(WithEndpoint("tcp::6641"))
+	assert.EqualError(t, err, "cannot set option when client is connected")
 }

--- a/client/options.go
+++ b/client/options.go
@@ -42,7 +42,9 @@ func WithTLSConfig(cfg *tls.Config) Option {
 
 // WithEndpoint sets the endpoint to be used by the client
 // It can be used multiple times, and the first endpoint that
-// successfully connects will be used:
+// successfully connects will be used.
+// Endpoints are specified in OVSDB Connection Format
+// For more details, see the ovsdb(7) man page
 func WithEndpoint(endpoint string) Option {
 	return func(o *options) error {
 		ep, err := url.Parse(endpoint)

--- a/server/server_integration_test.go
+++ b/server/server_integration_test.go
@@ -82,9 +82,10 @@ func TestClientServerEcho(t *testing.T) {
 		return server.Ready()
 	}, 1*time.Second, 10*time.Millisecond)
 
-	ovs, err := client.Connect(context.Background(), defDB, client.WithEndpoint(fmt.Sprintf("unix:%s", tmpfile)))
-	require.Nil(t, err)
-
+	ovs, err := client.NewOVSDBClient(defDB, client.WithEndpoint(fmt.Sprintf("unix:%s", tmpfile)))
+	require.NoError(t, err)
+	err = ovs.Connect(context.Background())
+	require.NoError(t, err)
 	err = ovs.Echo()
 	assert.Nil(t, err)
 }
@@ -118,8 +119,10 @@ func TestClientServerInsert(t *testing.T) {
 		return server.Ready()
 	}, 1*time.Second, 10*time.Millisecond)
 
-	ovs, err := client.Connect(context.Background(), defDB, client.WithEndpoint(fmt.Sprintf("unix:%s", tmpfile)))
-	require.Nil(t, err)
+	ovs, err := client.NewOVSDBClient(defDB, client.WithEndpoint(fmt.Sprintf("unix:%s", tmpfile)))
+	require.NoError(t, err)
+	err = ovs.Connect(context.Background())
+	require.NoError(t, err)
 
 	bridgeRow := &bridgeType{
 		Name:        "foo",
@@ -167,8 +170,10 @@ func TestClientServerMonitor(t *testing.T) {
 		return server.Ready()
 	}, 1*time.Second, 10*time.Millisecond)
 
-	ovs, err := client.Connect(context.Background(), defDB, client.WithEndpoint(fmt.Sprintf("unix:%s", tmpfile)))
-	require.Nil(t, err)
+	ovs, err := client.NewOVSDBClient(defDB, client.WithEndpoint(fmt.Sprintf("unix:%s", tmpfile)))
+	require.NoError(t, err)
+	err = ovs.Connect(context.Background())
+	require.NoError(t, err)
 
 	ovsRow := &ovsType{
 		UUID: "ovs",
@@ -183,7 +188,7 @@ func TestClientServerMonitor(t *testing.T) {
 	seenInsert := false
 	seenMutation := false
 	seenInitialOvs := false
-	ovs.Cache.AddEventHandler(&cache.EventHandlerFuncs{
+	ovs.Cache().AddEventHandler(&cache.EventHandlerFuncs{
 		AddFunc: func(table string, model model.Model) {
 			if table == "Bridge" {
 				br := model.(*bridgeType)
@@ -289,8 +294,10 @@ func TestClientServerInsertAndDelete(t *testing.T) {
 		return server.Ready()
 	}, 1*time.Second, 10*time.Millisecond)
 
-	ovs, err := client.Connect(context.Background(), defDB, client.WithEndpoint(fmt.Sprintf("unix:%s", tmpfile)))
-	require.Nil(t, err)
+	ovs, err := client.NewOVSDBClient(defDB, client.WithEndpoint(fmt.Sprintf("unix:%s", tmpfile)))
+	require.NoError(t, err)
+	err = ovs.Connect(context.Background())
+	require.NoError(t, err)
 
 	bridgeRow := &bridgeType{
 		Name:        "foo",


### PR DESCRIPTION
There are a couple of big API changes here.

1. `client.Connect` is no longer the way to create a client. You now do this with `client.NewOVSDBClient`
1. `Register` has been removed, as we there isn't really anything useful for users to register a handler for. The cache takes care of update notificaitons and has it's own handlers for add/update/delete, lock/stolen aren't implemented, and we'd be better providing a channel for disconnects. As of now though, I've opted to just return errors when disconnected.
1. `Options` have been moved to `NewOVSDBClient` which will allows for the client to be customized, not just the parameters of `Connect()`
1. `NewOVSDBClient` returns an interface, this allows for adding a `FakeOVSDBClient` in future for testing purposes (i.e it would could use some of the `server` logic to handle transactions without having to worry about actually creating a server).

Minor changes:
1. There is a `connected bool` which tracks the state of the connection. This is used to allow methods to return `ErrNotConnected` if the server is unavailable
1. The `Disconnect` logic has been cleaned up to ensure the we don't have races when clearing the connection and then reconnecting
1. Adds `SetOption` to the `Client` to allow the user to change any options *after* the client is connected. This would only take effect if the client was disconnected and then reconnected again.

The motivation for this is to gracefully handle connection issues.

These can easily be detected if an RPC method returns `ErrNotConnected`, to which the user may wish to call `Connect()`, `Monitor()` etc... again to re-establish their connection.

`SetOption` allows for changing connection parameters when we're disconnected. E.g to change TLS certs.