### PR TITLE
cache: Return IndexExistsError immediately

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -111,7 +111,6 @@ func (r *RowCache) create(uuid string, m model.Model) error {
 		return err
 	}
 	newIndexes := newColumnToValue(r.schema.Indexes)
-	var errs []error
 	for index := range r.indexes {
 
 		val, err := valueFromIndex(info, index)
@@ -120,14 +119,11 @@ func (r *RowCache) create(uuid string, m model.Model) error {
 			return err
 		}
 		if existing, ok := r.indexes[index][val]; ok {
-			errs = append(errs,
-				NewIndexExistsError(r.name, val, index, uuid, existing))
+			return NewIndexExistsError(r.name, val, index, uuid, existing)
 		}
 		newIndexes[index][val] = uuid
 	}
-	if len(errs) != 0 {
-		return fmt.Errorf("%v", errs)
-	}
+
 	// write indexes
 	for k1, v1 := range newIndexes {
 		for k2, v2 := range v1 {


### PR DESCRIPTION
Don't put them in an array of errs and return that because it can't be
type asserted back to IndexExistsError and, in turn, won't manifest as an `ovsdb.ConstraintViolation` in the client.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>