### PR TITLE
server: mutate insert only if not present

### DIFF
--- a/server/mutate.go
+++ b/server/mutate.go
@@ -16,6 +16,15 @@ func removeFromSlice(a, b reflect.Value) reflect.Value {
 	return a
 }
 
+func insertToSlice(a, b reflect.Value) reflect.Value {
+	for i := 0; i < a.Len(); i++ {
+		if a.Index(i).Interface() == b.Interface() {
+			return a
+		}
+	}
+	return reflect.Append(a, b)
+}
+
 func mutate(current interface{}, mutator ovsdb.Mutator, value interface{}) interface{} {
 	switch current.(type) {
 	case bool, string:
@@ -48,11 +57,14 @@ func mutateInsert(current, value interface{}) interface{} {
 	vc := reflect.ValueOf(current)
 	vv := reflect.ValueOf(value)
 	if vc.Kind() == reflect.Slice && vc.Type() == reflect.SliceOf(vv.Type()) {
-		v := reflect.Append(vc, vv)
+		v := insertToSlice(vc, vv)
 		return v.Interface()
 	}
 	if vc.Kind() == reflect.Slice && vv.Kind() == reflect.Slice {
-		v := reflect.AppendSlice(vc, vv)
+		v := vc
+		for i := 0; i < vv.Len(); i++ {
+			v = insertToSlice(v, vv.Index(i))
+		}
 		return v.Interface()
 	}
 	return current

--- a/server/mutate_test.go
+++ b/server/mutate_test.go
@@ -246,10 +246,17 @@ func TestMutateInsert(t *testing.T) {
 			[]string{"foo", "bar", "baz"},
 		},
 		{
+			"insert existing string",
+			[]string{"foo", "bar", "baz"},
+			ovsdb.MutateOperationInsert,
+			"baz",
+			[]string{"foo", "bar", "baz"},
+		},
+		{
 			"insert multiple string",
 			[]string{"foo", "bar"},
 			ovsdb.MutateOperationInsert,
-			[]string{"baz", "quux"},
+			[]string{"baz", "quux", "foo"},
 			[]string{"foo", "bar", "baz", "quux"},
 		},
 	}


### PR DESCRIPTION
From rfc7047 5.1:
"If <mutator> is "insert", then each of the values in the set in
<value> is added to <column> if it is not already present."

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>