### PR TITLE
Multi-database fixes for client and server

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -540,7 +540,7 @@ func (o *ovsdbClient) transact(ctx context.Context, dbName string, operation ...
 		return nil, fmt.Errorf("validation failed for the operation")
 	}
 
-	args := ovsdb.NewTransactArgs(o.primaryDBName, operation...)
+	args := ovsdb.NewTransactArgs(dbName, operation...)
 
 	if o.rpcClient == nil {
 		return nil, ErrNotConnected


### PR DESCRIPTION
First commit fixes querying the secondary database (eg, _Server).

Second commit prevents multiple monitors from filtering out data intended for the other monitors.

Fixes: https://github.com/ovn-org/libovsdb/pull/221/commits/349a5ccbff7027ac10e0e9844ea6cb375fa9c5ac

@squeed @dave-tucker 