### PR TITLE
Use pointers for optional datatypes. Use arrays for fixed size sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ The API to interact with OVSDB is based on tagged golang structs. We call it a M
         Config map[string]string `ovsdb:"other_config"`
     }
 
+libovsdb is able to translate a Model in to OVSDB format.
+To make the API use go idioms, the following mappings occur:
+
+1. OVSDB Set with min 0 and max unlimited = Slice
+1. OVSDB Set with min 0 and max 1 = Pointer to scalar type
+1. OVSDB Set with min 0 and max N = Array of N
+1. OVSDB Enum = Type-aliased Enum Type
+1. OVSDB Map = Map
+1. OVSDB Scalar Type = Equivalent scalar Go type
+
 A Open vSwitch Database is modeled using a DBModel which is a created by assigning table names to pointers to these structs:
 
     dbModel, _ := model.NewDBModel("OVN_Northbound", map[string]model.Model{

--- a/client/api_test_model.go
+++ b/client/api_test_model.go
@@ -131,21 +131,21 @@ func (*testLogicalSwitch) Table() string {
 //LogicalSwitchPort struct defines an object in Logical_Switch_Port table
 type testLogicalSwitchPort struct {
 	UUID             string            `ovsdb:"_uuid"`
-	Up               []bool            `ovsdb:"up"`
-	Dhcpv4Options    []string          `ovsdb:"dhcpv4_options"`
+	Up               *bool             `ovsdb:"up"`
+	Dhcpv4Options    *string           `ovsdb:"dhcpv4_options"`
 	Name             string            `ovsdb:"name"`
-	DynamicAddresses []string          `ovsdb:"dynamic_addresses"`
-	HaChassisGroup   []string          `ovsdb:"ha_chassis_group"`
+	DynamicAddresses *string           `ovsdb:"dynamic_addresses"`
+	HaChassisGroup   *string           `ovsdb:"ha_chassis_group"`
 	Options          map[string]string `ovsdb:"options"`
-	Enabled          []bool            `ovsdb:"enabled"`
+	Enabled          *bool             `ovsdb:"enabled"`
 	Addresses        []string          `ovsdb:"addresses"`
-	Dhcpv6Options    []string          `ovsdb:"dhcpv6_options"`
-	TagRequest       []int             `ovsdb:"tag_request"`
-	Tag              []int             `ovsdb:"tag"`
+	Dhcpv6Options    *string           `ovsdb:"dhcpv6_options"`
+	TagRequest       *int              `ovsdb:"tag_request"`
+	Tag              *int              `ovsdb:"tag"`
 	PortSecurity     []string          `ovsdb:"port_security"`
 	ExternalIds      map[string]string `ovsdb:"external_ids"`
 	Type             string            `ovsdb:"type"`
-	ParentName       []string          `ovsdb:"parent_name"`
+	ParentName       *string           `ovsdb:"parent_name"`
 }
 
 // Table returns the table name. It's part of the Model interface

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -41,26 +41,26 @@ const (
 // Bridge defines an object in Bridge table
 type Bridge struct {
 	UUID                string            `ovsdb:"_uuid"`
-	AutoAttach          []string          `ovsdb:"auto_attach"`
+	AutoAttach          *string           `ovsdb:"auto_attach"`
 	Controller          []string          `ovsdb:"controller"`
-	DatapathID          []string          `ovsdb:"datapath_id"`
+	DatapathID          *string           `ovsdb:"datapath_id"`
 	DatapathType        string            `ovsdb:"datapath_type"`
 	DatapathVersion     string            `ovsdb:"datapath_version"`
 	ExternalIDs         map[string]string `ovsdb:"external_ids"`
-	FailMode            []BridgeFailMode  `ovsdb:"fail_mode"`
-	FloodVLANs          []int             `ovsdb:"flood_vlans"`
+	FailMode            *BridgeFailMode   `ovsdb:"fail_mode"`
+	FloodVLANs          [4096]int         `ovsdb:"flood_vlans"`
 	FlowTables          map[int]string    `ovsdb:"flow_tables"`
-	IPFIX               []string          `ovsdb:"ipfix"`
+	IPFIX               *string           `ovsdb:"ipfix"`
 	McastSnoopingEnable bool              `ovsdb:"mcast_snooping_enable"`
 	Mirrors             []string          `ovsdb:"mirrors"`
 	Name                string            `ovsdb:"name"`
-	Netflow             []string          `ovsdb:"netflow"`
+	Netflow             *string           `ovsdb:"netflow"`
 	OtherConfig         map[string]string `ovsdb:"other_config"`
 	Ports               []string          `ovsdb:"ports"`
 	Protocols           []BridgeProtocols `ovsdb:"protocols"`
 	RSTPEnable          bool              `ovsdb:"rstp_enable"`
 	RSTPStatus          map[string]string `ovsdb:"rstp_status"`
-	Sflow               []string          `ovsdb:"sflow"`
+	Sflow               *string           `ovsdb:"sflow"`
 	Status              map[string]string `ovsdb:"status"`
 	STPEnable           bool              `ovsdb:"stp_enable"`
 }
@@ -72,19 +72,19 @@ type OpenvSwitch struct {
 	CurCfg          int               `ovsdb:"cur_cfg"`
 	DatapathTypes   []string          `ovsdb:"datapath_types"`
 	Datapaths       map[string]string `ovsdb:"datapaths"`
-	DbVersion       []string          `ovsdb:"db_version"`
+	DbVersion       *string           `ovsdb:"db_version"`
 	DpdkInitialized bool              `ovsdb:"dpdk_initialized"`
-	DpdkVersion     []string          `ovsdb:"dpdk_version"`
+	DpdkVersion     *string           `ovsdb:"dpdk_version"`
 	ExternalIDs     map[string]string `ovsdb:"external_ids"`
 	IfaceTypes      []string          `ovsdb:"iface_types"`
 	ManagerOptions  []string          `ovsdb:"manager_options"`
 	NextCfg         int               `ovsdb:"next_cfg"`
 	OtherConfig     map[string]string `ovsdb:"other_config"`
-	OVSVersion      []string          `ovsdb:"ovs_version"`
-	SSL             []string          `ovsdb:"ssl"`
+	OVSVersion      *string           `ovsdb:"ovs_version"`
+	SSL             *string           `ovsdb:"ssl"`
 	Statistics      map[string]string `ovsdb:"statistics"`
-	SystemType      []string          `ovsdb:"system_type"`
-	SystemVersion   []string          `ovsdb:"system_version"`
+	SystemType      *string           `ovsdb:"system_type"`
+	SystemVersion   *string           `ovsdb:"system_version"`
 }
 
 var defDB, _ = model.NewDBModel("Open_vSwitch",

--- a/client/condition_test.go
+++ b/client/condition_test.go
@@ -16,25 +16,25 @@ func TestEqualityConditional(t *testing.T) {
 			UUID:        aUUID0,
 			Name:        "lsp0",
 			ExternalIds: map[string]string{"foo": "bar"},
-			Enabled:     []bool{true},
+			Enabled:     &trueVal,
 		},
 		&testLogicalSwitchPort{
 			UUID:        aUUID1,
 			Name:        "lsp1",
 			ExternalIds: map[string]string{"foo": "baz"},
-			Enabled:     []bool{false},
+			Enabled:     &falseVal,
 		},
 		&testLogicalSwitchPort{
 			UUID:        aUUID2,
 			Name:        "lsp2",
 			ExternalIds: map[string]string{"unique": "id"},
-			Enabled:     []bool{false},
+			Enabled:     &falseVal,
 		},
 		&testLogicalSwitchPort{
 			UUID:        aUUID3,
 			Name:        "lsp3",
 			ExternalIds: map[string]string{"foo": "baz"},
-			Enabled:     []bool{true},
+			Enabled:     &trueVal,
 		},
 	}
 	lspcache := map[string]model.Model{}
@@ -156,25 +156,25 @@ func TestPredicateConditional(t *testing.T) {
 			UUID:        aUUID0,
 			Name:        "lsp0",
 			ExternalIds: map[string]string{"foo": "bar"},
-			Enabled:     []bool{true},
+			Enabled:     &trueVal,
 		},
 		&testLogicalSwitchPort{
 			UUID:        aUUID1,
 			Name:        "lsp1",
 			ExternalIds: map[string]string{"foo": "baz"},
-			Enabled:     []bool{false},
+			Enabled:     &falseVal,
 		},
 		&testLogicalSwitchPort{
 			UUID:        aUUID2,
 			Name:        "lsp2",
 			ExternalIds: map[string]string{"unique": "id"},
-			Enabled:     []bool{false},
+			Enabled:     &falseVal,
 		},
 		&testLogicalSwitchPort{
 			UUID:        aUUID3,
 			Name:        "lsp3",
 			ExternalIds: map[string]string{"foo": "baz"},
-			Enabled:     []bool{true},
+			Enabled:     &trueVal,
 		},
 	}
 	lspcache := map[string]model.Model{}
@@ -214,7 +214,7 @@ func TestPredicateConditional(t *testing.T) {
 		{
 			name: "by random field",
 			predicate: func(lsp *testLogicalSwitchPort) bool {
-				return lsp.Enabled[0] == false
+				return lsp.Enabled != nil && *lsp.Enabled == false
 			},
 			condition: [][]ovsdb.Condition{
 				{
@@ -230,8 +230,8 @@ func TestPredicateConditional(t *testing.T) {
 						Value:    ovsdb.UUID{GoUUID: aUUID2},
 					}}},
 			matches: map[model.Model]bool{
-				&testLogicalSwitchPort{UUID: aUUID1, Enabled: []bool{true}}:  false,
-				&testLogicalSwitchPort{UUID: aUUID1, Enabled: []bool{false}}: true,
+				&testLogicalSwitchPort{UUID: aUUID1, Enabled: &trueVal}:  false,
+				&testLogicalSwitchPort{UUID: aUUID1, Enabled: &falseVal}: true,
 			},
 		},
 	}
@@ -265,25 +265,25 @@ func TestExplicitConditional(t *testing.T) {
 			UUID:        aUUID0,
 			Name:        "lsp0",
 			ExternalIds: map[string]string{"foo": "bar"},
-			Enabled:     []bool{true},
+			Enabled:     &trueVal,
 		},
 		&testLogicalSwitchPort{
 			UUID:        aUUID1,
 			Name:        "lsp1",
 			ExternalIds: map[string]string{"foo": "baz"},
-			Enabled:     []bool{false},
+			Enabled:     &falseVal,
 		},
 		&testLogicalSwitchPort{
 			UUID:        aUUID2,
 			Name:        "lsp2",
 			ExternalIds: map[string]string{"unique": "id"},
-			Enabled:     []bool{false},
+			Enabled:     &falseVal,
 		},
 		&testLogicalSwitchPort{
 			UUID:        aUUID3,
 			Name:        "lsp3",
 			ExternalIds: map[string]string{"foo": "baz"},
-			Enabled:     []bool{true},
+			Enabled:     &trueVal,
 		},
 	}
 	lspcache := map[string]model.Model{}
@@ -362,7 +362,7 @@ func TestExplicitConditional(t *testing.T) {
 				{
 					Field:    &testObj.Enabled,
 					Function: ovsdb.ConditionEqual,
-					Value:    []bool{true},
+					Value:    &trueVal,
 				},
 			},
 			result: [][]ovsdb.Condition{
@@ -370,7 +370,7 @@ func TestExplicitConditional(t *testing.T) {
 					{
 						Column:   "enabled",
 						Function: ovsdb.ConditionEqual,
-						Value:    testOvsSet(t, []bool{true}),
+						Value:    testOvsSet(t, &trueVal),
 					}}},
 		},
 		{
@@ -379,7 +379,7 @@ func TestExplicitConditional(t *testing.T) {
 				{
 					Field:    &testObj.Enabled,
 					Function: ovsdb.ConditionEqual,
-					Value:    []bool{true},
+					Value:    &trueVal,
 				},
 				{
 					Field:    &testObj.Name,
@@ -392,7 +392,7 @@ func TestExplicitConditional(t *testing.T) {
 					{
 						Column:   "enabled",
 						Function: ovsdb.ConditionEqual,
-						Value:    testOvsSet(t, []bool{true}),
+						Value:    testOvsSet(t, &trueVal),
 					}},
 				{
 					{
@@ -407,7 +407,7 @@ func TestExplicitConditional(t *testing.T) {
 				{
 					Field:    &testObj.Enabled,
 					Function: ovsdb.ConditionEqual,
-					Value:    []bool{true},
+					Value:    &trueVal,
 				},
 				{
 					Field:    &testObj.Name,
@@ -419,7 +419,7 @@ func TestExplicitConditional(t *testing.T) {
 				{
 					Column:   "enabled",
 					Function: ovsdb.ConditionEqual,
-					Value:    testOvsSet(t, []bool{true}),
+					Value:    testOvsSet(t, &trueVal),
 				},
 				{
 					Column:   "name",

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -33,7 +33,7 @@ var (
 	}
 	aFloat = 42.00
 
-	aFloatSet = []float64{
+	aFloatSet = [10]float64{
 		3.0,
 		2.0,
 		42.0,
@@ -77,7 +77,8 @@ var testSchema = []byte(`{
               "refType": "weak",
               "type": "uuid"
             },
-            "min": 0
+            "min": 0,
+            "max": "unlimited"
           }
         },
         "aUUID": {
@@ -187,12 +188,12 @@ func TestMapperGetData(t *testing.T) {
 	type ormTestType struct {
 		AString             string            `ovsdb:"aString"`
 		ASet                []string          `ovsdb:"aSet"`
-		ASingleSet          []string          `ovsdb:"aSingleSet"`
+		ASingleSet          *string           `ovsdb:"aSingleSet"`
 		AUUIDSet            []string          `ovsdb:"aUUIDSet"`
 		AUUID               string            `ovsdb:"aUUID"`
 		AIntSet             []int             `ovsdb:"aIntSet"`
 		AFloat              float64           `ovsdb:"aFloat"`
-		AFloatSet           []float64         `ovsdb:"aFloatSet"`
+		AFloatSet           [10]float64       `ovsdb:"aFloatSet"`
 		YetAnotherStringSet []string          `ovsdb:"aEmptySet"`
 		AEnum               string            `ovsdb:"aEnum"`
 		AMap                map[string]string `ovsdb:"aMap"`
@@ -202,7 +203,7 @@ func TestMapperGetData(t *testing.T) {
 	var expected = ormTestType{
 		AString:             aString,
 		ASet:                aSet,
-		ASingleSet:          []string{aString},
+		ASingleSet:          &aString,
 		AUUIDSet:            aUUIDSet,
 		AUUID:               aUUID0,
 		AIntSet:             aIntSet,
@@ -304,7 +305,7 @@ func TestMapperNewRow(t *testing.T) {
 	}, {
 		name: "aFloatSet",
 		objInput: &struct {
-			MyFloatSet []float64 `ovsdb:"aFloatSet"`
+			MyFloatSet [10]float64 `ovsdb:"aFloatSet"`
 		}{
 			MyFloatSet: aFloatSet,
 		},
@@ -880,7 +881,8 @@ func TestMapperMutation(t *testing.T) {
         "set": {
           "type": {
             "key": "string",
-            "min": 0
+            "min": 0,
+            "max": "unlimited"
           }
         },
         "map": {
@@ -890,11 +892,11 @@ func TestMapperMutation(t *testing.T) {
           }
         },
         "unmutable": {
-	  "mutable": false,
+          "mutable": false,
           "type": {
             "key": "integer"
           }
-	},
+	      },
         "int": {
           "type": {
             "key": "integer"

--- a/modelgen/table_test.go
+++ b/modelgen/table_test.go
@@ -58,7 +58,7 @@ type (
 	AtomicTableProtocol  = string
 )
 
-const (
+var (
 	AtomicTableEventTypeEmptyLbBackends AtomicTableEventType = "empty_lb_backends"
 	AtomicTableProtocolTCP              AtomicTableProtocol  = "tcp"
 	AtomicTableProtocolUDP              AtomicTableProtocol  = "udp"
@@ -67,12 +67,12 @@ const (
 
 // AtomicTable defines an object in atomicTable table
 type AtomicTable struct {
-	UUID      string                ` + "`" + `ovsdb:"_uuid"` + "`" + `
-	EventType AtomicTableEventType  ` + "`" + `ovsdb:"event_type"` + "`" + `
-	Float     float64               ` + "`" + `ovsdb:"float"` + "`" + `
-	Int       int                   ` + "`" + `ovsdb:"int"` + "`" + `
-	Protocol  []AtomicTableProtocol ` + "`" + `ovsdb:"protocol"` + "`" + `
-	Str       string                ` + "`" + `ovsdb:"str"` + "`" + `
+	UUID      string               ` + "`" + `ovsdb:"_uuid"` + "`" + `
+	EventType AtomicTableEventType ` + "`" + `ovsdb:"event_type"` + "`" + `
+	Float     float64              ` + "`" + `ovsdb:"float"` + "`" + `
+	Int       int                  ` + "`" + `ovsdb:"int"` + "`" + `
+	Protocol  *AtomicTableProtocol ` + "`" + `ovsdb:"protocol"` + "`" + `
+	Str       string               ` + "`" + `ovsdb:"str"` + "`" + `
 }
 `,
 		},
@@ -88,12 +88,12 @@ package test
 
 // AtomicTable defines an object in atomicTable table
 type AtomicTable struct {
-	UUID      string   ` + "`" + `ovsdb:"_uuid"` + "`" + `
-	EventType string   ` + "`" + `ovsdb:"event_type"` + "`" + `
-	Float     float64  ` + "`" + `ovsdb:"float"` + "`" + `
-	Int       int      ` + "`" + `ovsdb:"int"` + "`" + `
-	Protocol  []string ` + "`" + `ovsdb:"protocol"` + "`" + `
-	Str       string   ` + "`" + `ovsdb:"str"` + "`" + `
+	UUID      string  ` + "`" + `ovsdb:"_uuid"` + "`" + `
+	EventType string  ` + "`" + `ovsdb:"event_type"` + "`" + `
+	Float     float64 ` + "`" + `ovsdb:"float"` + "`" + `
+	Int       int     ` + "`" + `ovsdb:"int"` + "`" + `
+	Protocol  *string ` + "`" + `ovsdb:"protocol"` + "`" + `
+	Str       string  ` + "`" + `ovsdb:"str"` + "`" + `
 }
 `,
 		},
@@ -118,7 +118,7 @@ type (
 	AtomicTableProtocol  = string
 )
 
-const (
+var (
 	AtomicTableEventTypeEmptyLbBackends AtomicTableEventType = "empty_lb_backends"
 	AtomicTableProtocolTCP              AtomicTableProtocol  = "tcp"
 	AtomicTableProtocolUDP              AtomicTableProtocol  = "udp"
@@ -127,18 +127,18 @@ const (
 
 // AtomicTable defines an object in atomicTable table
 type AtomicTable struct {
-	UUID      string                ` + "`" + `ovsdb:"_uuid"` + "`" + `
-	EventType AtomicTableEventType  ` + "`" + `ovsdb:"event_type"` + "`" + `
-	Float     float64               ` + "`" + `ovsdb:"float"` + "`" + `
-	Int       int                   ` + "`" + `ovsdb:"int"` + "`" + `
-	Protocol  []AtomicTableProtocol ` + "`" + `ovsdb:"protocol"` + "`" + `
-	Str       string                ` + "`" + `ovsdb:"str"` + "`" + `
+	UUID      string               ` + "`" + `ovsdb:"_uuid"` + "`" + `
+	EventType AtomicTableEventType ` + "`" + `ovsdb:"event_type"` + "`" + `
+	Float     float64              ` + "`" + `ovsdb:"float"` + "`" + `
+	Int       int                  ` + "`" + `ovsdb:"int"` + "`" + `
+	Protocol  *AtomicTableProtocol ` + "`" + `ovsdb:"protocol"` + "`" + `
+	Str       string               ` + "`" + `ovsdb:"str"` + "`" + `
 
 	OtherUUID      string
 	OtherEventType string
 	OtherFloat     float64
 	OtherInt       int
-	OtherProtocol  []string
+	OtherProtocol  *string
 	OtherStr       string
 }
 `,
@@ -167,7 +167,7 @@ type (
 	AtomicTableProtocol  = string
 )
 
-const (
+var (
 	AtomicTableEventTypeEmptyLbBackends AtomicTableEventType = "empty_lb_backends"
 	AtomicTableProtocolTCP              AtomicTableProtocol  = "tcp"
 	AtomicTableProtocolUDP              AtomicTableProtocol  = "udp"
@@ -176,12 +176,12 @@ const (
 
 // AtomicTable defines an object in atomicTable table
 type AtomicTable struct {
-	UUID      string                ` + "`" + `ovsdb:"_uuid"` + "`" + `
-	EventType AtomicTableEventType  ` + "`" + `ovsdb:"event_type"` + "`" + `
-	Float     float64               ` + "`" + `ovsdb:"float"` + "`" + `
-	Int       int                   ` + "`" + `ovsdb:"int"` + "`" + `
-	Protocol  []AtomicTableProtocol ` + "`" + `ovsdb:"protocol"` + "`" + `
-	Str       string                ` + "`" + `ovsdb:"str"` + "`" + `
+	UUID      string               ` + "`" + `ovsdb:"_uuid"` + "`" + `
+	EventType AtomicTableEventType ` + "`" + `ovsdb:"event_type"` + "`" + `
+	Float     float64              ` + "`" + `ovsdb:"float"` + "`" + `
+	Int       int                  ` + "`" + `ovsdb:"int"` + "`" + `
+	Protocol  *AtomicTableProtocol ` + "`" + `ovsdb:"protocol"` + "`" + `
+	Str       string               ` + "`" + `ovsdb:"str"` + "`" + `
 }
 
 func TestFunc() string {

--- a/ovsdb/bindings.go
+++ b/ovsdb/bindings.go
@@ -20,7 +20,7 @@ type ErrWrongType struct {
 }
 
 func (e *ErrWrongType) Error() string {
-	return fmt.Sprintf("Wrong Type (%s): expected %s but got %s (%s)",
+	return fmt.Sprintf("Wrong Type (%s): expected %s but got %+v (%s)",
 		e.from, e.expected, e.got, reflect.TypeOf(e.got))
 }
 
@@ -54,7 +54,7 @@ func NativeTypeFromAtomic(basicType string) reflect.Type {
 
 //NativeType returns the reflect.Type that can hold the value of a column
 //OVS Type to Native Type convertions:
-// OVS sets -> go slices
+// OVS sets -> go slices, arrays or a go native type depending on the key
 // OVS uuid -> go strings
 // OVS map  -> go map
 // OVS enum -> go native type depending on the type of the enum key
@@ -70,6 +70,18 @@ func NativeType(column *ColumnSchema) reflect.Type {
 		return reflect.MapOf(keyType, valueType)
 	case TypeSet:
 		keyType := NativeTypeFromAtomic(column.TypeObj.Key.Type)
+		// optional type
+		if column.TypeObj.Min() == 0 && column.TypeObj.Max() == 1 {
+			return reflect.PtrTo(keyType)
+		}
+		// non-optional type with max 1
+		if column.TypeObj.Min() == 1 && column.TypeObj.Max() == 1 {
+			return keyType
+		}
+		// max is > 1, use an array
+		if column.TypeObj.Max() > 1 {
+			return reflect.ArrayOf(column.TypeObj.Max(), keyType)
+		}
 		return reflect.SliceOf(keyType)
 	default:
 		panic(fmt.Errorf("unknown extended type %s", column.Type))
@@ -114,31 +126,77 @@ func OvsToNative(column *ColumnSchema, ovsElem interface{}) (interface{}, error)
 		naType := NativeType(column)
 		// The inner slice is []interface{}
 		// We need to convert it to the real type os slice
-		var nativeSet reflect.Value
-
-		// RFC says that for a set of exactly one, an atomic type an be sent
-		switch ovsSet := ovsElem.(type) {
-		case OvsSet:
-			nativeSet = reflect.MakeSlice(naType, 0, len(ovsSet.GoSet))
-			for _, v := range ovsSet.GoSet {
-				nv, err := OvsToNativeAtomic(column.TypeObj.Key.Type, v)
+		switch naType.Kind() {
+		case reflect.Ptr:
+			switch ovsSet := ovsElem.(type) {
+			case OvsSet:
+				if len(ovsSet.GoSet) > 1 {
+					return nil, fmt.Errorf("expected a slice of len =< 1, but got a slice with %d elements", len(ovsSet.GoSet))
+				}
+				if len(ovsSet.GoSet) == 0 {
+					return reflect.Zero(naType).Interface(), nil
+				}
+				native, err := OvsToNativeAtomic(column.TypeObj.Key.Type, ovsSet.GoSet[0])
 				if err != nil {
 					return nil, err
 				}
+				pv := reflect.New(naType.Elem())
+				pv.Elem().Set(reflect.ValueOf(native))
+				return pv.Interface(), nil
+			default:
+				native, err := OvsToNativeAtomic(column.TypeObj.Key.Type, ovsElem)
+				if err != nil {
+					return nil, err
+				}
+				pv := reflect.New(naType.Elem())
+				pv.Elem().Set(reflect.ValueOf(native))
+				return pv.Interface(), nil
+			}
+		case reflect.Array:
+			array := reflect.New(reflect.ArrayOf(column.TypeObj.Max(), naType.Elem())).Elem()
+			switch ovsSet := ovsElem.(type) {
+			case OvsSet:
+				for i, v := range ovsSet.GoSet {
+					nv, err := OvsToNativeAtomic(column.TypeObj.Key.Type, v)
+					if err != nil {
+						return nil, err
+					}
+					array.Index(i).Set(reflect.ValueOf(nv))
+				}
+			default:
+				nv, err := OvsToNativeAtomic(column.TypeObj.Key.Type, ovsElem)
+				if err != nil {
+					return nil, err
+				}
+				array.Index(0).Set(reflect.ValueOf(nv))
+			}
+			return array.Interface(), nil
+		case reflect.Slice:
+			var nativeSet reflect.Value
+			switch ovsSet := ovsElem.(type) {
+			case OvsSet:
+				nativeSet = reflect.MakeSlice(naType, 0, len(ovsSet.GoSet))
+				for _, v := range ovsSet.GoSet {
+					nv, err := OvsToNativeAtomic(column.TypeObj.Key.Type, v)
+					if err != nil {
+						return nil, err
+					}
+					nativeSet = reflect.Append(nativeSet, reflect.ValueOf(nv))
+				}
+
+			default:
+				nativeSet = reflect.MakeSlice(naType, 0, 1)
+				nv, err := OvsToNativeAtomic(column.TypeObj.Key.Type, ovsElem)
+				if err != nil {
+					return nil, err
+				}
+
 				nativeSet = reflect.Append(nativeSet, reflect.ValueOf(nv))
 			}
-
+			return nativeSet.Interface(), nil
 		default:
-			nativeSet = reflect.MakeSlice(naType, 0, 1)
-			nv, err := OvsToNativeAtomic(column.TypeObj.Key.Type, ovsElem)
-			if err != nil {
-				return nil, err
-			}
-
-			nativeSet = reflect.Append(nativeSet, reflect.ValueOf(nv))
+			return nil, fmt.Errorf("native type was not slice, array or pointer. got %d", naType.Kind())
 		}
-		return nativeSet.Interface(), nil
-
 	case TypeMap:
 		naType := NativeType(column)
 		ovsMap, ok := ovsElem.(OvsMap)
@@ -354,11 +412,16 @@ func isDefaultBaseValue(elem interface{}, etype ExtendedType) bool {
 	if !value.IsValid() {
 		return true
 	}
-
+	if reflect.TypeOf(elem).Kind() == reflect.Ptr {
+		return reflect.ValueOf(elem).IsZero()
+	}
 	switch etype {
 	case TypeUUID:
 		return elem.(string) == "00000000-0000-0000-0000-000000000000" || elem.(string) == "" || isNamed(elem.(string))
 	case TypeMap, TypeSet:
+		if value.Kind() == reflect.Array {
+			return value.Len() == 0
+		}
 		return value.IsNil() || value.Len() == 0
 	case TypeString:
 		return elem.(string) == ""

--- a/ovsdb/notation_test.go
+++ b/ovsdb/notation_test.go
@@ -86,11 +86,10 @@ func TestValidateOvsSet(t *testing.T) {
 		t.Error("Expected: ", expected, "Got", string(data))
 	}
 	// Negative condition test
-	integer := 5
-	_, err = NewOvsSet(&integer)
+	oSet, err = NewOvsSet(struct{ foo string }{})
 	if err == nil {
 		t.Error("OvsSet must fail for anything other than Slices and atomic types")
-		t.Error("Expected: ", expected, "Got", string(data))
+		t.Error("Got", oSet)
 	}
 }
 


### PR DESCRIPTION
This PR changes:

1. Modelgen to generate pointers to an atomic type when it is a set with a min value of 0 and a max value of 1
2. Modelgen to generate arrays for fixed size sets (e.g max != unlimited)
3. Bindings to cope with these new types

Fixes: #191 