### PR TITLE
bindings: convert optional nil pointers to empty sets

### DIFF
--- a/ovsdb/bindings.go
+++ b/ovsdb/bindings.go
@@ -258,7 +258,7 @@ func NativeToOvs(column *ColumnSchema, rawElem interface{}) (interface{}, error)
 	case TypeSet:
 		var ovsSet OvsSet
 		if column.TypeObj.Key.Type == TypeUUID {
-			var ovsSlice []interface{}
+			ovsSlice := []interface{}{}
 			if _, ok := rawElem.([]string); ok {
 				for _, v := range rawElem.([]string) {
 					uuid := UUID{GoUUID: v}
@@ -266,8 +266,10 @@ func NativeToOvs(column *ColumnSchema, rawElem interface{}) (interface{}, error)
 				}
 			} else if _, ok := rawElem.(*string); ok {
 				v := rawElem.(*string)
-				uuid := UUID{GoUUID: *v}
-				ovsSlice = append(ovsSlice, uuid)
+				if v != nil {
+					uuid := UUID{GoUUID: *v}
+					ovsSlice = append(ovsSlice, uuid)
+				}
 			} else {
 				return nil, fmt.Errorf("uuid slice was neither []string or *string")
 			}

--- a/ovsdb/bindings_test.go
+++ b/ovsdb/bindings_test.go
@@ -395,6 +395,23 @@ func TestOvsToNativeAndNativeToOvs(t *testing.T) {
 			ovs:    aSingleUUIDSet,
 		},
 		{
+			name: "null UUID set with min 0 max 1",
+			schema: []byte(`{
+			"type":{
+				"key": {
+					"refTable": "SomeOtherTAble",
+					"refType": "weak",
+					"type": "uuid"
+				},
+				"min": 0,
+				"max": 1
+			}
+			}`),
+			input:  es,
+			native: (*string)(nil),
+			ovs:    es,
+		},
+		{
 			name: "A string with min 0 max 1",
 			schema: []byte(`{
 			"type":{


### PR DESCRIPTION
An optional field can be a nil pointer which represents, in this case,
an empty set.

Make NativeToOvs convert nil pointers to empty OvsSets so Update()
operations that want to clear an optional field work.

Fixes: #230 
Signed-off-by: Adrian Moreno <amorenoz@redhat.com>