### PR TITLE
cache: Disable Index Checking on Populate

### DIFF
--- a/server/database.go
+++ b/server/database.go
@@ -142,7 +142,7 @@ func (db *inMemoryDatabase) Insert(database string, table string, rowUUID string
 	}
 
 	// insert in to db
-	if err := targetDb.Table(table).Create(rowUUID, model); err != nil {
+	if err := targetDb.Table(table).Create(rowUUID, model, true); err != nil {
 		if indexErr, ok := err.(*cache.IndexExistsError); ok {
 			e := ovsdb.ConstraintViolation{}
 			return ovsdb.OperationResult{
@@ -227,7 +227,7 @@ func (db *inMemoryDatabase) Update(database, table string, where []ovsdb.Conditi
 		if err != nil {
 			panic(err)
 		}
-		if err = targetDb.Table(table).Update(uuid.(string), row); err != nil {
+		if err = targetDb.Table(table).Update(uuid.(string), row, true); err != nil {
 			if indexErr, ok := err.(*cache.IndexExistsError); ok {
 				e := ovsdb.ConstraintViolation{}
 				return ovsdb.OperationResult{
@@ -300,7 +300,7 @@ func (db *inMemoryDatabase) Mutate(database, table string, where []ovsdb.Conditi
 				panic(err)
 			}
 			// the field in old has been set, write back to db
-			err = targetDb.Table(table).Update(uuid.(string), old)
+			err = targetDb.Table(table).Update(uuid.(string), old, true)
 			if err != nil {
 				if indexErr, ok := err.(*cache.IndexExistsError); ok {
 					e := ovsdb.ConstraintViolation{}


### PR DESCRIPTION
The ordering of the updates from the table-update notification is
undefined. It's a hard problem to sort the update in such a way each
operation would be processed in order to ensure no indexes collided.
We can instead take the easy way out and ignore index checking
altogether as we assume the server has already take care of this.
THe cache is locked during update, so the client doesn't need to worry
about the indexes being inconsistent during the populate.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>