### PR TITLE
cache: rlock row by model

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -90,6 +90,8 @@ func (r *RowCache) Row(uuid string) model.Model {
 
 // RowByModel searches the cache using a the indexes for a provided model
 func (r *RowCache) RowByModel(m model.Model) model.Model {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
 	if reflect.TypeOf(m) != r.dataType {
 		return nil
 	}


### PR DESCRIPTION
Fixes
```
WARNING: DATA RACE^M
Write at 0x00c058cc14d0 by goroutine 1665:^M
  runtime.mapassign()^M
      /usr/local/go/src/runtime/map.go:571 +0x0^M
  github.com/ovn-org/libovsdb/cache.(*RowCache).Create()^M
      /go/src/github.com/ovn-org/ovn-kubernetes/go-controller/vendor/github.com/ovn-org/libovsdb/cache/cache.go:147 +0xb35^M
  github.com/ovn-org/libovsdb/cache.(*TableCache).Populate()^M
      /go/src/github.com/ovn-org/ovn-kubernetes/go-controller/vendor/github.com/ovn-org/libovsdb/cache/cache.go:442 +0x5a5^M
  github.com/ovn-org/libovsdb/cache.(*TableCache).Update()^M
      /go/src/github.com/ovn-org/ovn-kubernetes/go-controller/vendor/github.com/ovn-org/libovsdb/cache/cache.go:396 +0x2da^M
  github.com/ovn-org/libovsdb/client.(*ovsdbClient).update()^M
      /go/src/github.com/ovn-org/ovn-kubernetes/go-controller/vendor/github.com/ovn-org/libovsdb/client/client.go:306 +0x1e5^M
  github.com/ovn-org/libovsdb/client.(*ovsdbClient).createRPC2Client.func2()^M
      /go/src/github.com/ovn-org/ovn-kubernetes/go-controller/vendor/github.com/ovn-org/libovsdb/client/client.go:236 +0x6d^M
  runtime.call64()^M
      /usr/local/go/src/runtime/asm_amd64.s:552 +0x3d^M
  reflect.Value.Call()^M
      /usr/local/go/src/reflect/value.go:337 +0xd8^M
  github.com/cenkalti/rpc2.(*Client).handleRequest()^M
      /go/src/github.com/ovn-org/ovn-kubernetes/go-controller/vendor/github.com/cenkalti/rpc2/client.go:134 +0x231^M
  github.com/cenkalti/rpc2.(*Client).readRequest()^M
      /go/src/github.com/ovn-org/ovn-kubernetes/go-controller/vendor/github.com/cenkalti/rpc2/client.go:184 +0x328^M
  github.com/cenkalti/rpc2.(*Client).readLoop()^M
      /go/src/github.com/ovn-org/ovn-kubernetes/go-controller/vendor/github.com/cenkalti/rpc2/client.go:93 +0x264^M
  github.com/cenkalti/rpc2.(*Client).Run()^M
      /go/src/github.com/ovn-org/ovn-kubernetes/go-controller/vendor/github.com/cenkalti/rpc2/client.go:62 +0x38^M
^M
Previous read at 0x00c058cc14d0 by goroutine 935:^M
  runtime.mapaccess2()^M
      /usr/local/go/src/runtime/map.go:452 +0x0^M
  github.com/ovn-org/libovsdb/cache.(*RowCache).RowByModel()^M
      /go/src/github.com/ovn-org/ovn-kubernetes/go-controller/vendor/github.com/ovn-org/libovsdb/cache/cache.go:109 +0x39e^M
  github.com/ovn-org/libovsdb/client.api.Get()^M
      /go/src/github.com/ovn-org/ovn-kubernetes/go-controller/vendor/github.com/ovn-org/libovsdb/client/api.go:219 +0xf5^M
  github.com/ovn-org/libovsdb/client.(*api).Get()^M
      <autogenerated>:1 +0x9b^M
  github.com/ovn-org/libovsdb/client.(*ovsdbClient).Get()^M
      /go/src/github.com/ovn-org/ovn-kubernetes/go-controller/vendor/github.com/ovn-org/libovsdb/client/client.go:587 +0x76^M
  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.glob..func12.4.1.1.1.1()^M
      /go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/policy_test.go:1022 +0x151^M
  runtime.call64()^M
      /usr/local/go/src/runtime/asm_amd64.s:552 +0x3d^M
  reflect.Value.Call()^M
  ...
```

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>