### PR TITLE
Fix incorrect model schema parsing for enum type columns

### DIFF
--- a/ovsdb/schema.go
+++ b/ovsdb/schema.go
@@ -528,10 +528,10 @@ func (c *ColumnSchema) UnmarshalJSON(data []byte) error {
 	// Infer the ExtendedType from the TypeObj
 	if c.TypeObj.Value != nil {
 		c.Type = TypeMap
-	} else if c.TypeObj.Min() != 1 || c.TypeObj.Max() != 1 {
-		c.Type = TypeSet
 	} else if len(c.TypeObj.Key.Enum) > 0 {
 		c.Type = TypeEnum
+	} else if c.TypeObj.Min() != 1 || c.TypeObj.Max() != 1 {
+		c.Type = TypeSet
 	} else {
 		c.Type = c.TypeObj.Key.Type
 	}


### PR DESCRIPTION
Enum type columns, such as: LoadBalancer.Protocol was currently parsed
to:

```
// LoadBalancer defines an object in Load_Balancer table
type LoadBalancer struct {
	Protocol        []LoadBalancerProtocol        `ovsdb:"protocol"`
}
```
Which is incorrect since the protocol is an enumerated field, not a set
of enumerated fields. This happened because the table schema for
load_balancer specified a max / min field in OVN. The table schema
definition in OVN is a bit dubious since it defines:

```
protocol":{"type":{"key":{"enum":["set",["sctp","tcp","udp"]],"type":"string"},"min":0}}
```

but we can work-around such particularities by switching the order at
which we parse the fields.

/assign @dave-tucker 