### PR TITLE
Support map[string] UUID

### DIFF
--- a/ovsdb/bindings.go
+++ b/ovsdb/bindings.go
@@ -165,6 +165,20 @@ func OvsToNative(column *ColumnSchema, ovsElem interface{}) (interface{}, error)
 	}
 }
 
+// NativeToOvsAtomic returns the OVS type of the atomic native value
+func NativeToOvsAtomic(basicType string, nativeElem interface{}) (interface{}, error) {
+	naType := NativeTypeFromAtomic(basicType)
+	if reflect.TypeOf(nativeElem) != naType {
+		return nil, NewErrWrongType("NativeToOvsAtomic", naType.String(), nativeElem)
+	}
+	switch basicType {
+	case TypeUUID:
+		return UUID{GoUUID: nativeElem.(string)}, nil
+	default:
+		return nativeElem, nil
+	}
+}
+
 // NativeToOvs transforms an native type to a ovs type based on the column type information
 func NativeToOvs(column *ColumnSchema, rawElem interface{}) (interface{}, error) {
 	naType := NativeType(column)
@@ -197,11 +211,21 @@ func NativeToOvs(column *ColumnSchema, rawElem interface{}) (interface{}, error)
 		}
 		return ovsSet, nil
 	case TypeMap:
-		ovsMap, err := NewOvsMap(rawElem)
-		if err != nil {
-			return nil, err
+		nativeMapVal := reflect.ValueOf(rawElem)
+		ovsMap := make(map[interface{}]interface{}, nativeMapVal.Len())
+		for _, key := range nativeMapVal.MapKeys() {
+			ovsKey, err := NativeToOvsAtomic(column.TypeObj.Key.Type, key.Interface())
+			if err != nil {
+				return nil, err
+			}
+			ovsVal, err := NativeToOvsAtomic(column.TypeObj.Value.Type, nativeMapVal.MapIndex(key).Interface())
+			if err != nil {
+				return nil, err
+			}
+			ovsMap[ovsKey] = ovsVal
 		}
-		return ovsMap, nil
+		return OvsMap{GoMap: ovsMap}, nil
+
 	default:
 		panic(fmt.Sprintf("Unknown Type: %v", column.Type))
 	}

--- a/ovsdb/bindings_test.go
+++ b/ovsdb/bindings_test.go
@@ -48,6 +48,12 @@ var (
 		"key3": "value3",
 	}
 
+	aUUIDMap = map[string]string{
+		"key1": aUUID0,
+		"key2": aUUID1,
+		"key3": aUUID2,
+	}
+
 	aEmptySet = []string{}
 )
 
@@ -74,6 +80,12 @@ func TestOvsToNativeAndNativeToOvs(t *testing.T) {
 	ens, _ := NewOvsSet(aEnumSet)
 
 	m, _ := NewOvsMap(aMap)
+
+	um, _ := NewOvsMap(map[string]UUID{
+		"key1": {GoUUID: aUUID0},
+		"key2": {GoUUID: aUUID1},
+		"key3": {GoUUID: aUUID2},
+	})
 
 	tests := []struct {
 		name   string
@@ -329,6 +341,20 @@ func TestOvsToNativeAndNativeToOvs(t *testing.T) {
 			input:  m,
 			native: aMap,
 			ovs:    m,
+		},
+		{
+			name: "Map (string->uuid)",
+			schema: []byte(`{
+			"type": {
+				"key": "string",
+				"max": "unlimited",
+				"min": 0,
+				"value": "uuid"
+			}
+			}`),
+			input:  um,
+			native: aUUIDMap,
+			ovs:    um,
 		},
 	}
 	for _, tt := range tests {

--- a/ovsdb/map.go
+++ b/ovsdb/map.go
@@ -42,7 +42,20 @@ func (o *OvsMap) UnmarshalJSON(b []byte) (err error) {
 		innerSlice := oMap[1].([]interface{})
 		for _, val := range innerSlice {
 			f := val.([]interface{})
-			o.GoMap[f[0]] = f[1]
+			switch f[1].(type) {
+			case []interface{}:
+				vSet := f[1].([]interface{})
+				if len(vSet) != 2 || vSet[0] == "map" {
+					return &json.UnmarshalTypeError{Value: reflect.ValueOf(oMap).String(), Type: reflect.TypeOf(*o)}
+				}
+				goSlice, err := ovsSliceToGoNotation(vSet)
+				if err != nil {
+					return err
+				}
+				o.GoMap[f[0]] = goSlice
+			default:
+				o.GoMap[f[0]] = f[1]
+			}
 		}
 	}
 	return err


### PR DESCRIPTION
This type is used and needs to be supported.

bindings (native2ovs): transform each key/value to its ovs
representation. Avoid calling NewOvsMap to avoid a redundant copy
map: consider the possibility of values being UUIDs when unmarshalling
Fixes: #167 

Signed-off-by: Adrian Moreno <amorenoz@redhat.com>