### PR TITLE
More Robust Error Handling For Cache Issues

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -721,7 +721,8 @@ func TestTableCache_populate(t *testing.T) {
 			},
 		},
 	}
-	tc.Populate(updates)
+	err = tc.Populate(updates)
+	require.NoError(t, err)
 
 	got := tc.Table("Open_vSwitch").Row("test")
 	assert.Equal(t, testRowModel, got)
@@ -733,7 +734,8 @@ func TestTableCache_populate(t *testing.T) {
 		Old: &testRow,
 		New: &updatedRow,
 	}
-	tc.Populate(updates)
+	err = tc.Populate(updates)
+	require.NoError(t, err)
 
 	got = tc.cache["Open_vSwitch"].cache["test"]
 	assert.Equal(t, updatedRowModel, got)
@@ -744,7 +746,8 @@ func TestTableCache_populate(t *testing.T) {
 		New: nil,
 	}
 
-	tc.Populate(updates)
+	err = tc.Populate(updates)
+	require.NoError(t, err)
 
 	_, ok := tc.cache["Open_vSwitch"].cache["test"]
 	assert.False(t, ok)
@@ -786,7 +789,8 @@ func TestTableCachePopulate(t *testing.T) {
 			},
 		},
 	}
-	tc.Populate(updates)
+	err = tc.Populate(updates)
+	require.NoError(t, err)
 
 	got := tc.Table("Open_vSwitch").Row("test")
 	assert.Equal(t, testRowModel, got)
@@ -798,7 +802,8 @@ func TestTableCachePopulate(t *testing.T) {
 		Old: &testRow,
 		New: &updatedRow,
 	}
-	tc.Populate(updates)
+	err = tc.Populate(updates)
+	require.NoError(t, err)
 
 	got = tc.cache["Open_vSwitch"].cache["test"]
 	assert.Equal(t, updatedRowModel, got)
@@ -809,7 +814,8 @@ func TestTableCachePopulate(t *testing.T) {
 		New: nil,
 	}
 
-	tc.Populate(updates)
+	err = tc.Populate(updates)
+	require.NoError(t, err)
 
 	_, ok := tc.cache["Open_vSwitch"].cache["test"]
 	assert.False(t, ok)
@@ -851,7 +857,8 @@ func TestTableCachePopulate2(t *testing.T) {
 	}
 
 	t.Log("Initial")
-	tc.Populate2(updates)
+	err = tc.Populate2(updates)
+	require.NoError(t, err)
 	got := tc.Table("Open_vSwitch").Row("test")
 	assert.Equal(t, testRowModel, got)
 
@@ -865,7 +872,8 @@ func TestTableCachePopulate2(t *testing.T) {
 			},
 		},
 	}
-	tc.Populate2(updates)
+	err = tc.Populate2(updates)
+	require.NoError(t, err)
 	got = tc.Table("Open_vSwitch").Row("test2")
 	assert.Equal(t, testRowModel2, got)
 
@@ -879,7 +887,8 @@ func TestTableCachePopulate2(t *testing.T) {
 			},
 		},
 	}
-	tc.Populate2(updates)
+	err = tc.Populate2(updates)
+	require.NoError(t, err)
 	got = tc.cache["Open_vSwitch"].cache["test"]
 	assert.Equal(t, updatedRowModel, got)
 
@@ -892,7 +901,8 @@ func TestTableCachePopulate2(t *testing.T) {
 			},
 		},
 	}
-	tc.Populate2(updates)
+	err = tc.Populate2(updates)
+	require.NoError(t, err)
 	_, ok := tc.cache["Open_vSwitch"].cache["test"]
 	assert.False(t, ok)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -795,14 +795,14 @@ func (o *ovsdbClient) monitor(ctx context.Context, cookie MonitorCookie, reconne
 		u := tableUpdates.(ovsdb.TableUpdates)
 		db.cacheMutex.Lock()
 		defer db.cacheMutex.Unlock()
-		db.cache.Populate(u)
+		err = db.cache.Populate(u)
 	} else {
 		u := tableUpdates.(ovsdb.TableUpdates2)
 		db.cacheMutex.Lock()
 		defer db.cacheMutex.Unlock()
-		db.cache.Populate2(u)
+		err = db.cache.Populate2(u)
 	}
-	return nil
+	return err
 }
 
 // Echo tests the liveness of the OVSDB connetion

--- a/client/client.go
+++ b/client/client.go
@@ -795,12 +795,12 @@ func (o *ovsdbClient) monitor(ctx context.Context, cookie MonitorCookie, reconne
 		u := tableUpdates.(ovsdb.TableUpdates)
 		db.cacheMutex.Lock()
 		defer db.cacheMutex.Unlock()
-		db.cache.Update(nil, u)
+		db.cache.Populate(u)
 	} else {
 		u := tableUpdates.(ovsdb.TableUpdates2)
 		db.cacheMutex.Lock()
 		defer db.cacheMutex.Unlock()
-		db.cache.Update2(nil, u)
+		db.cache.Populate2(u)
 	}
 	return nil
 }
@@ -870,7 +870,7 @@ func (o *ovsdbClient) watchForLeaderChange() error {
 
 func (o *ovsdbClient) handleDisconnectNotification() {
 	<-o.rpcClient.DisconnectNotify()
-	// close the stopCh, which will stop the cache event processor
+	// close the stopCh, which will stop the cache event processor and update processing
 	close(o.stopCh)
 	o.metrics.numDisconnects.Inc()
 	o.rpcMutex.Lock()

--- a/server/database.go
+++ b/server/database.go
@@ -64,8 +64,7 @@ func (db *inMemoryDatabase) Commit(database string, id uuid.UUID, updates ovsdb.
 	db.mutex.RLock()
 	targetDb := db.databases[database]
 	db.mutex.RLock()
-	targetDb.Populate2(updates)
-	return nil
+	return targetDb.Populate2(updates)
 }
 
 func (db *inMemoryDatabase) CheckIndexes(database string, table string, m model.Model) error {


### PR DESCRIPTION
1. Put Updates Received from RPC calls in to a buffered channel. This ensures that we process updates **after** we've processed the initial cache contents
2. Ensure the cache cannot panic
3. When we get errors that would cause cache inconsistencies, trigger a reconnect so the cache is purged and rebuilt when the monitor is established.