### PR TITLE
server: Fix Update Operation

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -231,7 +231,7 @@ func (r *RowCache) IndexExists(row model.Model) error {
 		if err != nil {
 			continue
 		}
-		if existing, ok := r.indexes[index][val]; ok {
+		if existing, ok := r.indexes[index][val]; ok && existing != uuid.(string) {
 			return NewIndexExistsError(
 				r.name,
 				val,

--- a/server/transact.go
+++ b/server/transact.go
@@ -199,6 +199,22 @@ func (o *OvsdbServer) Update(database, table string, where []ovsdb.Condition, ro
 		if err != nil {
 			panic(err)
 		}
+		new, err := dbModel.Model.NewModel(table)
+		if err != nil {
+			panic(err)
+		}
+		err = m.GetRowData(table, &oldRow, new)
+		if err != nil {
+			panic(err)
+		}
+		info, err = mapper.NewInfo(schema, new)
+		if err != nil {
+			panic(err)
+		}
+		err = info.SetField("_uuid", uuid)
+		if err != nil {
+			panic(err)
+		}
 
 		for column, value := range row {
 			colSchema := schema.Column(column)
@@ -226,13 +242,13 @@ func (o *OvsdbServer) Update(database, table string, where []ovsdb.Condition, ro
 			}
 		}
 
-		newRow, err := m.NewRow(table, old)
+		newRow, err := m.NewRow(table, new)
 		if err != nil {
 			panic(err)
 		}
 
 		// check for index conflicts
-		if err := o.db.CheckIndexes(database, table, old); err != nil {
+		if err := o.db.CheckIndexes(database, table, new); err != nil {
 			if indexExists, ok := err.(*cache.ErrIndexExists); ok {
 				e := ovsdb.ConstraintViolation{}
 				return ovsdb.OperationResult{
@@ -288,6 +304,22 @@ func (o *OvsdbServer) Mutate(database, table string, where []ovsdb.Condition, mu
 		if err != nil {
 			panic(err)
 		}
+		new, err := dbModel.Model.NewModel(table)
+		if err != nil {
+			panic(err)
+		}
+		err = m.GetRowData(table, &oldRow, new)
+		if err != nil {
+			panic(err)
+		}
+		info, err = mapper.NewInfo(schema, new)
+		if err != nil {
+			panic(err)
+		}
+		err = info.SetField("_uuid", uuid)
+		if err != nil {
+			panic(err)
+		}
 		for _, mutation := range mutations {
 			column := schema.Column(mutation.Column)
 			nativeValue, err := ovsdb.OvsToNative(column, mutation.Value)
@@ -297,24 +329,20 @@ func (o *OvsdbServer) Mutate(database, table string, where []ovsdb.Condition, mu
 			if err := ovsdb.ValidateMutation(column, mutation.Mutator, nativeValue); err != nil {
 				panic(err)
 			}
-			info, err := mapper.NewInfo(schema, old)
-			if err != nil {
-				panic(err)
-			}
 			current, err := info.FieldByColumn(mutation.Column)
 			if err != nil {
 				panic(err)
 			}
-			new := mutate(current, mutation.Mutator, nativeValue)
-			if err := info.SetField(mutation.Column, new); err != nil {
+			newValue := mutate(current, mutation.Mutator, nativeValue)
+			if err := info.SetField(mutation.Column, newValue); err != nil {
 				panic(err)
 			}
-			newRow, err := m.NewRow(table, old)
+			newRow, err := m.NewRow(table, new)
 			if err != nil {
 				panic(err)
 			}
 			// check indexes
-			if err := o.db.CheckIndexes(database, table, old); err != nil {
+			if err := o.db.CheckIndexes(database, table, new); err != nil {
 				if indexExists, ok := err.(*cache.ErrIndexExists); ok {
 					e := ovsdb.ConstraintViolation{}
 					return ovsdb.OperationResult{


### PR DESCRIPTION
The update operation wasn't working :(
This commit fixes it such that:
- It checks the fields sent in the Update RPC
- For each field, it attempts to info.SetField in the matching row
- Calls `cache.Update` to commit changes

Fixes: #201

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>