### PR TITLE
server: Fix diff of non-normalized fields

### DIFF
--- a/server/transact.go
+++ b/server/transact.go
@@ -251,7 +251,13 @@ func (o *OvsdbServer) Update(database, table string, where []ovsdb.Condition, ro
 			if err != nil {
 				panic(err)
 			}
-			rowDelta[column] = diff(oldValue, value)
+			// convert the native to an ovs value
+			// since the value in the RowUpdate hasn't been normalized
+			newValue, err := ovsdb.NativeToOvs(colSchema, native)
+			if err != nil {
+				panic(err)
+			}
+			rowDelta[column] = diff(oldValue, newValue)
 		}
 
 		newRow, err := m.NewRow(table, new)


### PR DESCRIPTION
Since there are many valid ways of notating a Set with min: 0 and max: 1
we could encounter values in the diff function that aren't OvsSet. It's
easier to convert this to a normalized value using NativeToOvs than to
update the diff logic.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>