### PR TITLE
ovsdb: remove interfaceToOVSDBNotationInterface

### DIFF
--- a/ovsdb/condition.go
+++ b/ovsdb/condition.go
@@ -78,7 +78,7 @@ func (c *Condition) UnmarshalJSON(b []byte) error {
 	default:
 		return fmt.Errorf("%s is not a valid function", function)
 	}
-	vv, err := interfaceToOVSDBNotationInterface(reflect.ValueOf(v[2]))
+	vv, err := ovsSliceToGoNotation(v[2])
 	if err != nil {
 		return err
 	}

--- a/ovsdb/map.go
+++ b/ovsdb/map.go
@@ -42,6 +42,21 @@ func (o *OvsMap) UnmarshalJSON(b []byte) (err error) {
 		innerSlice := oMap[1].([]interface{})
 		for _, val := range innerSlice {
 			f := val.([]interface{})
+			var k interface{}
+			switch f[0].(type) {
+			case []interface{}:
+				vSet := f[0].([]interface{})
+				if len(vSet) != 2 || vSet[0] == "map" {
+					return &json.UnmarshalTypeError{Value: reflect.ValueOf(oMap).String(), Type: reflect.TypeOf(*o)}
+				}
+				goSlice, err := ovsSliceToGoNotation(vSet)
+				if err != nil {
+					return err
+				}
+				k = goSlice
+			default:
+				k = f[0]
+			}
 			switch f[1].(type) {
 			case []interface{}:
 				vSet := f[1].([]interface{})
@@ -52,9 +67,9 @@ func (o *OvsMap) UnmarshalJSON(b []byte) (err error) {
 				if err != nil {
 					return err
 				}
-				o.GoMap[f[0]] = goSlice
+				o.GoMap[k] = goSlice
 			default:
-				o.GoMap[f[0]] = f[1]
+				o.GoMap[k] = f[1]
 			}
 		}
 	}

--- a/ovsdb/mutation.go
+++ b/ovsdb/mutation.go
@@ -3,7 +3,6 @@ package ovsdb
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 )
 
 type Mutator string
@@ -79,7 +78,7 @@ func (m *Mutation) UnmarshalJSON(b []byte) error {
 	default:
 		return fmt.Errorf("%s is not a valid mutator", mutator)
 	}
-	vv, err := interfaceToOVSDBNotationInterface(reflect.ValueOf(v[2]))
+	vv, err := ovsSliceToGoNotation(v[2])
 	if err != nil {
 		return err
 	}

--- a/ovsdb/set.go
+++ b/ovsdb/set.go
@@ -20,7 +20,7 @@ type OvsSet struct {
 // NewOvsSet creates a new OVSDB style set from a Go interface (object)
 func NewOvsSet(obj interface{}) (OvsSet, error) {
 	v := reflect.ValueOf(obj)
-	var ovsSet []interface{}
+	ovsSet := make([]interface{}, 0)
 	switch v.Kind() {
 	case reflect.Slice, reflect.Array:
 		for i := 0; i < v.Len(); i++ {
@@ -55,6 +55,7 @@ func (o OvsSet) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON will unmarshal a JSON byte array to an OVSDB style Set
 func (o *OvsSet) UnmarshalJSON(b []byte) (err error) {
+	o.GoSet = make([]interface{}, 0)
 	addToSet := func(o *OvsSet, v interface{}) error {
 		goVal, err := ovsSliceToGoNotation(v)
 		if err == nil {


### PR DESCRIPTION
Adjust ovsSliceToGoNotation to provide the same functionality.
Move the interfaceToOVSDBNotation tests to test ovsSliceToGoNotation
instead. Clean up the Set and Map notation tests too.

Fixes: #183
Fixes: #149 

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>