### PR TITLE
Makefile: Add missing dependency to test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build: prebuild
 	@go build -v ./...
 
 .PHONY: test
-test:
+test: prebuild
 	@echo "+ $@"
 	@go test -race -coverprofile=unit.cov -test.short -timeout 30s -v ./...
 


### PR DESCRIPTION
Fix the following issue when making test:

    make test ; echo $?
    ...
    PASS
    coverage: [no statements]
    ok      github.com/ovn-org/libovsdb/test/ovs    0.030s  coverage: [no statements]
    make: *** [Makefile:20: test] Error 2
    2

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>