### PR TITLE
cache: Fix Delete Handling

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -606,10 +606,11 @@ func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) {
 					t.eventProcessor.AddEvent(updateEvent, table, existing, modified)
 				}
 			case row.Delete != nil:
-				m, err := t.CreateModel(table, row.Delete, uuid)
-				if err != nil {
-					panic(err)
-				}
+				fallthrough
+			default:
+				// If everything else is nil (including Delete because it's a key with
+				// no value on the wire), then process a delete
+				m := tCache.Row(uuid)
 				if err := tCache.Delete(uuid); err != nil {
 					panic(err)
 				}

--- a/server/transact.go
+++ b/server/transact.go
@@ -467,7 +467,8 @@ func (o *OvsdbServer) Delete(database, table string, where []ovsdb.Condition) (o
 			panic(err)
 		}
 		tableUpdate.AddRowUpdate(uuid.(string), &ovsdb.RowUpdate2{
-			Delete: &oldRow,
+			Delete: &ovsdb.Row{},
+			Old:    &oldRow,
 		})
 	}
 	return ovsdb.OperationResult{

--- a/test/ovs/ovs_integration_test.go
+++ b/test/ovs/ovs_integration_test.go
@@ -505,6 +505,12 @@ func (suite *OVSIntegrationSuite) TestInsertAndDeleteTransactIntegration() {
 		}
 		suite.T().Fatal(err)
 	}
+
+	require.Eventually(suite.T(), func() bool {
+		br := &bridgeType{UUID: bridgeUUID}
+		err := suite.client.Get(br)
+		return err != nil
+	}, 2*time.Second, 500*time.Millisecond)
 }
 
 func (suite *OVSIntegrationSuite) TestTableSchemaValidationIntegration() {


### PR DESCRIPTION
We can't rely on the Delete field of RowUpdate2 being non-nil as
ovsdb-server sends a {"delete": null} which the Go JSON parser makes
equivalent to nil.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>