### PR TITLE
Refactor Database Model and Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,16 @@ To make the API use go idioms, the following mappings occur:
 1. OVSDB Map = Map
 1. OVSDB Scalar Type = Equivalent scalar Go type
 
-A Open vSwitch Database is modeled using a DBModel which is a created by assigning table names to pointers to these structs:
+A Open vSwitch Database is modeled using a ClientDBModel which is a created by assigning table names to pointers to these structs:
 
-    dbModel, _ := model.NewDBModel("OVN_Northbound", map[string]model.Model{
+    dbModelReq, _ := model.NewClientDBModel("OVN_Northbound", map[string]model.Model{
                 "Logical_Switch": &MyLogicalSwitch{},
     })
 
 
 Finally, a client object can be created:
 
-    ovs, _ := client.Connect(context.Background(), dbModel, client.WithEndpoint("tcp:172.18.0.4:6641"))
+    ovs, _ := client.Connect(context.Background(), dbModelReq, client.WithEndpoint("tcp:172.18.0.4:6641"))
     client.MonitorAll(nil) // Only needed if you want to use the built-in cache
 
 
@@ -219,7 +219,7 @@ It can be used as follows:
             Package name (default "ovsmodel")
 
 The result will be the definition of a Model per table defined in the ovsdb schema file.
-Additionally, a function called `FullDatabaseModel()` that returns the `DBModel` is created for convenience.
+Additionally, a function called `FullDatabaseModel()` that returns the `ClientDBModel` is created for convenience.
 
 Example:
 
@@ -237,7 +237,7 @@ Run `go generate`
     go generate ./...
 
 
-In your application, load the DBModel, connect to the server and start interacting with the database:
+In your application, load the ClientDBModel, connect to the server and start interacting with the database:
 
     import (
         "fmt"
@@ -247,8 +247,8 @@ In your application, load the DBModel, connect to the server and start interacti
     )
     
     func main() {
-        dbModel, _ := generated.FullDatabaseModel()
-        ovs, _ := client.Connect(context.Background(), dbModel, client.WithEndpoint("tcp:localhost:6641"))
+        dbModelReq, _ := generated.FullDatabaseModel()
+        ovs, _ := client.Connect(context.Background(), dbModelReq, client.WithEndpoint("tcp:localhost:6641"))
         ovs.MonitorAll()
 
         // Create a *LogicalRouter, as a pointer to a Model is required by the API

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -451,7 +451,7 @@ func NewTableCache(dbModel *model.DatabaseModel, data Data, logger *logr.Logger)
 	}
 	eventProcessor := newEventProcessor(bufferSize, logger)
 	cache := make(map[string]*RowCache)
-	tableTypes := dbModel.Client().Types()
+	tableTypes := dbModel.Types()
 	for name, tableSchema := range dbModel.Schema().Tables {
 		cache[name] = newRowCache(name, tableSchema, tableTypes[name])
 	}
@@ -482,9 +482,9 @@ func (t *TableCache) Mapper() *mapper.Mapper {
 	return t.dbModel.Mapper()
 }
 
-// ClientDBModel returns the ClientDBModel
-func (t *TableCache) ClientDBModel() *model.ClientDBModel {
-	return t.dbModel.Client()
+// DatabaseModel returns the DatabaseModelRequest
+func (t *TableCache) DatabaseModel() *model.DatabaseModel {
+	return t.dbModel
 }
 
 // Table returns the a Table from the cache with a given name
@@ -549,7 +549,7 @@ func (t *TableCache) Populate(tableUpdates ovsdb.TableUpdates) error {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
-	for table := range t.dbModel.Client().Types() {
+	for table := range t.dbModel.Types() {
 		updates, ok := tableUpdates[table]
 		if !ok {
 			continue
@@ -600,7 +600,7 @@ func (t *TableCache) Populate(tableUpdates ovsdb.TableUpdates) error {
 func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) error {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
-	for table := range t.dbModel.Client().Types() {
+	for table := range t.dbModel.Types() {
 		updates, ok := tableUpdates[table]
 		if !ok {
 			continue
@@ -672,7 +672,7 @@ func (t *TableCache) Purge(dbModel *model.DatabaseModel) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 	t.dbModel = dbModel
-	tableTypes := t.dbModel.Client().Types()
+	tableTypes := t.dbModel.Types()
 	for name, tableSchema := range t.dbModel.Schema().Tables {
 		t.cache[name] = newRowCache(name, tableSchema, tableTypes[name])
 	}
@@ -851,7 +851,7 @@ func (t *TableCache) CreateModel(tableName string, row *ovsdb.Row, uuid string) 
 	if table == nil {
 		return nil, fmt.Errorf("table %s not found", tableName)
 	}
-	model, err := t.dbModel.Client().NewModel(tableName)
+	model, err := t.dbModel.NewModel(tableName)
 	if err != nil {
 		return nil, err
 	}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -105,7 +105,8 @@ func TestRowCacheCreate(t *testing.T) {
 	testData := Data{
 		"Open_vSwitch": map[string]model.Model{"bar": &testModel{Foo: "bar"}},
 	}
-	tc, err := NewTableCache(&schema, db, testData, nil)
+	dbModel := model.NewDatabaseModel(&schema, db)
+	tc, err := NewTableCache(dbModel, testData, nil)
 	require.Nil(t, err)
 
 	tests := []struct {
@@ -192,7 +193,8 @@ func TestRowCacheCreateMultiIndex(t *testing.T) {
 	testData := Data{
 		"Open_vSwitch": map[string]model.Model{"bar": &testModel{Foo: "bar", Bar: "bar"}},
 	}
-	tc, err := NewTableCache(&schema, db, testData, nil)
+	dbModel := model.NewDatabaseModel(&schema, db)
+	tc, err := NewTableCache(dbModel, testData, nil)
 	require.Nil(t, err)
 	tests := []struct {
 		name               string
@@ -287,7 +289,8 @@ func TestRowCacheUpdate(t *testing.T) {
 			"foobar": &testModel{Foo: "foobar"},
 		},
 	}
-	tc, err := NewTableCache(&schema, db, testData, nil)
+	dbModel := model.NewDatabaseModel(&schema, db)
+	tc, err := NewTableCache(dbModel, testData, nil)
 	require.Nil(t, err)
 
 	tests := []struct {
@@ -370,7 +373,8 @@ func TestRowCacheUpdateMultiIndex(t *testing.T) {
 			"foobar": &testModel{Foo: "foobar", Bar: "foobar"},
 		},
 	}
-	tc, err := NewTableCache(&schema, db, testData, nil)
+	dbModel := model.NewDatabaseModel(&schema, db)
+	tc, err := NewTableCache(dbModel, testData, nil)
 	require.Nil(t, err)
 
 	tests := []struct {
@@ -450,7 +454,8 @@ func TestRowCacheDelete(t *testing.T) {
 			"bar": &testModel{Foo: "bar"},
 		},
 	}
-	tc, err := NewTableCache(&schema, db, testData, nil)
+	dbModel := model.NewDatabaseModel(&schema, db)
+	tc, err := NewTableCache(dbModel, testData, nil)
 	require.Nil(t, err)
 
 	tests := []struct {
@@ -706,7 +711,8 @@ func TestTableCache_populate(t *testing.T) {
 	     }
 	`), &schema)
 	assert.Nil(t, err)
-	tc, err := NewTableCache(&schema, db, nil, nil)
+	dbModel := model.NewDatabaseModel(&schema, db)
+	tc, err := NewTableCache(dbModel, nil, nil)
 	assert.Nil(t, err)
 
 	testRow := ovsdb.Row(map[string]interface{}{"_uuid": "test", "foo": "bar"})
@@ -774,7 +780,8 @@ func TestTableCachePopulate(t *testing.T) {
 	     }
 	`), &schema)
 	assert.Nil(t, err)
-	tc, err := NewTableCache(&schema, db, nil, nil)
+	dbModel := model.NewDatabaseModel(&schema, db)
+	tc, err := NewTableCache(dbModel, nil, nil)
 	assert.Nil(t, err)
 
 	testRow := ovsdb.Row(map[string]interface{}{"_uuid": "test", "foo": "bar"})
@@ -841,7 +848,8 @@ func TestTableCachePopulate2(t *testing.T) {
 	     }
 	`), &schema)
 	assert.Nil(t, err)
-	tc, err := NewTableCache(&schema, db, nil, nil)
+	dbModel := model.NewDatabaseModel(&schema, db)
+	tc, err := NewTableCache(dbModel, nil, nil)
 	assert.Nil(t, err)
 
 	testRow := ovsdb.Row(map[string]interface{}{"_uuid": "test", "foo": "bar"})
@@ -967,7 +975,8 @@ func TestIndex(t *testing.T) {
 	     }
 	`), &schema)
 	assert.Nil(t, err)
-	tc, err := NewTableCache(&schema, db, nil, nil)
+	dbModel := model.NewDatabaseModel(&schema, db)
+	tc, err := NewTableCache(dbModel, nil, nil)
 	assert.Nil(t, err)
 	obj := &indexTestModel{
 		UUID: "test1",
@@ -1065,7 +1074,8 @@ func TestTableCacheRowByModelSingleIndex(t *testing.T) {
 			"bar": &testModel{Foo: "bar", Bar: "bar"},
 		},
 	}
-	tc, err := NewTableCache(&schema, db, testData, nil)
+	dbModel := model.NewDatabaseModel(&schema, db)
+	tc, err := NewTableCache(dbModel, testData, nil)
 	require.NoError(t, err)
 
 	t.Run("get foo by index", func(t *testing.T) {
@@ -1114,7 +1124,8 @@ func TestTableCacheRowByModelTwoIndexes(t *testing.T) {
 			"bar": &testModel{Foo: "bar", Bar: "bar"},
 		},
 	}
-	tc, err := NewTableCache(&schema, db, testData, nil)
+	dbModel := model.NewDatabaseModel(&schema, db)
+	tc, err := NewTableCache(dbModel, testData, nil)
 	require.NoError(t, err)
 
 	t.Run("get foo by Foo index", func(t *testing.T) {
@@ -1162,7 +1173,8 @@ func TestTableCacheRowByModelMultiIndex(t *testing.T) {
 	testData := Data{
 		"Open_vSwitch": map[string]model.Model{"foo": myFoo, "bar": &testModel{Foo: "bar", Bar: "bar"}},
 	}
-	tc, err := NewTableCache(&schema, db, testData, nil)
+	dbModel := model.NewDatabaseModel(&schema, db)
+	tc, err := NewTableCache(dbModel, testData, nil)
 	require.NoError(t, err)
 
 	t.Run("incomplete index", func(t *testing.T) {
@@ -1308,7 +1320,8 @@ func TestTableCacheApplyModifications(t *testing.T) {
 			  }
 			`), &schema)
 			require.NoError(t, err)
-			tc, err := NewTableCache(&schema, db, nil, nil)
+			dbModel := model.NewDatabaseModel(&schema, db)
+			tc, err := NewTableCache(dbModel, nil, nil)
 			assert.Nil(t, err)
 			original := model.Clone(tt.base).(*testDBModel)
 			err = tc.ApplyModifications("Open_vSwitch", original, tt.update)

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -82,7 +82,7 @@ func TestRowCache_Rows(t *testing.T) {
 
 func TestRowCacheCreate(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
-	db, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	require.Nil(t, err)
 	err = json.Unmarshal([]byte(`
 		 {"name": "TestDB",
@@ -168,7 +168,7 @@ func TestRowCacheCreate(t *testing.T) {
 
 func TestRowCacheCreateMultiIndex(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
-	db, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	require.Nil(t, err)
 	err = json.Unmarshal([]byte(`
 		 {"name": "TestDB",
@@ -261,7 +261,7 @@ func TestRowCacheCreateMultiIndex(t *testing.T) {
 
 func TestRowCacheUpdate(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
-	db, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	require.Nil(t, err)
 	err = json.Unmarshal([]byte(`
 		 {"name": "TestDB",
@@ -343,7 +343,7 @@ func TestRowCacheUpdate(t *testing.T) {
 
 func TestRowCacheUpdateMultiIndex(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
-	db, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	require.Nil(t, err)
 	err = json.Unmarshal([]byte(`
 		 {"name": "TestDB",
@@ -425,7 +425,7 @@ func TestRowCacheUpdateMultiIndex(t *testing.T) {
 
 func TestRowCacheDelete(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
-	db, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	require.Nil(t, err)
 	err = json.Unmarshal([]byte(`
 		 {"name": "TestDB",
@@ -685,7 +685,7 @@ func TestTableCacheTables(t *testing.T) {
 
 func TestTableCache_populate(t *testing.T) {
 	t.Log("Create")
-	db, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	assert.Nil(t, err)
 	var schema ovsdb.DatabaseSchema
 	err = json.Unmarshal([]byte(`
@@ -753,7 +753,7 @@ func TestTableCache_populate(t *testing.T) {
 
 func TestTableCachePopulate(t *testing.T) {
 	t.Log("Create")
-	db, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	assert.Nil(t, err)
 	var schema ovsdb.DatabaseSchema
 	err = json.Unmarshal([]byte(`
@@ -820,7 +820,7 @@ func TestTableCachePopulate(t *testing.T) {
 }
 
 func TestTableCachePopulate2(t *testing.T) {
-	db, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	assert.Nil(t, err)
 	var schema ovsdb.DatabaseSchema
 	err = json.Unmarshal([]byte(`
@@ -943,7 +943,7 @@ func TestIndex(t *testing.T) {
 		Bar  string `ovsdb:"bar"`
 		Baz  int    `ovsdb:"baz"`
 	}
-	db, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &indexTestModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &indexTestModel{}})
 	assert.Nil(t, err)
 	var schema ovsdb.DatabaseSchema
 	err = json.Unmarshal([]byte(`
@@ -1038,7 +1038,7 @@ func TestIndex(t *testing.T) {
 
 func TestTableCacheRowByModelSingleIndex(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
-	db, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	require.Nil(t, err)
 	err = json.Unmarshal([]byte(`
 		 {"name": "TestDB",
@@ -1087,7 +1087,7 @@ func TestTableCacheRowByModelSingleIndex(t *testing.T) {
 
 func TestTableCacheRowByModelTwoIndexes(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
-	db, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	require.Nil(t, err)
 	err = json.Unmarshal([]byte(`
 		 {"name": "TestDB",
@@ -1138,7 +1138,7 @@ func TestTableCacheRowByModelTwoIndexes(t *testing.T) {
 
 func TestTableCacheRowByModelMultiIndex(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
-	db, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	require.Nil(t, err)
 	err = json.Unmarshal([]byte(`
 		 {"name": "TestDB",
@@ -1287,7 +1287,7 @@ func TestTableCacheApplyModifications(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			db, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+			db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 			assert.Nil(t, err)
 			var schema ovsdb.DatabaseSchema
 			err = json.Unmarshal([]byte(`

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -251,7 +251,7 @@ func TestRowCacheCreateMultiIndex(t *testing.T) {
 				}
 			} else {
 				assert.Nil(t, err)
-				mapperInfo, err := mapper.NewInfo(tSchema, tt.model)
+				mapperInfo, err := mapper.NewInfo("Open_vSwitch", tSchema, tt.model)
 				require.Nil(t, err)
 				h, err := valueFromIndex(mapperInfo, newIndex("foo", "bar"))
 				require.Nil(t, err)
@@ -417,7 +417,7 @@ func TestRowCacheUpdateMultiIndex(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.Nil(t, err)
-				mapperInfo, err := mapper.NewInfo(tSchema, tt.model)
+				mapperInfo, err := mapper.NewInfo("Open_vSwitch", tSchema, tt.model)
 				require.Nil(t, err)
 				h, err := valueFromIndex(mapperInfo, newIndex("foo", "bar"))
 				require.Nil(t, err)
@@ -991,7 +991,7 @@ func TestIndex(t *testing.T) {
 	t.Run("Index by single column", func(t *testing.T) {
 		idx, err := table.Index("foo")
 		assert.Nil(t, err)
-		info, err := mapper.NewInfo(schema.Table("Open_vSwitch"), obj)
+		info, err := mapper.NewInfo("Open_vSwitch", schema.Table("Open_vSwitch"), obj)
 		assert.Nil(t, err)
 		v, err := valueFromIndex(info, newIndex("foo"))
 		assert.Nil(t, err)
@@ -1003,7 +1003,7 @@ func TestIndex(t *testing.T) {
 		obj2 := obj
 		obj2.Foo = "wrong"
 		assert.Nil(t, err)
-		info, err := mapper.NewInfo(schema.Table("Open_vSwitch"), obj2)
+		info, err := mapper.NewInfo("Open_vSwitch", schema.Table("Open_vSwitch"), obj2)
 		assert.Nil(t, err)
 		v, err := valueFromIndex(info, newIndex("foo"))
 		assert.Nil(t, err)
@@ -1021,7 +1021,7 @@ func TestIndex(t *testing.T) {
 	t.Run("Index by multi-column", func(t *testing.T) {
 		idx, err := table.Index("bar", "baz")
 		assert.Nil(t, err)
-		info, err := mapper.NewInfo(schema.Table("Open_vSwitch"), obj)
+		info, err := mapper.NewInfo("Open_vSwitch", schema.Table("Open_vSwitch"), obj)
 		assert.Nil(t, err)
 		v, err := valueFromIndex(info, newIndex("bar", "baz"))
 		assert.Nil(t, err)
@@ -1032,7 +1032,7 @@ func TestIndex(t *testing.T) {
 		assert.Nil(t, err)
 		obj2 := obj
 		obj2.Baz++
-		info, err := mapper.NewInfo(schema.Table("Open_vSwitch"), obj)
+		info, err := mapper.NewInfo("Open_vSwitch", schema.Table("Open_vSwitch"), obj)
 		assert.Nil(t, err)
 		v, err := valueFromIndex(info, newIndex("bar", "baz"))
 		assert.Nil(t, err)

--- a/client/api.go
+++ b/client/api.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/ovn-org/libovsdb/cache"
-	"github.com/ovn-org/libovsdb/mapper"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
 )
@@ -187,13 +186,13 @@ func (a api) conditionFromModel(any bool, model model.Model, cond ...model.Condi
 	}
 
 	if len(cond) == 0 {
-		conditional, err = newEqualityConditional(a.cache.Mapper(), tableName, any, model)
+		conditional, err = newEqualityConditional(a.cache.DatabaseModel(), tableName, any, model)
 		if err != nil {
 			conditional = newErrorConditional(err)
 		}
 
 	} else {
-		conditional, err = newExplicitConditional(a.cache.Mapper(), tableName, any, model, cond...)
+		conditional, err = newExplicitConditional(a.cache.DatabaseModel(), tableName, any, model, cond...)
 		if err != nil {
 			conditional = newErrorConditional(err)
 		}
@@ -243,10 +242,8 @@ func (a api) Create(models ...model.Model) ([]ovsdb.Operation, error) {
 			return nil, err
 		}
 
-		table := a.cache.Mapper().Schema.Table(tableName)
-
 		// Read _uuid field, and use it as named-uuid
-		info, err := mapper.NewInfo(tableName, table, model)
+		info, err := a.cache.DatabaseModel().NewModelInfo(model)
 		if err != nil {
 			return nil, err
 		}
@@ -294,7 +291,7 @@ func (a api) Mutate(model model.Model, mutationObjs ...model.Mutation) ([]ovsdb.
 		return nil, err
 	}
 
-	info, err := mapper.NewInfo(tableName, table, model)
+	info, err := a.cache.DatabaseModel().NewModelInfo(model)
 	if err != nil {
 		return nil, err
 	}
@@ -335,7 +332,7 @@ func (a api) Update(model model.Model, fields ...interface{}) ([]ovsdb.Operation
 		return nil, err
 	}
 	tableSchema := a.cache.Mapper().Schema.Table(table)
-	info, err := mapper.NewInfo(table, tableSchema, model)
+	info, err := a.cache.DatabaseModel().NewModelInfo(model)
 	if err != nil {
 		return nil, err
 	}

--- a/client/api.go
+++ b/client/api.go
@@ -280,7 +280,7 @@ func (a api) Mutate(model model.Model, mutationObjs ...model.Mutation) ([]ovsdb.
 		return nil, fmt.Errorf("at least one Mutation must be provided")
 	}
 
-	tableName := a.cache.ClientDBModel().FindTable(reflect.ValueOf(model).Type())
+	tableName := a.cache.DatabaseModel().FindTable(reflect.ValueOf(model).Type())
 	if tableName == "" {
 		return nil, fmt.Errorf("table not found for object")
 	}
@@ -414,7 +414,7 @@ func (a api) getTableFromModel(m interface{}) (string, error) {
 	if _, ok := m.(model.Model); !ok {
 		return "", &ErrWrongType{reflect.TypeOf(m), "Type does not implement Model interface"}
 	}
-	table := a.cache.ClientDBModel().FindTable(reflect.TypeOf(m))
+	table := a.cache.DatabaseModel().FindTable(reflect.TypeOf(m))
 	if table == "" {
 		return "", &ErrWrongType{reflect.TypeOf(m), "Model not found in Database Model"}
 	}
@@ -439,7 +439,7 @@ func (a api) getTableFromFunc(predicate interface{}) (string, error) {
 			fmt.Sprintf("Type %s does not implement Model interface", modelType.String())}
 	}
 
-	table := a.cache.ClientDBModel().FindTable(modelType)
+	table := a.cache.DatabaseModel().FindTable(modelType)
 	if table == "" {
 		return "", &ErrWrongType{predType,
 			fmt.Sprintf("Model %s not found in Database Model", modelType.String())}

--- a/client/api.go
+++ b/client/api.go
@@ -203,7 +203,7 @@ func (a api) conditionFromModel(any bool, model model.Model, cond ...model.Condi
 
 // Get is a generic Get function capable of returning (through a provided pointer)
 // a instance of any row in the cache.
-// 'result' must be a pointer to an Model that exists in the DBModel
+// 'result' must be a pointer to an Model that exists in the ClientDBModel
 //
 // The way the cache is searched depends on the fields already populated in 'result'
 // Any table index (including _uuid) will be used for comparison
@@ -280,7 +280,7 @@ func (a api) Mutate(model model.Model, mutationObjs ...model.Mutation) ([]ovsdb.
 		return nil, fmt.Errorf("at least one Mutation must be provided")
 	}
 
-	tableName := a.cache.DBModel().FindTable(reflect.ValueOf(model).Type())
+	tableName := a.cache.ClientDBModel().FindTable(reflect.ValueOf(model).Type())
 	if tableName == "" {
 		return nil, fmt.Errorf("table not found for object")
 	}
@@ -414,7 +414,7 @@ func (a api) getTableFromModel(m interface{}) (string, error) {
 	if _, ok := m.(model.Model); !ok {
 		return "", &ErrWrongType{reflect.TypeOf(m), "Type does not implement Model interface"}
 	}
-	table := a.cache.DBModel().FindTable(reflect.TypeOf(m))
+	table := a.cache.ClientDBModel().FindTable(reflect.TypeOf(m))
 	if table == "" {
 		return "", &ErrWrongType{reflect.TypeOf(m), "Model not found in Database Model"}
 	}
@@ -439,7 +439,7 @@ func (a api) getTableFromFunc(predicate interface{}) (string, error) {
 			fmt.Sprintf("Type %s does not implement Model interface", modelType.String())}
 	}
 
-	table := a.cache.DBModel().FindTable(modelType)
+	table := a.cache.ClientDBModel().FindTable(modelType)
 	if table == "" {
 		return "", &ErrWrongType{predType,
 			fmt.Sprintf("Model %s not found in Database Model", modelType.String())}

--- a/client/api.go
+++ b/client/api.go
@@ -246,7 +246,7 @@ func (a api) Create(models ...model.Model) ([]ovsdb.Operation, error) {
 		table := a.cache.Mapper().Schema.Table(tableName)
 
 		// Read _uuid field, and use it as named-uuid
-		info, err := mapper.NewInfo(table, model)
+		info, err := mapper.NewInfo(tableName, table, model)
 		if err != nil {
 			return nil, err
 		}
@@ -256,7 +256,7 @@ func (a api) Create(models ...model.Model) ([]ovsdb.Operation, error) {
 			return nil, err
 		}
 
-		row, err := a.cache.Mapper().NewRow(tableName, model)
+		row, err := a.cache.Mapper().NewRow(info)
 		if err != nil {
 			return nil, err
 		}
@@ -294,7 +294,7 @@ func (a api) Mutate(model model.Model, mutationObjs ...model.Mutation) ([]ovsdb.
 		return nil, err
 	}
 
-	info, err := mapper.NewInfo(table, model)
+	info, err := mapper.NewInfo(tableName, table, model)
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +305,7 @@ func (a api) Mutate(model model.Model, mutationObjs ...model.Mutation) ([]ovsdb.
 			return nil, err
 		}
 
-		mutation, err := a.cache.Mapper().NewMutation(tableName, model, col, mobj.Mutator, mobj.Value)
+		mutation, err := a.cache.Mapper().NewMutation(info, col, mobj.Mutator, mobj.Value)
 		if err != nil {
 			return nil, err
 		}
@@ -335,12 +335,12 @@ func (a api) Update(model model.Model, fields ...interface{}) ([]ovsdb.Operation
 		return nil, err
 	}
 	tableSchema := a.cache.Mapper().Schema.Table(table)
+	info, err := mapper.NewInfo(table, tableSchema, model)
+	if err != nil {
+		return nil, err
+	}
 
 	if len(fields) > 0 {
-		info, err := mapper.NewInfo(tableSchema, model)
-		if err != nil {
-			return nil, err
-		}
 		for _, f := range fields {
 			colName, err := info.ColumnByPtr(f)
 			if err != nil {
@@ -357,7 +357,7 @@ func (a api) Update(model model.Model, fields ...interface{}) ([]ovsdb.Operation
 		return nil, err
 	}
 
-	row, err := a.cache.Mapper().NewRow(table, model, fields...)
+	row, err := a.cache.Mapper().NewRow(info, fields...)
 	if err != nil {
 		return nil, err
 	}

--- a/client/api_test_model.go
+++ b/client/api_test_model.go
@@ -157,7 +157,7 @@ func apiTestCache(t *testing.T, data map[string]map[string]model.Model) *cache.T
 	var schema ovsdb.DatabaseSchema
 	err := json.Unmarshal(apiTestSchema, &schema)
 	assert.Nil(t, err)
-	db, err := model.NewDBModel("OVN_NorthBound", map[string]model.Model{"Logical_Switch": &testLogicalSwitch{}, "Logical_Switch_Port": &testLogicalSwitchPort{}})
+	db, err := model.NewClientDBModel("OVN_NorthBound", map[string]model.Model{"Logical_Switch": &testLogicalSwitch{}, "Logical_Switch_Port": &testLogicalSwitchPort{}})
 	assert.Nil(t, err)
 	cache, err := cache.NewTableCache(&schema, db, data, nil)
 	assert.Nil(t, err)

--- a/client/api_test_model.go
+++ b/client/api_test_model.go
@@ -157,9 +157,10 @@ func apiTestCache(t *testing.T, data map[string]map[string]model.Model) *cache.T
 	var schema ovsdb.DatabaseSchema
 	err := json.Unmarshal(apiTestSchema, &schema)
 	assert.Nil(t, err)
-	db, err := model.NewClientDBModel("OVN_NorthBound", map[string]model.Model{"Logical_Switch": &testLogicalSwitch{}, "Logical_Switch_Port": &testLogicalSwitchPort{}})
+	db, err := model.NewClientDBModel("OVN_Northbound", map[string]model.Model{"Logical_Switch": &testLogicalSwitch{}, "Logical_Switch_Port": &testLogicalSwitchPort{}})
 	assert.Nil(t, err)
-	dbModel := model.NewDatabaseModel(&schema, db)
+	dbModel, errs := model.NewDatabaseModel(&schema, db)
+	assert.Empty(t, errs)
 	cache, err := cache.NewTableCache(dbModel, data, nil)
 	assert.Nil(t, err)
 	return cache

--- a/client/api_test_model.go
+++ b/client/api_test_model.go
@@ -159,7 +159,8 @@ func apiTestCache(t *testing.T, data map[string]map[string]model.Model) *cache.T
 	assert.Nil(t, err)
 	db, err := model.NewClientDBModel("OVN_NorthBound", map[string]model.Model{"Logical_Switch": &testLogicalSwitch{}, "Logical_Switch_Port": &testLogicalSwitchPort{}})
 	assert.Nil(t, err)
-	cache, err := cache.NewTableCache(&schema, db, data, nil)
+	dbModel := model.NewDatabaseModel(&schema, db)
+	cache, err := cache.NewTableCache(dbModel, data, nil)
 	assert.Nil(t, err)
 	return cache
 }

--- a/client/client.go
+++ b/client/client.go
@@ -85,7 +85,7 @@ type ovsdbClient struct {
 
 // database is everything needed to map between go types and an ovsdb Database
 type database struct {
-	model       *model.DBModel
+	model       *model.ClientDBModel
 	schema      *ovsdb.DatabaseSchema
 	schemaMutex sync.RWMutex
 	cache       *cache.TableCache
@@ -102,12 +102,12 @@ type database struct {
 // database model. The client can be configured using one or more Option(s),
 // like WithTLSConfig. If no WithEndpoint option is supplied, the default of
 // unix:/var/run/openvswitch/ovsdb.sock is used
-func NewOVSDBClient(databaseModel *model.DBModel, opts ...Option) (Client, error) {
+func NewOVSDBClient(databaseModel *model.ClientDBModel, opts ...Option) (Client, error) {
 	return newOVSDBClient(databaseModel, opts...)
 }
 
 // newOVSDBClient creates a new ovsdbClient
-func newOVSDBClient(databaseModel *model.DBModel, opts ...Option) (*ovsdbClient, error) {
+func newOVSDBClient(databaseModel *model.ClientDBModel, opts ...Option) (*ovsdbClient, error) {
 	ovs := &ovsdbClient{
 		primaryDBName: databaseModel.Name(),
 		databases: map[string]*database{

--- a/client/client.go
+++ b/client/client.go
@@ -638,7 +638,7 @@ func (o *ovsdbClient) transact(ctx context.Context, dbName string, operation ...
 // MonitorAll is a convenience method to monitor every table/column
 func (o *ovsdbClient) MonitorAll(ctx context.Context) (MonitorCookie, error) {
 	m := newMonitor()
-	for name := range o.primaryDB().model.Client().Types() {
+	for name := range o.primaryDB().model.Types() {
 		m.Tables = append(m.Tables, TableMonitor{Table: name})
 	}
 	return o.Monitor(ctx, m)
@@ -696,7 +696,7 @@ func (o *ovsdbClient) monitor(ctx context.Context, cookie MonitorCookie, reconne
 	db.schemaMutex.RLock()
 	mapper := db.model.Mapper()
 	db.schemaMutex.RUnlock()
-	typeMap := o.databases[dbName].model.Client().Types()
+	typeMap := o.databases[dbName].model.Types()
 	requests := make(map[string]ovsdb.MonitorRequest)
 	for _, o := range monitor.Tables {
 		m, ok := typeMap[o.Table]

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -564,7 +564,8 @@ func BenchmarkUpdate1(b *testing.B) {
 		"Open_vSwitch": &OpenvSwitch{},
 	})
 	require.NoError(b, err)
-	ovs.primaryDB().cache, err = cache.NewTableCache(&s, clientDBModel, nil, nil)
+	dbModel := model.NewDatabaseModel(&s, clientDBModel)
+	ovs.primaryDB().cache, err = cache.NewTableCache(dbModel, nil, nil)
 	require.NoError(b, err)
 	update := []byte(`{
 		"Open_vSwitch": {
@@ -588,7 +589,8 @@ func BenchmarkUpdate2(b *testing.B) {
 		"Open_vSwitch": &OpenvSwitch{},
 	})
 	require.NoError(b, err)
-	ovs.primaryDB().cache, err = cache.NewTableCache(&s, clientDBModel, nil, nil)
+	dbModel := model.NewDatabaseModel(&s, clientDBModel)
+	ovs.primaryDB().cache, err = cache.NewTableCache(dbModel, nil, nil)
 	require.NoError(b, err)
 	update := []byte(`{
 		"Open_vSwitch": {
@@ -613,7 +615,8 @@ func BenchmarkUpdate3(b *testing.B) {
 		"Open_vSwitch": &OpenvSwitch{},
 	})
 	require.NoError(b, err)
-	ovs.primaryDB().cache, err = cache.NewTableCache(&s, clientDBModel, nil, nil)
+	dbModel := model.NewDatabaseModel(&s, clientDBModel)
+	ovs.primaryDB().cache, err = cache.NewTableCache(dbModel, nil, nil)
 	require.NoError(b, err)
 	update := []byte(`{
 		"Open_vSwitch": {
@@ -639,7 +642,8 @@ func BenchmarkUpdate5(b *testing.B) {
 		"Open_vSwitch": &OpenvSwitch{},
 	})
 	require.NoError(b, err)
-	ovs.primaryDB().cache, err = cache.NewTableCache(&s, clientDBModel, nil, nil)
+	dbModel := model.NewDatabaseModel(&s, clientDBModel)
+	ovs.primaryDB().cache, err = cache.NewTableCache(dbModel, nil, nil)
 	require.NoError(b, err)
 	update := []byte(`{
 		"Open_vSwitch": {
@@ -667,7 +671,8 @@ func BenchmarkUpdate8(b *testing.B) {
 		"Open_vSwitch": &OpenvSwitch{},
 	})
 	require.NoError(b, err)
-	ovs.primaryDB().cache, err = cache.NewTableCache(&s, clientDBModel, nil, nil)
+	dbModel := model.NewDatabaseModel(&s, clientDBModel)
+	ovs.primaryDB().cache, err = cache.NewTableCache(dbModel, nil, nil)
 	require.NoError(b, err)
 	update := []byte(`{
 		"Open_vSwitch": {
@@ -712,7 +717,8 @@ func TestUpdate(t *testing.T) {
 		"Open_vSwitch": &OpenvSwitch{},
 	})
 	require.NoError(t, err)
-	ovs.primaryDB().cache, err = cache.NewTableCache(&s, clientDBModel, nil, nil)
+	dbModel := model.NewDatabaseModel(&s, clientDBModel)
+	ovs.primaryDB().cache, err = cache.NewTableCache(dbModel, nil, nil)
 	require.NoError(t, err)
 	var reply []interface{}
 	update := []byte(`{
@@ -736,7 +742,7 @@ func TestOperationWhenNotConnected(t *testing.T) {
 	var s ovsdb.DatabaseSchema
 	err = json.Unmarshal([]byte(schema), &s)
 	require.NoError(t, err)
-	ovs.primaryDB().schema = &s
+	_ = ovs.primaryDB().model.SetSchema(&s)
 
 	tests := []struct {
 		name string

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -491,7 +491,7 @@ func testOvsMap(t *testing.T, set interface{}) ovsdb.OvsMap {
 
 func updateBenchmark(ovs *ovsdbClient, updates []byte, b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		params := []json.RawMessage{[]byte(`["Open_vSwitch","v1"]`), updates}
+		params := []json.RawMessage{[]byte(`{"databaseName":"Open_vSwitch","id":"v1"}`), updates}
 		var reply []interface{}
 		err := ovs.update(params, &reply)
 		if err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -87,7 +87,7 @@ type OpenvSwitch struct {
 	SystemVersion   *string           `ovsdb:"system_version"`
 }
 
-var defDB, _ = model.NewDBModel("Open_vSwitch",
+var defDB, _ = model.NewClientDBModel("Open_vSwitch",
 	map[string]model.Model{
 		"Open_vSwitch": &OpenvSwitch{},
 		"Bridge":       &Bridge{},
@@ -559,12 +559,12 @@ func BenchmarkUpdate1(b *testing.B) {
 	var s ovsdb.DatabaseSchema
 	err = json.Unmarshal([]byte(schema), &s)
 	require.NoError(b, err)
-	dbModel, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+	clientDBModel, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Bridge":       &Bridge{},
 		"Open_vSwitch": &OpenvSwitch{},
 	})
 	require.NoError(b, err)
-	ovs.primaryDB().cache, err = cache.NewTableCache(&s, dbModel, nil, nil)
+	ovs.primaryDB().cache, err = cache.NewTableCache(&s, clientDBModel, nil, nil)
 	require.NoError(b, err)
 	update := []byte(`{
 		"Open_vSwitch": {
@@ -583,12 +583,12 @@ func BenchmarkUpdate2(b *testing.B) {
 	var s ovsdb.DatabaseSchema
 	err = json.Unmarshal([]byte(schema), &s)
 	require.NoError(b, err)
-	dbModel, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+	clientDBModel, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Bridge":       &Bridge{},
 		"Open_vSwitch": &OpenvSwitch{},
 	})
 	require.NoError(b, err)
-	ovs.primaryDB().cache, err = cache.NewTableCache(&s, dbModel, nil, nil)
+	ovs.primaryDB().cache, err = cache.NewTableCache(&s, clientDBModel, nil, nil)
 	require.NoError(b, err)
 	update := []byte(`{
 		"Open_vSwitch": {
@@ -608,12 +608,12 @@ func BenchmarkUpdate3(b *testing.B) {
 	var s ovsdb.DatabaseSchema
 	err = json.Unmarshal([]byte(schema), &s)
 	require.NoError(b, err)
-	dbModel, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+	clientDBModel, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Bridge":       &Bridge{},
 		"Open_vSwitch": &OpenvSwitch{},
 	})
 	require.NoError(b, err)
-	ovs.primaryDB().cache, err = cache.NewTableCache(&s, dbModel, nil, nil)
+	ovs.primaryDB().cache, err = cache.NewTableCache(&s, clientDBModel, nil, nil)
 	require.NoError(b, err)
 	update := []byte(`{
 		"Open_vSwitch": {
@@ -634,12 +634,12 @@ func BenchmarkUpdate5(b *testing.B) {
 	var s ovsdb.DatabaseSchema
 	err = json.Unmarshal([]byte(schema), &s)
 	require.NoError(b, err)
-	dbModel, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+	clientDBModel, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Bridge":       &Bridge{},
 		"Open_vSwitch": &OpenvSwitch{},
 	})
 	require.NoError(b, err)
-	ovs.primaryDB().cache, err = cache.NewTableCache(&s, dbModel, nil, nil)
+	ovs.primaryDB().cache, err = cache.NewTableCache(&s, clientDBModel, nil, nil)
 	require.NoError(b, err)
 	update := []byte(`{
 		"Open_vSwitch": {
@@ -662,12 +662,12 @@ func BenchmarkUpdate8(b *testing.B) {
 	var s ovsdb.DatabaseSchema
 	err = json.Unmarshal([]byte(schema), &s)
 	require.NoError(b, err)
-	dbModel, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+	clientDBModel, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Bridge":       &Bridge{},
 		"Open_vSwitch": &OpenvSwitch{},
 	})
 	require.NoError(b, err)
-	ovs.primaryDB().cache, err = cache.NewTableCache(&s, dbModel, nil, nil)
+	ovs.primaryDB().cache, err = cache.NewTableCache(&s, clientDBModel, nil, nil)
 	require.NoError(b, err)
 	update := []byte(`{
 		"Open_vSwitch": {
@@ -707,12 +707,12 @@ func TestUpdate(t *testing.T) {
 	var s ovsdb.DatabaseSchema
 	err = json.Unmarshal([]byte(schema), &s)
 	require.NoError(t, err)
-	dbModel, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+	clientDBModel, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Bridge":       &Bridge{},
 		"Open_vSwitch": &OpenvSwitch{},
 	})
 	require.NoError(t, err)
-	ovs.primaryDB().cache, err = cache.NewTableCache(&s, dbModel, nil, nil)
+	ovs.primaryDB().cache, err = cache.NewTableCache(&s, clientDBModel, nil, nil)
 	require.NoError(t, err)
 	var reply []interface{}
 	update := []byte(`{

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -564,7 +564,8 @@ func BenchmarkUpdate1(b *testing.B) {
 		"Open_vSwitch": &OpenvSwitch{},
 	})
 	require.NoError(b, err)
-	dbModel := model.NewDatabaseModel(&s, clientDBModel)
+	dbModel, errs := model.NewDatabaseModel(&s, clientDBModel)
+	require.Empty(b, errs)
 	ovs.primaryDB().cache, err = cache.NewTableCache(dbModel, nil, nil)
 	require.NoError(b, err)
 	update := []byte(`{
@@ -589,7 +590,8 @@ func BenchmarkUpdate2(b *testing.B) {
 		"Open_vSwitch": &OpenvSwitch{},
 	})
 	require.NoError(b, err)
-	dbModel := model.NewDatabaseModel(&s, clientDBModel)
+	dbModel, errs := model.NewDatabaseModel(&s, clientDBModel)
+	require.Empty(b, errs)
 	ovs.primaryDB().cache, err = cache.NewTableCache(dbModel, nil, nil)
 	require.NoError(b, err)
 	update := []byte(`{
@@ -615,7 +617,8 @@ func BenchmarkUpdate3(b *testing.B) {
 		"Open_vSwitch": &OpenvSwitch{},
 	})
 	require.NoError(b, err)
-	dbModel := model.NewDatabaseModel(&s, clientDBModel)
+	dbModel, errs := model.NewDatabaseModel(&s, clientDBModel)
+	require.Empty(b, errs)
 	ovs.primaryDB().cache, err = cache.NewTableCache(dbModel, nil, nil)
 	require.NoError(b, err)
 	update := []byte(`{
@@ -642,7 +645,8 @@ func BenchmarkUpdate5(b *testing.B) {
 		"Open_vSwitch": &OpenvSwitch{},
 	})
 	require.NoError(b, err)
-	dbModel := model.NewDatabaseModel(&s, clientDBModel)
+	dbModel, errs := model.NewDatabaseModel(&s, clientDBModel)
+	require.Empty(b, errs)
 	ovs.primaryDB().cache, err = cache.NewTableCache(dbModel, nil, nil)
 	require.NoError(b, err)
 	update := []byte(`{
@@ -671,7 +675,8 @@ func BenchmarkUpdate8(b *testing.B) {
 		"Open_vSwitch": &OpenvSwitch{},
 	})
 	require.NoError(b, err)
-	dbModel := model.NewDatabaseModel(&s, clientDBModel)
+	dbModel, errs := model.NewDatabaseModel(&s, clientDBModel)
+	require.Empty(b, errs)
 	ovs.primaryDB().cache, err = cache.NewTableCache(dbModel, nil, nil)
 	require.NoError(b, err)
 	update := []byte(`{
@@ -717,7 +722,8 @@ func TestUpdate(t *testing.T) {
 		"Open_vSwitch": &OpenvSwitch{},
 	})
 	require.NoError(t, err)
-	dbModel := model.NewDatabaseModel(&s, clientDBModel)
+	dbModel, errs := model.NewDatabaseModel(&s, clientDBModel)
+	require.Empty(t, errs)
 	ovs.primaryDB().cache, err = cache.NewTableCache(dbModel, nil, nil)
 	require.NoError(t, err)
 	var reply []interface{}

--- a/client/condition_test.go
+++ b/client/condition_test.go
@@ -128,7 +128,7 @@ func TestEqualityConditional(t *testing.T) {
 	}
 	for _, tt := range test {
 		t.Run(fmt.Sprintf("Equality Conditional: %s", tt.name), func(t *testing.T) {
-			cond, err := newEqualityConditional(tcache.Mapper(), "Logical_Switch_Port", tt.all, tt.model)
+			cond, err := newEqualityConditional(tcache.DatabaseModel(), "Logical_Switch_Port", tt.all, tt.model)
 			assert.Nil(t, err)
 			for model, shouldMatch := range tt.matches {
 				matches, err := cond.Matches(model)
@@ -431,7 +431,7 @@ func TestExplicitConditional(t *testing.T) {
 	}
 	for _, tt := range test {
 		t.Run(fmt.Sprintf("Explicit Conditional: %s", tt.name), func(t *testing.T) {
-			cond, err := newExplicitConditional(tcache.Mapper(), "Logical_Switch_Port", tt.all, testObj, tt.args...)
+			cond, err := newExplicitConditional(tcache.DatabaseModel(), "Logical_Switch_Port", tt.all, testObj, tt.args...)
 			assert.Nil(t, err)
 			_, err = cond.Matches(testObj)
 			assert.NotNilf(t, err, "Explicit conditions should fail to match on cache")

--- a/client/doc.go
+++ b/client/doc.go
@@ -11,21 +11,21 @@ which column in the database. We refer to pointers to this structs as Models. Ex
    	Config map[string]string `ovsdb:"other_config"`
    }
 
-Based on these Models a Database Model (see DBModel type) is built to represent
+Based on these Models a Database Model (see ClientDBModel type) is built to represent
 the entire OVSDB:
 
-   dbModel, _ := client.NewDBModel("OVN_Northbound",
+   clientDBModel, _ := client.NewClientDBModel("OVN_Northbound",
        map[string]client.Model{
    	"Logical_Switch": &MyLogicalSwitch{},
    })
 
 
-The DBModel represents the entire Database (or the part of it we're interested in).
+The ClientDBModel represents the entire Database (or the part of it we're interested in).
 Using it, the libovsdb.client package is able to properly encode and decode OVSDB messages
 and store them in Model instances.
 A client instance is created by simply specifying the connection information and the database model:
 
-     ovs, _ := client.Connect(context.Background(), dbModel)
+     ovs, _ := client.Connect(context.Background(), clientDBModel)
 
 Main API
 

--- a/client/monitor.go
+++ b/client/monitor.go
@@ -72,7 +72,7 @@ func WithTable(m model.Model, fields ...interface{}) MonitorOption {
 	return func(o *ovsdbClient, monitor *Monitor) error {
 		tableName := o.primaryDB().model.FindTable(reflect.TypeOf(m))
 		if tableName == "" {
-			return fmt.Errorf("object of type %s is not part of the DBModel", reflect.TypeOf(m))
+			return fmt.Errorf("object of type %s is not part of the ClientDBModel", reflect.TypeOf(m))
 		}
 		tableMonitor := TableMonitor{
 			Table:  tableName,
@@ -87,7 +87,7 @@ func WithConditionalTable(m model.Model, condition model.Condition, fields ...in
 	return func(o *ovsdbClient, monitor *Monitor) error {
 		tableName := o.primaryDB().model.FindTable(reflect.TypeOf(m))
 		if tableName == "" {
-			return fmt.Errorf("object of type %s is not part of the DBModel", reflect.TypeOf(m))
+			return fmt.Errorf("object of type %s is not part of the ClientDBModel", reflect.TypeOf(m))
 		}
 		tableMonitor := TableMonitor{
 			Table:     tableName,

--- a/client/monitor.go
+++ b/client/monitor.go
@@ -70,7 +70,7 @@ type TableMonitor struct {
 
 func WithTable(m model.Model, fields ...interface{}) MonitorOption {
 	return func(o *ovsdbClient, monitor *Monitor) error {
-		tableName := o.primaryDB().model.FindTable(reflect.TypeOf(m))
+		tableName := o.primaryDB().model.Client().FindTable(reflect.TypeOf(m))
 		if tableName == "" {
 			return fmt.Errorf("object of type %s is not part of the ClientDBModel", reflect.TypeOf(m))
 		}
@@ -85,7 +85,7 @@ func WithTable(m model.Model, fields ...interface{}) MonitorOption {
 
 func WithConditionalTable(m model.Model, condition model.Condition, fields ...interface{}) MonitorOption {
 	return func(o *ovsdbClient, monitor *Monitor) error {
-		tableName := o.primaryDB().model.FindTable(reflect.TypeOf(m))
+		tableName := o.primaryDB().model.Client().FindTable(reflect.TypeOf(m))
 		if tableName == "" {
 			return fmt.Errorf("object of type %s is not part of the ClientDBModel", reflect.TypeOf(m))
 		}

--- a/client/monitor.go
+++ b/client/monitor.go
@@ -70,7 +70,7 @@ type TableMonitor struct {
 
 func WithTable(m model.Model, fields ...interface{}) MonitorOption {
 	return func(o *ovsdbClient, monitor *Monitor) error {
-		tableName := o.primaryDB().model.Client().FindTable(reflect.TypeOf(m))
+		tableName := o.primaryDB().model.FindTable(reflect.TypeOf(m))
 		if tableName == "" {
 			return fmt.Errorf("object of type %s is not part of the ClientDBModel", reflect.TypeOf(m))
 		}
@@ -85,7 +85,7 @@ func WithTable(m model.Model, fields ...interface{}) MonitorOption {
 
 func WithConditionalTable(m model.Model, condition model.Condition, fields ...interface{}) MonitorOption {
 	return func(o *ovsdbClient, monitor *Monitor) error {
-		tableName := o.primaryDB().model.Client().FindTable(reflect.TypeOf(m))
+		tableName := o.primaryDB().model.FindTable(reflect.TypeOf(m))
 		if tableName == "" {
 			return fmt.Errorf("object of type %s is not part of the ClientDBModel", reflect.TypeOf(m))
 		}

--- a/cmd/stress/stress.go
+++ b/cmd/stress/stress.go
@@ -36,14 +36,14 @@ type ovsType struct {
 }
 
 var (
-	cpuprofile = flag.String("cpuprofile", "", "write cpu profile to this file")
-	memprofile = flag.String("memoryprofile", "", "write memory profile to this file")
-	nins       = flag.Int("inserts", 100, "the number of insertions to make to the database (per client)")
-	nclients   = flag.Int("clients", 1, "the number of clients to use")
-	parallel   = flag.Bool("parallel", false, "run clients in parallel")
-	verbose    = flag.Bool("verbose", false, "Be verbose")
-	connection = flag.String("ovsdb", "unix:/var/run/openvswitch/db.sock", "OVSDB connection string")
-	dbModel    *model.DBModel
+	cpuprofile    = flag.String("cpuprofile", "", "write cpu profile to this file")
+	memprofile    = flag.String("memoryprofile", "", "write memory profile to this file")
+	nins          = flag.Int("inserts", 100, "the number of insertions to make to the database (per client)")
+	nclients      = flag.Int("clients", 1, "the number of clients to use")
+	parallel      = flag.Bool("parallel", false, "run clients in parallel")
+	verbose       = flag.Bool("verbose", false, "Be verbose")
+	connection    = flag.String("ovsdb", "unix:/var/run/openvswitch/db.sock", "OVSDB connection string")
+	clientDBModel *model.ClientDBModel
 )
 
 type result struct {
@@ -54,7 +54,7 @@ type result struct {
 }
 
 func cleanup(ctx context.Context) {
-	ovs, err := client.NewOVSDBClient(dbModel, client.WithEndpoint(*connection))
+	ovs, err := client.NewOVSDBClient(clientDBModel, client.WithEndpoint(*connection))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func run(ctx context.Context, resultsChan chan result, wg *sync.WaitGroup) {
 	ready := false
 	var rootUUID string
 
-	ovs, err := client.NewOVSDBClient(dbModel, client.WithEndpoint(*connection))
+	ovs, err := client.NewOVSDBClient(clientDBModel, client.WithEndpoint(*connection))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -249,7 +249,7 @@ func main() {
 	}
 
 	var err error
-	dbModel, err = model.NewDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &ovsType{}, "Bridge": &bridgeType{}})
+	clientDBModel, err = model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &ovsType{}, "Bridge": &bridgeType{}})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example/ovsdb-server/main.go
+++ b/example/ovsdb-server/main.go
@@ -47,7 +47,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	path := filepath.Join(wd, "vswitchd", "vswitchd.ovsschema")
+	path := filepath.Join(wd, "vswitchd", "ovs.ovsschema")
 	f, err := os.Open(path)
 	if err != nil {
 		log.Fatal(err)

--- a/example/ovsdb-server/main.go
+++ b/example/ovsdb-server/main.go
@@ -61,10 +61,7 @@ func main() {
 		schema.Name: clientDBModel,
 	})
 
-	s, err := server.NewOvsdbServer(ovsDB, server.DatabaseModel{
-		Model:  clientDBModel,
-		Schema: schema,
-	})
+	s, err := server.NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, clientDBModel))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example/ovsdb-server/main.go
+++ b/example/ovsdb-server/main.go
@@ -39,7 +39,7 @@ func main() {
 		defer pprof.StopCPUProfile()
 	}
 
-	dbModel, err := vswitchd.FullDatabaseModel()
+	clientDBModel, err := vswitchd.FullDatabaseModel()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -57,12 +57,12 @@ func main() {
 		log.Fatal(err)
 	}
 
-	ovsDB := server.NewInMemoryDatabase(map[string]*model.DBModel{
-		schema.Name: dbModel,
+	ovsDB := server.NewInMemoryDatabase(map[string]*model.ClientDBModel{
+		schema.Name: clientDBModel,
 	})
 
 	s, err := server.NewOvsdbServer(ovsDB, server.DatabaseModel{
-		Model:  dbModel,
+		Model:  clientDBModel,
 		Schema: schema,
 	})
 	if err != nil {
@@ -80,7 +80,7 @@ func main() {
 	}(s)
 
 	time.Sleep(1 * time.Second)
-	c, err := client.NewOVSDBClient(dbModel, client.WithEndpoint(fmt.Sprintf("tcp::%d", *port)))
+	c, err := client.NewOVSDBClient(clientDBModel, client.WithEndpoint(fmt.Sprintf("tcp::%d", *port)))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example/ovsdb-server/main.go
+++ b/example/ovsdb-server/main.go
@@ -61,7 +61,11 @@ func main() {
 		schema.Name: clientDBModel,
 	})
 
-	s, err := server.NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, clientDBModel))
+	dbModel, errs := model.NewDatabaseModel(schema, clientDBModel)
+	if len(errs) > 0 {
+		log.Fatal(errs)
+	}
+	s, err := server.NewOvsdbServer(ovsDB, dbModel)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example/play_with_ovs/main.go
+++ b/example/play_with_ovs/main.go
@@ -97,13 +97,13 @@ func main() {
 	quit = make(chan bool)
 	update = make(chan model.Model)
 
-	dbModel, err := model.NewDBModel("Open_vSwitch",
+	clientDBModel, err := model.NewClientDBModel("Open_vSwitch",
 		map[string]model.Model{bridgeTable: &vswitchd.Bridge{}, ovsTable: &vswitchd.OpenvSwitch{}})
 	if err != nil {
 		log.Fatal("Unable to create DB model ", err)
 	}
 
-	ovs, err := client.NewOVSDBClient(dbModel, client.WithEndpoint(*connection))
+	ovs, err := client.NewOVSDBClient(clientDBModel, client.WithEndpoint(*connection))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/mapper/info.go
+++ b/mapper/info.go
@@ -7,37 +7,42 @@ import (
 	"github.com/ovn-org/libovsdb/ovsdb"
 )
 
-// Info is a struct that handles the type map of an object
-// The object must have exported tagged fields with the 'ovs'
+// Info is a struct that wraps an object with its metadata
 type Info struct {
 	// FieldName indexed by column
-	fields map[string]string
-	obj    interface{}
-	table  *ovsdb.TableSchema
+	Obj      interface{}
+	Metadata *Metadata
+}
+
+// Metadata represents the information needed to know how to map OVSDB columns into an objetss fields
+type Metadata struct {
+	Fields      map[string]string  // Map of ColumnName -> FieldName
+	TableSchema *ovsdb.TableSchema // TableSchema associated
+	TableName   string             // Table name
 }
 
 // FieldByColumn returns the field value that corresponds to a column
 func (i *Info) FieldByColumn(column string) (interface{}, error) {
-	fieldName, ok := i.fields[column]
+	fieldName, ok := i.Metadata.Fields[column]
 	if !ok {
 		return nil, fmt.Errorf("FieldByColumn: column %s not found in orm info", column)
 	}
-	return reflect.ValueOf(i.obj).Elem().FieldByName(fieldName).Interface(), nil
+	return reflect.ValueOf(i.Obj).Elem().FieldByName(fieldName).Interface(), nil
 }
 
 // FieldByColumn returns the field value that corresponds to a column
 func (i *Info) hasColumn(column string) bool {
-	_, ok := i.fields[column]
+	_, ok := i.Metadata.Fields[column]
 	return ok
 }
 
 // SetField sets the field in the column to the specified value
 func (i *Info) SetField(column string, value interface{}) error {
-	fieldName, ok := i.fields[column]
+	fieldName, ok := i.Metadata.Fields[column]
 	if !ok {
 		return fmt.Errorf("SetField: column %s not found in orm info", column)
 	}
-	fieldValue := reflect.ValueOf(i.obj).Elem().FieldByName(fieldName)
+	fieldValue := reflect.ValueOf(i.Obj).Elem().FieldByName(fieldName)
 
 	if !fieldValue.Type().AssignableTo(reflect.TypeOf(value)) {
 		return fmt.Errorf("column %s: native value %v (%s) is not assignable to field %s (%s)",
@@ -53,12 +58,12 @@ func (i *Info) ColumnByPtr(fieldPtr interface{}) (string, error) {
 	if fieldPtrVal.Kind() != reflect.Ptr {
 		return "", ovsdb.NewErrWrongType("ColumnByPointer", "pointer to a field in the struct", fieldPtr)
 	}
-	offset := fieldPtrVal.Pointer() - reflect.ValueOf(i.obj).Pointer()
-	objType := reflect.TypeOf(i.obj).Elem()
+	offset := fieldPtrVal.Pointer() - reflect.ValueOf(i.Obj).Pointer()
+	objType := reflect.TypeOf(i.Obj).Elem()
 	for j := 0; j < objType.NumField(); j++ {
 		if objType.Field(j).Offset == offset {
 			column := objType.Field(j).Tag.Get("ovsdb")
-			if _, ok := i.fields[column]; !ok {
+			if _, ok := i.Metadata.Fields[column]; !ok {
 				return "", fmt.Errorf("field does not have orm column information")
 			}
 			return column, nil
@@ -74,7 +79,7 @@ func (i *Info) getValidIndexes() ([][]string, error) {
 	var possibleIndexes [][]string
 
 	possibleIndexes = append(possibleIndexes, []string{"_uuid"})
-	possibleIndexes = append(possibleIndexes, i.table.Indexes...)
+	possibleIndexes = append(possibleIndexes, i.Metadata.TableSchema.Indexes...)
 
 	// Iterate through indexes and validate them
 OUTER:
@@ -83,7 +88,7 @@ OUTER:
 			if !i.hasColumn(col) {
 				continue OUTER
 			}
-			columnSchema := i.table.Column(col)
+			columnSchema := i.Metadata.TableSchema.Column(col)
 			if columnSchema == nil {
 				continue OUTER
 			}
@@ -101,7 +106,7 @@ OUTER:
 }
 
 // NewInfo creates a MapperInfo structure around an object based on a given table schema
-func NewInfo(table *ovsdb.TableSchema, obj interface{}) (*Info, error) {
+func NewInfo(tableName string, table *ovsdb.TableSchema, obj interface{}) (*Info, error) {
 	objPtrVal := reflect.ValueOf(obj)
 	if objPtrVal.Type().Kind() != reflect.Ptr {
 		return nil, ovsdb.NewErrWrongType("NewMapperInfo", "pointer to a struct", obj)
@@ -146,8 +151,11 @@ func NewInfo(table *ovsdb.TableSchema, obj interface{}) (*Info, error) {
 	}
 
 	return &Info{
-		fields: fields,
-		obj:    obj,
-		table:  table,
+		Obj: obj,
+		Metadata: &Metadata{
+			Fields:      fields,
+			TableSchema: table,
+			TableName:   tableName,
+		},
 	}, nil
 }

--- a/mapper/info_test.go
+++ b/mapper/info_test.go
@@ -58,7 +58,7 @@ func TestNewMapperInfo(t *testing.T) {
 			err := json.Unmarshal(tt.table, &table)
 			assert.Nil(t, err)
 
-			info, err := NewInfo(&table, tt.obj)
+			info, err := NewInfo("Test", &table, tt.obj)
 			if tt.err {
 				assert.NotNil(t, err)
 			} else {
@@ -67,6 +67,7 @@ func TestNewMapperInfo(t *testing.T) {
 			for _, col := range tt.expectedCols {
 				assert.Truef(t, info.hasColumn(col), "Expected column should be present in Mapper Info")
 			}
+			assert.Equal(t, "Test", info.Metadata.TableName)
 
 		})
 	}
@@ -141,7 +142,7 @@ func TestMapperInfoSet(t *testing.T) {
 			err := json.Unmarshal(tt.table, &table)
 			assert.Nil(t, err)
 
-			info, err := NewInfo(&table, tt.obj)
+			info, err := NewInfo("Test", &table, tt.obj)
 			assert.Nil(t, err)
 
 			err = info.SetField(tt.column, tt.field)
@@ -222,7 +223,7 @@ func TestMapperInfoColByPtr(t *testing.T) {
 			err := json.Unmarshal(tt.table, &table)
 			assert.Nil(t, err)
 
-			info, err := NewInfo(&table, tt.obj)
+			info, err := NewInfo("Test", &table, tt.obj)
 			assert.Nil(t, err)
 
 			col, err := info.ColumnByPtr(tt.field)
@@ -354,7 +355,7 @@ func TestOrmGetIndex(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("GetValidIndexes_%s", tt.name), func(t *testing.T) {
-			info, err := NewInfo(&table, tt.obj)
+			info, err := NewInfo("Test", &table, tt.obj)
 			assert.Nil(t, err)
 
 			indexes, err := info.getValidIndexes()

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -36,21 +36,6 @@ func (e *ErrMapper) Error() string {
 		e.objType, e.field, e.fieldType, e.fieldTag, e.reason)
 }
 
-// ErrNoTable describes a error in the provided table information
-type ErrNoTable struct {
-	table string
-}
-
-func (e *ErrNoTable) Error() string {
-	return fmt.Sprintf("Table not found: %s", e.table)
-}
-
-func newErrNoTable(table string) error {
-	return &ErrNoTable{
-		table: table,
-	}
-}
-
 // NewMapper returns a new mapper
 func NewMapper(schema *ovsdb.DatabaseSchema) *Mapper {
 	return &Mapper{
@@ -60,29 +45,19 @@ func NewMapper(schema *ovsdb.DatabaseSchema) *Mapper {
 
 // GetRowData transforms a Row to a struct based on its tags
 // The result object must be given as pointer to an object with the right tags
-func (m Mapper) GetRowData(tableName string, row *ovsdb.Row, result interface{}) error {
+func (m Mapper) GetRowData(row *ovsdb.Row, result *Info) error {
 	if row == nil {
 		return nil
 	}
-	return m.getData(tableName, *row, result)
+	return m.getData(*row, result)
 }
 
 // getData transforms a map[string]interface{} containing OvS types (e.g: a ResultRow
 // has this format) to orm struct
 // The result object must be given as pointer to an object with the right tags
-func (m Mapper) getData(tableName string, ovsData ovsdb.Row, result interface{}) error {
-	table := m.Schema.Table(tableName)
-	if table == nil {
-		return newErrNoTable(tableName)
-	}
-
-	mapperInfo, err := NewInfo(table, result)
-	if err != nil {
-		return err
-	}
-
-	for name, column := range table.Columns {
-		if !mapperInfo.hasColumn(name) {
+func (m Mapper) getData(ovsData ovsdb.Row, result *Info) error {
+	for name, column := range result.Metadata.TableSchema.Columns {
+		if !result.hasColumn(name) {
 			// If provided struct does not have a field to hold this value, skip it
 			continue
 		}
@@ -96,10 +71,10 @@ func (m Mapper) getData(tableName string, ovsData ovsdb.Row, result interface{})
 		nativeElem, err := ovsdb.OvsToNative(column, ovsElem)
 		if err != nil {
 			return fmt.Errorf("table %s, column %s: failed to extract native element: %s",
-				tableName, name, err.Error())
+				result.Metadata.TableName, name, err.Error())
 		}
 
-		if err := mapperInfo.SetField(name, nativeElem); err != nil {
+		if err := result.SetField(name, nativeElem); err != nil {
 			return err
 		}
 	}
@@ -109,24 +84,15 @@ func (m Mapper) getData(tableName string, ovsData ovsdb.Row, result interface{})
 // NewRow transforms an orm struct to a map[string] interface{} that can be used as libovsdb.Row
 // By default, default or null values are skipped. This behavior can be modified by specifying
 // a list of fields (pointers to fields in the struct) to be added to the row
-func (m Mapper) NewRow(tableName string, data interface{}, fields ...interface{}) (ovsdb.Row, error) {
-	table := m.Schema.Table(tableName)
-	if table == nil {
-		return nil, newErrNoTable(tableName)
-	}
-	mapperInfo, err := NewInfo(table, data)
-	if err != nil {
-		return nil, err
-	}
-
+func (m Mapper) NewRow(data *Info, fields ...interface{}) (ovsdb.Row, error) {
 	columns := make(map[string]*ovsdb.ColumnSchema)
-	for k, v := range table.Columns {
+	for k, v := range data.Metadata.TableSchema.Columns {
 		columns[k] = v
 	}
 	columns["_uuid"] = &ovsdb.UUIDColumn
 	ovsRow := make(map[string]interface{}, len(columns))
 	for name, column := range columns {
-		nativeElem, err := mapperInfo.FieldByColumn(name)
+		nativeElem, err := data.FieldByColumn(name)
 		if err != nil {
 			// If provided struct does not have a field to hold this value, skip it
 			continue
@@ -136,7 +102,7 @@ func (m Mapper) NewRow(tableName string, data interface{}, fields ...interface{}
 		if len(fields) > 0 {
 			found := false
 			for _, f := range fields {
-				col, err := mapperInfo.ColumnByPtr(f)
+				col, err := data.ColumnByPtr(f)
 				if err != nil {
 					return nil, err
 				}
@@ -154,7 +120,7 @@ func (m Mapper) NewRow(tableName string, data interface{}, fields ...interface{}
 		}
 		ovsElem, err := ovsdb.NativeToOvs(column, nativeElem)
 		if err != nil {
-			return nil, fmt.Errorf("table %s, column %s: failed to generate ovs element. %s", tableName, name, err.Error())
+			return nil, fmt.Errorf("table %s, column %s: failed to generate ovs element. %s", data.Metadata.TableName, name, err.Error())
 		}
 		ovsRow[name] = ovsElem
 	}
@@ -169,25 +135,15 @@ func (m Mapper) NewRow(tableName string, data interface{}, fields ...interface{}
 // object has valid data. The order in which they are traversed matches the order defined
 // in the schema.
 // By `valid data` we mean non-default data.
-func (m Mapper) NewEqualityCondition(tableName string, data interface{}, fields ...interface{}) ([]ovsdb.Condition, error) {
+func (m Mapper) NewEqualityCondition(data *Info, fields ...interface{}) ([]ovsdb.Condition, error) {
 	var conditions []ovsdb.Condition
 	var condIndex [][]string
-
-	table := m.Schema.Table(tableName)
-	if table == nil {
-		return nil, newErrNoTable(tableName)
-	}
-
-	mapperInfo, err := NewInfo(table, data)
-	if err != nil {
-		return nil, err
-	}
 
 	// If index is provided, use it. If not, obtain the valid indexes from the mapper info
 	if len(fields) > 0 {
 		providedIndex := []string{}
 		for i := range fields {
-			if col, err := mapperInfo.ColumnByPtr(fields[i]); err == nil {
+			if col, err := data.ColumnByPtr(fields[i]); err == nil {
 				providedIndex = append(providedIndex, col)
 			} else {
 				return nil, err
@@ -196,7 +152,7 @@ func (m Mapper) NewEqualityCondition(tableName string, data interface{}, fields 
 		condIndex = append(condIndex, providedIndex)
 	} else {
 		var err error
-		condIndex, err = mapperInfo.getValidIndexes()
+		condIndex, err = data.getValidIndexes()
 		if err != nil {
 			return nil, err
 		}
@@ -208,12 +164,12 @@ func (m Mapper) NewEqualityCondition(tableName string, data interface{}, fields 
 
 	// Pick the first valid index
 	for _, col := range condIndex[0] {
-		field, err := mapperInfo.FieldByColumn(col)
+		field, err := data.FieldByColumn(col)
 		if err != nil {
 			return nil, err
 		}
 
-		column := table.Column(col)
+		column := data.Metadata.TableSchema.Column(col)
 		if column == nil {
 			return nil, fmt.Errorf("column %s not found", col)
 		}
@@ -229,47 +185,27 @@ func (m Mapper) NewEqualityCondition(tableName string, data interface{}, fields 
 // EqualFields compares two mapped objects.
 // The indexes to use for comparison are, the _uuid, the table indexes and the columns that correspond
 // to the mapped fields pointed to by 'fields'. They must be pointers to fields on the first mapped element (i.e: one)
-func (m Mapper) EqualFields(tableName string, one, other interface{}, fields ...interface{}) (bool, error) {
+func (m Mapper) EqualFields(one, other *Info, fields ...interface{}) (bool, error) {
 	indexes := []string{}
-
-	table := m.Schema.Table(tableName)
-	if table == nil {
-		return false, newErrNoTable(tableName)
-	}
-
-	info, err := NewInfo(table, one)
-	if err != nil {
-		return false, err
-	}
 	for _, f := range fields {
-		col, err := info.ColumnByPtr(f)
+		col, err := one.ColumnByPtr(f)
 		if err != nil {
 			return false, err
 		}
 		indexes = append(indexes, col)
 	}
-	return m.equalIndexes(table, one, other, indexes...)
+	return m.equalIndexes(one, other, indexes...)
 }
 
 // NewCondition returns a ovsdb.Condition based on the model
-func (m Mapper) NewCondition(tableName string, data interface{}, field interface{}, function ovsdb.ConditionFunction, value interface{}) (*ovsdb.Condition, error) {
-	table := m.Schema.Table(tableName)
-	if table == nil {
-		return nil, newErrNoTable(tableName)
-	}
-
-	info, err := NewInfo(table, data)
-	if err != nil {
-		return nil, err
-	}
-
-	column, err := info.ColumnByPtr(field)
+func (m Mapper) NewCondition(data *Info, field interface{}, function ovsdb.ConditionFunction, value interface{}) (*ovsdb.Condition, error) {
+	column, err := data.ColumnByPtr(field)
 	if err != nil {
 		return nil, err
 	}
 
 	// Check that the condition is valid
-	columnSchema := table.Column(column)
+	columnSchema := data.Metadata.TableSchema.Column(column)
 	if columnSchema == nil {
 		return nil, fmt.Errorf("column %s not found", column)
 	}
@@ -290,23 +226,13 @@ func (m Mapper) NewCondition(tableName string, data interface{}, field interface
 
 // NewMutation creates a RFC7047 mutation object based on an ORM object and the mutation fields (in native format)
 // It takes care of field validation against the column type
-func (m Mapper) NewMutation(tableName string, data interface{}, column string, mutator ovsdb.Mutator, value interface{}) (*ovsdb.Mutation, error) {
-	table := m.Schema.Table(tableName)
-	if table == nil {
-		return nil, newErrNoTable(tableName)
-	}
-
-	mapperInfo, err := NewInfo(table, data)
-	if err != nil {
-		return nil, err
-	}
-
+func (m Mapper) NewMutation(data *Info, column string, mutator ovsdb.Mutator, value interface{}) (*ovsdb.Mutation, error) {
 	// Check the column exists in the object
-	if !mapperInfo.hasColumn(column) {
+	if !data.hasColumn(column) {
 		return nil, fmt.Errorf("mutation contains column %s that does not exist in object %v", column, data)
 	}
 	// Check that the mutation is valid
-	columnSchema := table.Column(column)
+	columnSchema := data.Metadata.TableSchema.Column(column)
 	if columnSchema == nil {
 		return nil, fmt.Errorf("column %s not found", column)
 	}
@@ -315,6 +241,7 @@ func (m Mapper) NewMutation(tableName string, data interface{}, column string, m
 	}
 
 	var ovsValue interface{}
+	var err error
 	// Usually a mutation value is of the same type of the value being mutated
 	// except for delete mutation of maps where it can also be a list of same type of
 	// keys (rfc7047 5.1). Handle this special case here.
@@ -341,24 +268,15 @@ func (m Mapper) NewMutation(tableName string, data interface{}, column string, m
 // For any of the indexes defined in the Table Schema, the values all of its columns are simultaneously equal
 // (as per RFC7047)
 // The values of all of the optional indexes passed as variadic parameter to this function are equal.
-func (m Mapper) equalIndexes(table *ovsdb.TableSchema, one, other interface{}, indexes ...string) (bool, error) {
+func (m Mapper) equalIndexes(one, other *Info, indexes ...string) (bool, error) {
 	match := false
 
-	oneMapperInfo, err := NewInfo(table, one)
-	if err != nil {
-		return false, err
-	}
-	otherMapperInfo, err := NewInfo(table, other)
+	oneIndexes, err := one.getValidIndexes()
 	if err != nil {
 		return false, err
 	}
 
-	oneIndexes, err := oneMapperInfo.getValidIndexes()
-	if err != nil {
-		return false, err
-	}
-
-	otherIndexes, err := otherMapperInfo.getValidIndexes()
+	otherIndexes, err := other.getValidIndexes()
 	if err != nil {
 		return false, err
 	}
@@ -371,14 +289,14 @@ func (m Mapper) equalIndexes(table *ovsdb.TableSchema, one, other interface{}, i
 			if reflect.DeepEqual(ridx, lidx) {
 				// All columns in an index must be simultaneously equal
 				for _, col := range lidx {
-					if !oneMapperInfo.hasColumn(col) || !otherMapperInfo.hasColumn(col) {
+					if !one.hasColumn(col) || !other.hasColumn(col) {
 						break
 					}
-					lfield, err := oneMapperInfo.FieldByColumn(col)
+					lfield, err := one.FieldByColumn(col)
 					if err != nil {
 						return false, err
 					}
-					rfield, err := otherMapperInfo.FieldByColumn(col)
+					rfield, err := other.FieldByColumn(col)
 					if err != nil {
 						return false, err
 					}
@@ -401,23 +319,18 @@ func (m Mapper) equalIndexes(table *ovsdb.TableSchema, one, other interface{}, i
 // NewMonitorRequest returns a monitor request for the provided tableName
 // If fields is provided, the request will be constrained to the provided columns
 // If no fields are provided, all columns will be used
-func (m *Mapper) NewMonitorRequest(tableName string, data interface{}, fields []interface{}) (*ovsdb.MonitorRequest, error) {
+func (m *Mapper) NewMonitorRequest(data *Info, fields []interface{}) (*ovsdb.MonitorRequest, error) {
 	var columns []string
-	schema := m.Schema.Tables[tableName]
-	info, err := NewInfo(&schema, data)
-	if err != nil {
-		return nil, err
-	}
 	if len(fields) > 0 {
 		for _, f := range fields {
-			column, err := info.ColumnByPtr(f)
+			column, err := data.ColumnByPtr(f)
 			if err != nil {
 				return nil, err
 			}
 			columns = append(columns, column)
 		}
 	} else {
-		for c := range info.table.Columns {
+		for c := range data.Metadata.TableSchema.Columns {
 			columns = append(columns, c)
 		}
 	}

--- a/model/client.go
+++ b/model/client.go
@@ -15,7 +15,7 @@ type ClientDBModel struct {
 }
 
 // NewModel returns a new instance of a model from a specific string
-func (db ClientDBModel) NewModel(table string) (Model, error) {
+func (db ClientDBModel) newModel(table string) (Model, error) {
 	mtype, ok := db.types[table]
 	if !ok {
 		return nil, fmt.Errorf("table %s not found in database model", string(table))
@@ -24,32 +24,14 @@ func (db ClientDBModel) NewModel(table string) (Model, error) {
 	return model.Interface().(Model), nil
 }
 
-// Types returns the ClientDBModel Types
-// the ClientDBModel types is a map of reflect.Types indexed by string
-// The reflect.Type is a pointer to a struct that contains 'ovs' tags
-// as described above. Such pointer to struct also implements the Model interface
-func (db ClientDBModel) Types() map[string]reflect.Type {
-	return db.types
-}
-
 // Name returns the database name
 func (db ClientDBModel) Name() string {
 	return db.name
 }
 
-// FindTable returns the string associated with a reflect.Type or ""
-func (db ClientDBModel) FindTable(mType reflect.Type) string {
-	for table, tType := range db.types {
-		if tType == mType {
-			return table
-		}
-	}
-	return ""
-}
-
 // Validate validates the DatabaseModel against the input schema
 // Returns all the errors detected
-func (db ClientDBModel) Validate(schema *ovsdb.DatabaseSchema) []error {
+func (db ClientDBModel) validate(schema *ovsdb.DatabaseSchema) []error {
 	var errors []error
 	if db.name != schema.Name {
 		errors = append(errors, fmt.Errorf("database model name (%s) does not match schema (%s)",
@@ -62,7 +44,7 @@ func (db ClientDBModel) Validate(schema *ovsdb.DatabaseSchema) []error {
 			errors = append(errors, fmt.Errorf("database model contains a model for table %s that does not exist in schema", tableName))
 			continue
 		}
-		model, err := db.NewModel(tableName)
+		model, err := db.newModel(tableName)
 		if err != nil {
 			errors = append(errors, err)
 			continue

--- a/model/client.go
+++ b/model/client.go
@@ -49,7 +49,7 @@ func (db ClientDBModel) validate(schema *ovsdb.DatabaseSchema) []error {
 			errors = append(errors, err)
 			continue
 		}
-		if _, err := mapper.NewInfo(tableSchema, model); err != nil {
+		if _, err := mapper.NewInfo(tableName, tableSchema, model); err != nil {
 			errors = append(errors, err)
 		}
 	}

--- a/model/client.go
+++ b/model/client.go
@@ -1,0 +1,102 @@
+package model
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/ovn-org/libovsdb/mapper"
+	"github.com/ovn-org/libovsdb/ovsdb"
+)
+
+// ClientDBModel contains the client information needed to build a DatabaseModel
+type ClientDBModel struct {
+	name  string
+	types map[string]reflect.Type
+}
+
+// NewModel returns a new instance of a model from a specific string
+func (db ClientDBModel) NewModel(table string) (Model, error) {
+	mtype, ok := db.types[table]
+	if !ok {
+		return nil, fmt.Errorf("table %s not found in database model", string(table))
+	}
+	model := reflect.New(mtype.Elem())
+	return model.Interface().(Model), nil
+}
+
+// Types returns the ClientDBModel Types
+// the ClientDBModel types is a map of reflect.Types indexed by string
+// The reflect.Type is a pointer to a struct that contains 'ovs' tags
+// as described above. Such pointer to struct also implements the Model interface
+func (db ClientDBModel) Types() map[string]reflect.Type {
+	return db.types
+}
+
+// Name returns the database name
+func (db ClientDBModel) Name() string {
+	return db.name
+}
+
+// FindTable returns the string associated with a reflect.Type or ""
+func (db ClientDBModel) FindTable(mType reflect.Type) string {
+	for table, tType := range db.types {
+		if tType == mType {
+			return table
+		}
+	}
+	return ""
+}
+
+// Validate validates the DatabaseModel against the input schema
+// Returns all the errors detected
+func (db ClientDBModel) Validate(schema *ovsdb.DatabaseSchema) []error {
+	var errors []error
+	if db.name != schema.Name {
+		errors = append(errors, fmt.Errorf("database model name (%s) does not match schema (%s)",
+			db.name, schema.Name))
+	}
+
+	for tableName := range db.types {
+		tableSchema := schema.Table(tableName)
+		if tableSchema == nil {
+			errors = append(errors, fmt.Errorf("database model contains a model for table %s that does not exist in schema", tableName))
+			continue
+		}
+		model, err := db.NewModel(tableName)
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+		if _, err := mapper.NewInfo(tableSchema, model); err != nil {
+			errors = append(errors, err)
+		}
+	}
+	return errors
+}
+
+// NewClientDBModel constructs a ClientDBModel based on a database name and dictionary of models indexed by table name
+func NewClientDBModel(name string, models map[string]Model) (*ClientDBModel, error) {
+	types := make(map[string]reflect.Type, len(models))
+	for table, model := range models {
+		modelType := reflect.TypeOf(model)
+		if modelType.Kind() != reflect.Ptr || modelType.Elem().Kind() != reflect.Struct {
+			return nil, fmt.Errorf("model is expected to be a pointer to struct")
+		}
+		hasUUID := false
+		for i := 0; i < modelType.Elem().NumField(); i++ {
+			if field := modelType.Elem().Field(i); field.Tag.Get("ovsdb") == "_uuid" &&
+				field.Type.Kind() == reflect.String {
+				hasUUID = true
+			}
+		}
+		if !hasUUID {
+			return nil, fmt.Errorf("model is expected to have a string field called uuid")
+		}
+
+		types[table] = reflect.TypeOf(model)
+	}
+	return &ClientDBModel{
+		types: types,
+		name:  name,
+	}, nil
+}

--- a/model/database.go
+++ b/model/database.go
@@ -25,25 +25,6 @@ func NewDatabaseModel(schema *ovsdb.DatabaseSchema, request *ClientDBModel) *Dat
 	}
 }
 
-// Client returns the DatabaseModel's client dbModel
-func (db *DatabaseModel) Client() *ClientDBModel {
-	return db.client
-}
-
-// Schema returns the DatabaseModel's schema
-func (db *DatabaseModel) Schema() *ovsdb.DatabaseSchema {
-	db.mutex.RLock()
-	defer db.mutex.RUnlock()
-	return db.schema
-}
-
-// Mapper returns the DatabaseModel's mapper
-func (db *DatabaseModel) Mapper() *mapper.Mapper {
-	db.mutex.RLock()
-	defer db.mutex.RUnlock()
-	return db.mapper
-}
-
 // NewPartialDatabaseModel returns a DatabaseModel what does not have a schema yet
 func NewPartialDatabaseModel(client *ClientDBModel) *DatabaseModel {
 	return &DatabaseModel{
@@ -77,4 +58,23 @@ func (db *DatabaseModel) ClearSchema() {
 	defer db.mutex.Unlock()
 	db.schema = nil
 	db.mapper = nil
+}
+
+// Client returns the DatabaseModel's client dbModel
+func (db *DatabaseModel) Client() *ClientDBModel {
+	return db.client
+}
+
+// Schema returns the DatabaseModel's schema
+func (db *DatabaseModel) Schema() *ovsdb.DatabaseSchema {
+	db.mutex.RLock()
+	defer db.mutex.RUnlock()
+	return db.schema
+}
+
+// Mapper returns the DatabaseModel's mapper
+func (db *DatabaseModel) Mapper() *mapper.Mapper {
+	db.mutex.RLock()
+	defer db.mutex.RUnlock()
+	return db.mapper
 }

--- a/model/database.go
+++ b/model/database.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"sync"
+
 	"github.com/ovn-org/libovsdb/mapper"
 	"github.com/ovn-org/libovsdb/ovsdb"
 )
@@ -11,6 +13,7 @@ type DatabaseModel struct {
 	client *ClientDBModel
 	schema *ovsdb.DatabaseSchema
 	mapper *mapper.Mapper
+	mutex  sync.RWMutex
 }
 
 // NewDatabaseModel returns a new DatabaseModel
@@ -29,10 +32,49 @@ func (db *DatabaseModel) Client() *ClientDBModel {
 
 // Schema returns the DatabaseModel's schema
 func (db *DatabaseModel) Schema() *ovsdb.DatabaseSchema {
+	db.mutex.RLock()
+	defer db.mutex.RUnlock()
 	return db.schema
 }
 
 // Mapper returns the DatabaseModel's mapper
 func (db *DatabaseModel) Mapper() *mapper.Mapper {
+	db.mutex.RLock()
+	defer db.mutex.RUnlock()
 	return db.mapper
+}
+
+// NewPartialDatabaseModel returns a DatabaseModel what does not have a schema yet
+func NewPartialDatabaseModel(client *ClientDBModel) *DatabaseModel {
+	return &DatabaseModel{
+		client: client,
+	}
+}
+
+// Valid returns whether the DatabaseModel is fully functional
+func (db *DatabaseModel) Valid() bool {
+	db.mutex.RLock()
+	defer db.mutex.RUnlock()
+	return db.schema != nil
+}
+
+// SetSchema adds the Schema to the DatabaseModel making it valid if it was not before
+func (db *DatabaseModel) SetSchema(schema *ovsdb.DatabaseSchema) []error {
+	db.mutex.Lock()
+	defer db.mutex.Unlock()
+	errors := db.client.Validate(schema)
+	if len(errors) > 0 {
+		return errors
+	}
+	db.schema = schema
+	db.mapper = mapper.NewMapper(schema)
+	return errors
+}
+
+// ClearSchema removes the Schema from the DatabaseModel making it not valid
+func (db *DatabaseModel) ClearSchema() {
+	db.mutex.Lock()
+	defer db.mutex.Unlock()
+	db.schema = nil
+	db.mapper = nil
 }

--- a/model/database.go
+++ b/model/database.go
@@ -12,19 +12,21 @@ import (
 // A DatabaseModel represents libovsdb's metadata about the database.
 // It's the result of combining the client's ClientDBModel and the server's Schema
 type DatabaseModel struct {
-	client *ClientDBModel
-	schema *ovsdb.DatabaseSchema
-	mapper *mapper.Mapper
-	mutex  sync.RWMutex
+	client   *ClientDBModel
+	schema   *ovsdb.DatabaseSchema
+	mapper   *mapper.Mapper
+	mutex    sync.RWMutex
+	metadata map[reflect.Type]*mapper.Metadata
 }
 
 // NewDatabaseModel returns a new DatabaseModel
-func NewDatabaseModel(schema *ovsdb.DatabaseSchema, client *ClientDBModel) *DatabaseModel {
-	return &DatabaseModel{
-		client: client,
-		schema: schema,
-		mapper: mapper.NewMapper(schema),
+func NewDatabaseModel(schema *ovsdb.DatabaseSchema, client *ClientDBModel) (*DatabaseModel, []error) {
+	dbModel := NewPartialDatabaseModel(client)
+	errs := dbModel.SetSchema(schema)
+	if len(errs) > 0 {
+		return nil, errs
 	}
+	return dbModel, nil
 }
 
 // NewPartialDatabaseModel returns a DatabaseModel what does not have a schema yet
@@ -51,7 +53,13 @@ func (db *DatabaseModel) SetSchema(schema *ovsdb.DatabaseSchema) []error {
 	}
 	db.schema = schema
 	db.mapper = mapper.NewMapper(schema)
-	return errors
+	errs := db.generateModelInfo()
+	if len(errs) > 0 {
+		db.schema = nil
+		db.mapper = nil
+		return errs
+	}
+	return []error{}
 }
 
 // ClearSchema removes the Schema from the DatabaseModel making it not valid
@@ -107,4 +115,43 @@ func (db *DatabaseModel) FindTable(mType reflect.Type) string {
 		}
 	}
 	return ""
+}
+
+// generateModelMetadata creates metadata objects from all models included in the
+// database and caches them for future re-use
+func (db *DatabaseModel) generateModelInfo() []error {
+	errors := []error{}
+	metadata := make(map[reflect.Type]*mapper.Metadata, len(db.client.types))
+	for tableName, tType := range db.client.types {
+		tableSchema := db.schema.Table(tableName)
+		if tableSchema == nil {
+			errors = append(errors, fmt.Errorf("Database Model contains model for table %s which is not present in schema", tableName))
+			continue
+		}
+		obj, err := db.NewModel(tableName)
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+		info, err := mapper.NewInfo(tableName, tableSchema, obj)
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+		metadata[tType] = info.Metadata
+	}
+	db.metadata = metadata
+	return errors
+}
+
+// NewModelInfo returns a mapper.Info object based on a provided model
+func (db *DatabaseModel) NewModelInfo(obj interface{}) (*mapper.Info, error) {
+	meta, ok := db.metadata[reflect.TypeOf(obj)]
+	if !ok {
+		return nil, ovsdb.NewErrWrongType("NewModelInfo", "type that is part of the DatabaseModel", obj)
+	}
+	return &mapper.Info{
+		Obj:      obj,
+		Metadata: meta,
+	}, nil
 }

--- a/model/database.go
+++ b/model/database.go
@@ -1,0 +1,38 @@
+package model
+
+import (
+	"github.com/ovn-org/libovsdb/mapper"
+	"github.com/ovn-org/libovsdb/ovsdb"
+)
+
+// A DatabaseModel represents libovsdb's metadata about the database.
+// It's the result of combining the client's ClientDBModel and the server's Schema
+type DatabaseModel struct {
+	client *ClientDBModel
+	schema *ovsdb.DatabaseSchema
+	mapper *mapper.Mapper
+}
+
+// NewDatabaseModel returns a new DatabaseModel
+func NewDatabaseModel(schema *ovsdb.DatabaseSchema, request *ClientDBModel) *DatabaseModel {
+	return &DatabaseModel{
+		client: request,
+		schema: schema,
+		mapper: mapper.NewMapper(schema),
+	}
+}
+
+// Client returns the DatabaseModel's client dbModel
+func (db *DatabaseModel) Client() *ClientDBModel {
+	return db.client
+}
+
+// Schema returns the DatabaseModel's schema
+func (db *DatabaseModel) Schema() *ovsdb.DatabaseSchema {
+	return db.schema
+}
+
+// Mapper returns the DatabaseModel's mapper
+func (db *DatabaseModel) Mapper() *mapper.Mapper {
+	return db.mapper
+}

--- a/model/model.go
+++ b/model/model.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/ovn-org/libovsdb/mapper"
 	"github.com/ovn-org/libovsdb/ovsdb"
 )
 
@@ -32,99 +31,6 @@ func Clone(a Model) Model {
 	aBytes, _ := json.Marshal(a)
 	_ = json.Unmarshal(aBytes, b)
 	return b
-}
-
-// DBModel is a Database model
-type DBModel struct {
-	name  string
-	types map[string]reflect.Type
-}
-
-// NewModel returns a new instance of a model from a specific string
-func (db DBModel) NewModel(table string) (Model, error) {
-	mtype, ok := db.types[table]
-	if !ok {
-		return nil, fmt.Errorf("table %s not found in database model", string(table))
-	}
-	model := reflect.New(mtype.Elem())
-	return model.Interface().(Model), nil
-}
-
-// Types returns the DBModel Types
-// the DBModel types is a map of reflect.Types indexed by string
-// The reflect.Type is a pointer to a struct that contains 'ovs' tags
-// as described above. Such pointer to struct also implements the Model interface
-func (db DBModel) Types() map[string]reflect.Type {
-	return db.types
-}
-
-// Name returns the database name
-func (db DBModel) Name() string {
-	return db.name
-}
-
-// FindTable returns the string associated with a reflect.Type or ""
-func (db DBModel) FindTable(mType reflect.Type) string {
-	for table, tType := range db.types {
-		if tType == mType {
-			return table
-		}
-	}
-	return ""
-}
-
-// Validate validates the DatabaseModel against the input schema
-// Returns all the errors detected
-func (db DBModel) Validate(schema *ovsdb.DatabaseSchema) []error {
-	var errors []error
-	if db.name != schema.Name {
-		errors = append(errors, fmt.Errorf("database model name (%s) does not match schema (%s)",
-			db.name, schema.Name))
-	}
-
-	for tableName := range db.types {
-		tableSchema := schema.Table(tableName)
-		if tableSchema == nil {
-			errors = append(errors, fmt.Errorf("database model contains a model for table %s that does not exist in schema", tableName))
-			continue
-		}
-		model, err := db.NewModel(tableName)
-		if err != nil {
-			errors = append(errors, err)
-			continue
-		}
-		if _, err := mapper.NewInfo(tableSchema, model); err != nil {
-			errors = append(errors, err)
-		}
-	}
-	return errors
-}
-
-// NewDBModel constructs a DBModel based on a database name and dictionary of models indexed by table name
-func NewDBModel(name string, models map[string]Model) (*DBModel, error) {
-	types := make(map[string]reflect.Type, len(models))
-	for table, model := range models {
-		modelType := reflect.TypeOf(model)
-		if modelType.Kind() != reflect.Ptr || modelType.Elem().Kind() != reflect.Struct {
-			return nil, fmt.Errorf("model is expected to be a pointer to struct")
-		}
-		hasUUID := false
-		for i := 0; i < modelType.Elem().NumField(); i++ {
-			if field := modelType.Elem().Field(i); field.Tag.Get("ovsdb") == "_uuid" &&
-				field.Type.Kind() == reflect.String {
-				hasUUID = true
-			}
-		}
-		if !hasUUID {
-			return nil, fmt.Errorf("model is expected to have a string field called uuid")
-		}
-
-		types[table] = reflect.TypeOf(model)
-	}
-	return &DBModel{
-		types: types,
-		name:  name,
-	}, nil
 }
 
 func modelSetUUID(model Model, uuid string) error {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -53,7 +53,7 @@ func TestClientDBModel(t *testing.T) {
 			db, err := NewClientDBModel(tt.name, tt.obj)
 			if tt.valid {
 				assert.Nil(t, err)
-				assert.Len(t, db.Types(), len(tt.obj))
+				assert.Len(t, db.types, len(tt.obj))
 				assert.Equal(t, tt.name, db.Name())
 			} else {
 				assert.NotNil(t, err)
@@ -65,9 +65,9 @@ func TestClientDBModel(t *testing.T) {
 func TestNewModel(t *testing.T) {
 	db, err := NewClientDBModel("testTable", map[string]Model{"Test_A": &modelA{}, "Test_B": &modelB{}})
 	assert.Nil(t, err)
-	_, err = db.NewModel("Unknown")
+	_, err = db.newModel("Unknown")
 	assert.NotNilf(t, err, "Creating model from unknown table should fail")
-	model, err := db.NewModel("Test_A")
+	model, err := db.newModel("Test_A")
 	assert.Nilf(t, err, "Creating model from valid table should succeed")
 	assert.IsTypef(t, model, &modelA{}, "model creation should return the appropriate type")
 }
@@ -324,7 +324,7 @@ func TestValidate(t *testing.T) {
 			var schema ovsdb.DatabaseSchema
 			err := json.Unmarshal(tt.schema, &schema)
 			assert.Nil(t, err)
-			errors := model.Validate(&schema)
+			errors := model.validate(&schema)
 			if tt.err {
 				assert.Greater(t, len(errors), 0)
 			} else {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -23,7 +23,7 @@ type modelInvalid struct {
 	Foo string
 }
 
-func TestDBModel(t *testing.T) {
+func TestClientDBModel(t *testing.T) {
 	type Test struct {
 		name  string
 		obj   map[string]Model
@@ -50,7 +50,7 @@ func TestDBModel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("TestNewModel_%s", tt.name), func(t *testing.T) {
-			db, err := NewDBModel(tt.name, tt.obj)
+			db, err := NewClientDBModel(tt.name, tt.obj)
 			if tt.valid {
 				assert.Nil(t, err)
 				assert.Len(t, db.Types(), len(tt.obj))
@@ -63,7 +63,7 @@ func TestDBModel(t *testing.T) {
 }
 
 func TestNewModel(t *testing.T) {
-	db, err := NewDBModel("testTable", map[string]Model{"Test_A": &modelA{}, "Test_B": &modelB{}})
+	db, err := NewClientDBModel("testTable", map[string]Model{"Test_A": &modelA{}, "Test_B": &modelB{}})
 	assert.Nil(t, err)
 	_, err = db.NewModel("Unknown")
 	assert.NotNilf(t, err, "Creating model from unknown table should fail")
@@ -86,7 +86,7 @@ func TestSetUUID(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	model, err := NewDBModel("TestDB", map[string]Model{
+	model, err := NewClientDBModel("TestDB", map[string]Model{
 		"TestTable": &struct {
 			aUUID   string            `ovsdb:"_uuid"`
 			aString string            `ovsdb:"aString"`

--- a/modelgen/dbmodel.go
+++ b/modelgen/dbmodel.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ovn-org/libovsdb/ovsdb"
 )
 
-// NewDBTemplate return a new DBModel template
+// NewDBTemplate return a new ClientDBModel template
 // It includes the following other templates that can be overridden to customize the generated file
 // "header"
 // "preDBDefinitions"
@@ -40,8 +40,8 @@ package {{ index . "PackageName" }}
 {{ template "preDBDefinitions" }}
 
 // FullDatabaseModel returns the DatabaseModel object to be used in libovsdb
-func FullDatabaseModel() (*model.DBModel, error) {
-	return model.NewDBModel("{{ index . "DatabaseName" }}", map[string]model.Model{
+func FullDatabaseModel() (*model.ClientDBModel, error) {
+	return model.NewClientDBModel("{{ index . "DatabaseName" }}", map[string]model.Model{
     {{ range index . "Tables" }} "{{ .TableName }}" : &{{ .StructName }}{}, 
     {{ end }}
 	})

--- a/modelgen/dbmodel_test.go
+++ b/modelgen/dbmodel_test.go
@@ -59,8 +59,8 @@ import (
 )
 
 // FullDatabaseModel returns the DatabaseModel object to be used in libovsdb
-func FullDatabaseModel() (*model.DBModel, error) {
-	return model.NewDBModel("AtomicDB", map[string]model.Model{
+func FullDatabaseModel() (*model.ClientDBModel, error) {
+	return model.NewClientDBModel("AtomicDB", map[string]model.Model{
 		"atomicTable": &AtomicTable{},
 	})
 }

--- a/ovsdb/serverdb/model.go
+++ b/ovsdb/serverdb/model.go
@@ -11,8 +11,8 @@ import (
 )
 
 // FullDatabaseModel returns the DatabaseModel object to be used in libovsdb
-func FullDatabaseModel() (*model.DBModel, error) {
-	return model.NewDBModel("_Server", map[string]model.Model{
+func FullDatabaseModel() (*model.ClientDBModel, error) {
+	return model.NewClientDBModel("_Server", map[string]model.Model{
 		"Database": &Database{},
 	})
 }

--- a/server/database.go
+++ b/server/database.go
@@ -22,11 +22,11 @@ type Database interface {
 
 type inMemoryDatabase struct {
 	databases map[string]*cache.TableCache
-	models    map[string]*model.DBModel
+	models    map[string]*model.ClientDBModel
 	mutex     sync.RWMutex
 }
 
-func NewInMemoryDatabase(models map[string]*model.DBModel) Database {
+func NewInMemoryDatabase(models map[string]*model.ClientDBModel) Database {
 	return &inMemoryDatabase{
 		databases: make(map[string]*cache.TableCache),
 		models:    models,
@@ -37,7 +37,7 @@ func NewInMemoryDatabase(models map[string]*model.DBModel) Database {
 func (db *inMemoryDatabase) CreateDatabase(name string, schema *ovsdb.DatabaseSchema) error {
 	db.mutex.Lock()
 	defer db.mutex.Unlock()
-	var mo *model.DBModel
+	var mo *model.ClientDBModel
 	var ok bool
 	if mo, ok = db.models[schema.Name]; !ok {
 		return fmt.Errorf("no db model provided for schema with name %s", name)

--- a/server/database.go
+++ b/server/database.go
@@ -42,7 +42,8 @@ func (db *inMemoryDatabase) CreateDatabase(name string, schema *ovsdb.DatabaseSc
 	if mo, ok = db.models[schema.Name]; !ok {
 		return fmt.Errorf("no db model provided for schema with name %s", name)
 	}
-	database, err := cache.NewTableCache(schema, mo, nil, nil)
+	dbModel := model.NewDatabaseModel(schema, mo)
+	database, err := cache.NewTableCache(dbModel, nil, nil)
 	if err != nil {
 		return nil
 	}

--- a/server/database.go
+++ b/server/database.go
@@ -42,7 +42,10 @@ func (db *inMemoryDatabase) CreateDatabase(name string, schema *ovsdb.DatabaseSc
 	if mo, ok = db.models[schema.Name]; !ok {
 		return fmt.Errorf("no db model provided for schema with name %s", name)
 	}
-	dbModel := model.NewDatabaseModel(schema, mo)
+	dbModel, errs := model.NewDatabaseModel(schema, mo)
+	if len(errs) > 0 {
+		return fmt.Errorf("Failed to create DatabaseModel: %#+v", errs)
+	}
 	database, err := cache.NewTableCache(dbModel, nil, nil)
 	if err != nil {
 		return nil

--- a/server/server.go
+++ b/server/server.go
@@ -29,7 +29,7 @@ type OvsdbServer struct {
 }
 
 type DatabaseModel struct {
-	Model  *model.DBModel
+	Model  *model.ClientDBModel
 	Schema *ovsdb.DatabaseSchema
 }
 
@@ -141,7 +141,7 @@ type Transaction struct {
 	Cache *cache.TableCache
 }
 
-func NewTransaction(schema *ovsdb.DatabaseSchema, model *model.DBModel) Transaction {
+func NewTransaction(schema *ovsdb.DatabaseSchema, model *model.ClientDBModel) Transaction {
 	cache, err := cache.NewTableCache(schema, model, nil, nil)
 	if err != nil {
 		panic(err)

--- a/server/server.go
+++ b/server/server.go
@@ -22,34 +22,29 @@ type OvsdbServer struct {
 	db           Database
 	ready        bool
 	readyMutex   sync.RWMutex
-	models       map[string]DatabaseModel
+	models       map[string]*model.DatabaseModel
 	modelsMutex  sync.RWMutex
 	monitors     map[*rpc2.Client]*connectionMonitors
 	monitorMutex sync.RWMutex
 }
 
-type DatabaseModel struct {
-	Model  *model.ClientDBModel
-	Schema *ovsdb.DatabaseSchema
-}
-
 // NewOvsdbServer returns a new OvsdbServer
-func NewOvsdbServer(db Database, models ...DatabaseModel) (*OvsdbServer, error) {
+func NewOvsdbServer(db Database, models ...*model.DatabaseModel) (*OvsdbServer, error) {
 	o := &OvsdbServer{
 		done:         make(chan struct{}, 1),
 		db:           db,
-		models:       make(map[string]DatabaseModel),
+		models:       make(map[string]*model.DatabaseModel),
 		modelsMutex:  sync.RWMutex{},
 		monitors:     make(map[*rpc2.Client]*connectionMonitors),
 		monitorMutex: sync.RWMutex{},
 	}
 	o.modelsMutex.Lock()
 	for _, model := range models {
-		o.models[model.Schema.Name] = model
+		o.models[model.Schema().Name] = model
 	}
 	o.modelsMutex.Unlock()
 	for database, model := range o.models {
-		if err := o.db.CreateDatabase(database, model.Schema); err != nil {
+		if err := o.db.CreateDatabase(database, model.Schema()); err != nil {
 			return nil, err
 		}
 	}
@@ -113,7 +108,7 @@ func (o *OvsdbServer) ListDatabases(client *rpc2.Client, args []interface{}, rep
 	dbs := []string{}
 	o.modelsMutex.RLock()
 	for _, db := range o.models {
-		dbs = append(dbs, db.Schema.Name)
+		dbs = append(dbs, db.Schema().Name)
 	}
 	o.modelsMutex.RUnlock()
 	*reply = dbs
@@ -132,7 +127,7 @@ func (o *OvsdbServer) GetSchema(client *rpc2.Client, args []interface{}, reply *
 		return fmt.Errorf("database %s does not exist", db)
 	}
 	o.modelsMutex.RUnlock()
-	*reply = *model.Schema
+	*reply = *model.Schema()
 	return nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -136,8 +136,8 @@ type Transaction struct {
 	Cache *cache.TableCache
 }
 
-func NewTransaction(schema *ovsdb.DatabaseSchema, model *model.ClientDBModel) Transaction {
-	cache, err := cache.NewTableCache(schema, model, nil, nil)
+func NewTransaction(model *model.DatabaseModel) Transaction {
+	cache, err := cache.NewTableCache(model, nil, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/server/server_integration_test.go
+++ b/server/server_integration_test.go
@@ -69,10 +69,7 @@ func TestClientServerEcho(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
-	server, err := NewOvsdbServer(ovsDB, DatabaseModel{
-		Model:  defDB,
-		Schema: schema,
-	})
+	server, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
 	require.Nil(t, err)
 
 	go func(t *testing.T, o *OvsdbServer) {
@@ -106,10 +103,7 @@ func TestClientServerInsert(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
-	server, err := NewOvsdbServer(ovsDB, DatabaseModel{
-		Model:  defDB,
-		Schema: schema,
-	})
+	server, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
 	assert.Nil(t, err)
 
 	go func(t *testing.T, o *OvsdbServer) {
@@ -178,10 +172,7 @@ func TestClientServerMonitor(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
-	server, err := NewOvsdbServer(ovsDB, DatabaseModel{
-		Model:  defDB,
-		Schema: schema,
-	})
+	server, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
 	assert.Nil(t, err)
 
 	go func(t *testing.T, o *OvsdbServer) {
@@ -301,10 +292,7 @@ func TestClientServerInsertAndDelete(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
-	server, err := NewOvsdbServer(ovsDB, DatabaseModel{
-		Model:  defDB,
-		Schema: schema,
-	})
+	server, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
 	assert.Nil(t, err)
 
 	go func(t *testing.T, o *OvsdbServer) {
@@ -368,10 +356,7 @@ func TestClientServerInsertDuplicate(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
-	server, err := NewOvsdbServer(ovsDB, DatabaseModel{
-		Model:  defDB,
-		Schema: schema,
-	})
+	server, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
 	assert.Nil(t, err)
 
 	go func(t *testing.T, o *OvsdbServer) {
@@ -423,10 +408,7 @@ func TestClientServerInsertAndUpdate(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
-	server, err := NewOvsdbServer(ovsDB, DatabaseModel{
-		Model:  defDB,
-		Schema: schema,
-	})
+	server, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
 	assert.Nil(t, err)
 
 	go func(t *testing.T, o *OvsdbServer) {

--- a/server/server_integration_test.go
+++ b/server/server_integration_test.go
@@ -69,7 +69,9 @@ func TestClientServerEcho(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
-	server, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
+	dbModel, errs := model.NewDatabaseModel(schema, defDB)
+	require.Empty(t, errs)
+	server, err := NewOvsdbServer(ovsDB, dbModel)
 	require.Nil(t, err)
 
 	go func(t *testing.T, o *OvsdbServer) {
@@ -103,7 +105,9 @@ func TestClientServerInsert(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
-	server, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
+	dbModel, errs := model.NewDatabaseModel(schema, defDB)
+	require.Empty(t, errs)
+	server, err := NewOvsdbServer(ovsDB, dbModel)
 	assert.Nil(t, err)
 
 	go func(t *testing.T, o *OvsdbServer) {
@@ -172,7 +176,9 @@ func TestClientServerMonitor(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
-	server, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
+	dbModel, errs := model.NewDatabaseModel(schema, defDB)
+	require.Empty(t, errs)
+	server, err := NewOvsdbServer(ovsDB, dbModel)
 	assert.Nil(t, err)
 
 	go func(t *testing.T, o *OvsdbServer) {
@@ -292,7 +298,9 @@ func TestClientServerInsertAndDelete(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
-	server, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
+	dbModel, errs := model.NewDatabaseModel(schema, defDB)
+	require.Empty(t, errs)
+	server, err := NewOvsdbServer(ovsDB, dbModel)
 	assert.Nil(t, err)
 
 	go func(t *testing.T, o *OvsdbServer) {
@@ -356,7 +364,9 @@ func TestClientServerInsertDuplicate(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
-	server, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
+	dbModel, errs := model.NewDatabaseModel(schema, defDB)
+	require.Empty(t, errs)
+	server, err := NewOvsdbServer(ovsDB, dbModel)
 	assert.Nil(t, err)
 
 	go func(t *testing.T, o *OvsdbServer) {
@@ -408,7 +418,9 @@ func TestClientServerInsertAndUpdate(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
-	server, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
+	dbModel, errs := model.NewDatabaseModel(schema, defDB)
+	require.Empty(t, errs)
+	server, err := NewOvsdbServer(ovsDB, dbModel)
 	assert.Nil(t, err)
 
 	go func(t *testing.T, o *OvsdbServer) {

--- a/server/server_integration_test.go
+++ b/server/server_integration_test.go
@@ -56,7 +56,7 @@ func getSchema() (*ovsdb.DatabaseSchema, error) {
 }
 
 func TestClientServerEcho(t *testing.T) {
-	defDB, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
 		"Bridge":       &bridgeType{}})
 	require.Nil(t, err)
@@ -64,7 +64,7 @@ func TestClientServerEcho(t *testing.T) {
 	schema, err := getSchema()
 	require.Nil(t, err)
 
-	ovsDB := NewInMemoryDatabase(map[string]*model.DBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
 
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
@@ -94,7 +94,7 @@ func TestClientServerEcho(t *testing.T) {
 }
 
 func TestClientServerInsert(t *testing.T) {
-	defDB, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
 		"Bridge":       &bridgeType{}})
 	require.Nil(t, err)
@@ -102,7 +102,7 @@ func TestClientServerInsert(t *testing.T) {
 	schema, err := getSchema()
 	require.Nil(t, err)
 
-	ovsDB := NewInMemoryDatabase(map[string]*model.DBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
@@ -162,7 +162,7 @@ func TestClientServerInsert(t *testing.T) {
 }
 
 func TestClientServerMonitor(t *testing.T) {
-	defDB, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
 		"Bridge":       &bridgeType{}})
 	if err != nil {
@@ -174,7 +174,7 @@ func TestClientServerMonitor(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ovsDB := NewInMemoryDatabase(map[string]*model.DBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
@@ -289,7 +289,7 @@ func TestClientServerMonitor(t *testing.T) {
 }
 
 func TestClientServerInsertAndDelete(t *testing.T) {
-	defDB, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
 		"Bridge":       &bridgeType{}})
 	require.Nil(t, err)
@@ -297,7 +297,7 @@ func TestClientServerInsertAndDelete(t *testing.T) {
 	schema, err := getSchema()
 	require.Nil(t, err)
 
-	ovsDB := NewInMemoryDatabase(map[string]*model.DBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
@@ -355,7 +355,7 @@ func TestClientServerInsertAndDelete(t *testing.T) {
 }
 
 func TestClientServerInsertDuplicate(t *testing.T) {
-	defDB, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
 		"Bridge":       &bridgeType{},
 	})
@@ -364,7 +364,7 @@ func TestClientServerInsertDuplicate(t *testing.T) {
 	schema, err := getSchema()
 	require.Nil(t, err)
 
-	ovsDB := NewInMemoryDatabase(map[string]*model.DBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
@@ -411,7 +411,7 @@ func TestClientServerInsertDuplicate(t *testing.T) {
 }
 
 func TestClientServerInsertAndUpdate(t *testing.T) {
-	defDB, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
 		"Bridge":       &bridgeType{}})
 	require.Nil(t, err)
@@ -419,7 +419,7 @@ func TestClientServerInsertAndUpdate(t *testing.T) {
 	schema, err := getSchema()
 	require.Nil(t, err)
 
-	ovsDB := NewInMemoryDatabase(map[string]*model.DBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -77,8 +77,7 @@ func TestOvsdbServerMonitor(t *testing.T) {
 		t.Fatal(err)
 	}
 	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
-	o, err := NewOvsdbServer(ovsDB, DatabaseModel{
-		Model: defDB, Schema: schema})
+	o, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
 	require.Nil(t, err)
 	requests := make(map[string]ovsdb.MonitorRequest)
 	for table, tableSchema := range schema.Tables {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -66,7 +66,7 @@ func TestExpandNamedUUID(t *testing.T) {
 }
 
 func TestOvsdbServerMonitor(t *testing.T) {
-	defDB, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
 		"Bridge":       &bridgeType{}})
 	if err != nil {
@@ -76,7 +76,7 @@ func TestOvsdbServerMonitor(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ovsDB := NewInMemoryDatabase(map[string]*model.DBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
 	o, err := NewOvsdbServer(ovsDB, DatabaseModel{
 		Model: defDB, Schema: schema})
 	require.Nil(t, err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -77,7 +77,9 @@ func TestOvsdbServerMonitor(t *testing.T) {
 		t.Fatal(err)
 	}
 	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
-	o, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
+	dbModel, errs := model.NewDatabaseModel(schema, defDB)
+	require.Empty(t, errs)
+	o, err := NewOvsdbServer(ovsDB, dbModel)
 	require.Nil(t, err)
 	requests := make(map[string]ovsdb.MonitorRequest)
 	for table, tableSchema := range schema.Tables {

--- a/server/transact.go
+++ b/server/transact.go
@@ -82,7 +82,7 @@ func (o *OvsdbServer) Insert(database string, table string, rowUUID string, row 
 		rowUUID = uuid.NewString()
 	}
 
-	model, err := dbModel.Client().NewModel(table)
+	model, err := dbModel.NewModel(table)
 	if err != nil {
 		return ovsdb.OperationResult{
 			Error: err.Error(),
@@ -201,7 +201,7 @@ func (o *OvsdbServer) Update(database, table string, where []ovsdb.Condition, ro
 		if err != nil {
 			panic(err)
 		}
-		new, err := dbModel.Client().NewModel(table)
+		new, err := dbModel.NewModel(table)
 		if err != nil {
 			panic(err)
 		}
@@ -333,7 +333,7 @@ func (o *OvsdbServer) Mutate(database, table string, where []ovsdb.Condition, mu
 		if err != nil {
 			panic(err)
 		}
-		new, err := dbModel.Client().NewModel(table)
+		new, err := dbModel.NewModel(table)
 		if err != nil {
 			panic(err)
 		}

--- a/server/transact.go
+++ b/server/transact.go
@@ -75,14 +75,14 @@ func (o *OvsdbServer) Insert(database string, table string, rowUUID string, row 
 	dbModel := o.models[database]
 	o.modelsMutex.Unlock()
 
-	m := mapper.NewMapper(dbModel.Schema)
-	tSchema := dbModel.Schema.Table(table)
+	m := dbModel.Mapper()
+	tSchema := dbModel.Schema().Table(table)
 
 	if rowUUID == "" {
 		rowUUID = uuid.NewString()
 	}
 
-	model, err := dbModel.Model.NewModel(table)
+	model, err := dbModel.Client().NewModel(table)
 	if err != nil {
 		return ovsdb.OperationResult{
 			Error: err.Error(),
@@ -155,7 +155,7 @@ func (o *OvsdbServer) Select(database string, table string, where []ovsdb.Condit
 	dbModel := o.models[database]
 	o.modelsMutex.Unlock()
 
-	m := mapper.NewMapper(dbModel.Schema)
+	m := dbModel.Mapper()
 
 	var results []ovsdb.Row
 	rows, err := o.db.List(database, table, where...)
@@ -184,8 +184,8 @@ func (o *OvsdbServer) Update(database, table string, where []ovsdb.Condition, ro
 	dbModel := o.models[database]
 	o.modelsMutex.Unlock()
 
-	m := mapper.NewMapper(dbModel.Schema)
-	schema := dbModel.Schema.Table(table)
+	m := dbModel.Mapper()
+	schema := dbModel.Schema().Table(table)
 	tableUpdate := make(ovsdb.TableUpdate2)
 	rows, err := o.db.List(database, table, where...)
 	if err != nil {
@@ -201,7 +201,7 @@ func (o *OvsdbServer) Update(database, table string, where []ovsdb.Condition, ro
 		if err != nil {
 			panic(err)
 		}
-		new, err := dbModel.Model.NewModel(table)
+		new, err := dbModel.Client().NewModel(table)
 		if err != nil {
 			panic(err)
 		}
@@ -313,8 +313,8 @@ func (o *OvsdbServer) Mutate(database, table string, where []ovsdb.Condition, mu
 	dbModel := o.models[database]
 	o.modelsMutex.Unlock()
 
-	m := mapper.NewMapper(dbModel.Schema)
-	schema := dbModel.Schema.Table(table)
+	m := dbModel.Mapper()
+	schema := dbModel.Schema().Table(table)
 
 	tableUpdate := make(ovsdb.TableUpdate2)
 
@@ -333,7 +333,7 @@ func (o *OvsdbServer) Mutate(database, table string, where []ovsdb.Condition, mu
 		if err != nil {
 			panic(err)
 		}
-		new, err := dbModel.Model.NewModel(table)
+		new, err := dbModel.Client().NewModel(table)
 		if err != nil {
 			panic(err)
 		}
@@ -452,8 +452,8 @@ func (o *OvsdbServer) Delete(database, table string, where []ovsdb.Condition) (o
 	o.modelsMutex.Lock()
 	dbModel := o.models[database]
 	o.modelsMutex.Unlock()
-	m := mapper.NewMapper(dbModel.Schema)
-	schema := dbModel.Schema.Table(table)
+	m := dbModel.Mapper()
+	schema := dbModel.Schema().Table(table)
 	tableUpdate := make(ovsdb.TableUpdate2)
 	rows, err := o.db.List(database, table, where...)
 	if err != nil {

--- a/server/transact_test.go
+++ b/server/transact_test.go
@@ -23,8 +23,7 @@ func TestMutateOp(t *testing.T) {
 		t.Fatal(err)
 	}
 	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
-	o, err := NewOvsdbServer(ovsDB, DatabaseModel{
-		Model: defDB, Schema: schema})
+	o, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
 	require.Nil(t, err)
 
 	ovsUUID := uuid.NewString()
@@ -215,8 +214,7 @@ func TestOvsdbServerInsert(t *testing.T) {
 		t.Fatal(err)
 	}
 	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
-	o, err := NewOvsdbServer(ovsDB, DatabaseModel{
-		Model: defDB, Schema: schema})
+	o, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
 	require.Nil(t, err)
 	m := mapper.NewMapper(schema)
 
@@ -268,8 +266,7 @@ func TestOvsdbServerUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
-	o, err := NewOvsdbServer(ovsDB, DatabaseModel{
-		Model: defDB, Schema: schema})
+	o, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
 	require.Nil(t, err)
 	m := mapper.NewMapper(schema)
 

--- a/server/transact_test.go
+++ b/server/transact_test.go
@@ -23,7 +23,9 @@ func TestMutateOp(t *testing.T) {
 		t.Fatal(err)
 	}
 	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
-	o, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
+	dbModel, errs := model.NewDatabaseModel(schema, defDB)
+	require.Empty(t, errs)
+	o, err := NewOvsdbServer(ovsDB, dbModel)
 	require.Nil(t, err)
 
 	ovsUUID := uuid.NewString()
@@ -32,7 +34,7 @@ func TestMutateOp(t *testing.T) {
 	m := mapper.NewMapper(schema)
 
 	ovs := ovsType{}
-	info, err := mapper.NewInfo("Open_vSwitch", schema.Table("Open_vSwitch"), &ovs)
+	info, err := dbModel.NewModelInfo(&ovs)
 	require.NoError(t, err)
 	ovsRow, err := m.NewRow(info)
 	require.Nil(t, err)
@@ -45,7 +47,7 @@ func TestMutateOp(t *testing.T) {
 			"waldo": "fred",
 		},
 	}
-	bridgeInfo, err := mapper.NewInfo("Bridge", schema.Table("Bridge"), &bridge)
+	bridgeInfo, err := dbModel.NewModelInfo(&bridge)
 	require.NoError(t, err)
 	bridgeRow, err := m.NewRow(bridgeInfo)
 	require.Nil(t, err)
@@ -218,7 +220,9 @@ func TestOvsdbServerInsert(t *testing.T) {
 		t.Fatal(err)
 	}
 	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
-	o, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
+	dbModel, errs := model.NewDatabaseModel(schema, defDB)
+	require.Empty(t, errs)
+	o, err := NewOvsdbServer(ovsDB, dbModel)
 	require.Nil(t, err)
 	m := mapper.NewMapper(schema)
 
@@ -234,7 +238,7 @@ func TestOvsdbServerInsert(t *testing.T) {
 		},
 	}
 	bridgeUUID := uuid.NewString()
-	bridgeInfo, err := mapper.NewInfo("Bridge", schema.Table("Bridge"), &bridge)
+	bridgeInfo, err := dbModel.NewModelInfo(&bridge)
 	require.NoError(t, err)
 	bridgeRow, err := m.NewRow(bridgeInfo)
 	require.Nil(t, err)
@@ -272,7 +276,9 @@ func TestOvsdbServerUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
-	o, err := NewOvsdbServer(ovsDB, model.NewDatabaseModel(schema, defDB))
+	dbModel, errs := model.NewDatabaseModel(schema, defDB)
+	require.Empty(t, errs)
+	o, err := NewOvsdbServer(ovsDB, dbModel)
 	require.Nil(t, err)
 	m := mapper.NewMapper(schema)
 
@@ -285,7 +291,7 @@ func TestOvsdbServerUpdate(t *testing.T) {
 		},
 	}
 	bridgeUUID := uuid.NewString()
-	bridgeInfo, err := mapper.NewInfo("Bridge", schema.Table("Bridge"), &bridge)
+	bridgeInfo, err := dbModel.NewModelInfo(&bridge)
 	require.NoError(t, err)
 	bridgeRow, err := m.NewRow(bridgeInfo)
 	require.Nil(t, err)

--- a/server/transact_test.go
+++ b/server/transact_test.go
@@ -32,7 +32,9 @@ func TestMutateOp(t *testing.T) {
 	m := mapper.NewMapper(schema)
 
 	ovs := ovsType{}
-	ovsRow, err := m.NewRow("Open_vSwitch", &ovs)
+	info, err := mapper.NewInfo("Open_vSwitch", schema.Table("Open_vSwitch"), &ovs)
+	require.NoError(t, err)
+	ovsRow, err := m.NewRow(info)
 	require.Nil(t, err)
 
 	bridge := bridgeType{
@@ -43,7 +45,9 @@ func TestMutateOp(t *testing.T) {
 			"waldo": "fred",
 		},
 	}
-	bridgeRow, err := m.NewRow("Bridge", &bridge)
+	bridgeInfo, err := mapper.NewInfo("Bridge", schema.Table("Bridge"), &bridge)
+	require.NoError(t, err)
+	bridgeRow, err := m.NewRow(bridgeInfo)
 	require.Nil(t, err)
 
 	res, updates := o.Insert("Open_vSwitch", "Open_vSwitch", ovsUUID, ovsRow)
@@ -230,7 +234,9 @@ func TestOvsdbServerInsert(t *testing.T) {
 		},
 	}
 	bridgeUUID := uuid.NewString()
-	bridgeRow, err := m.NewRow("Bridge", &bridge)
+	bridgeInfo, err := mapper.NewInfo("Bridge", schema.Table("Bridge"), &bridge)
+	require.NoError(t, err)
+	bridgeRow, err := m.NewRow(bridgeInfo)
 	require.Nil(t, err)
 
 	res, updates := o.Insert("Open_vSwitch", "Bridge", bridgeUUID, bridgeRow)
@@ -279,7 +285,9 @@ func TestOvsdbServerUpdate(t *testing.T) {
 		},
 	}
 	bridgeUUID := uuid.NewString()
-	bridgeRow, err := m.NewRow("Bridge", &bridge)
+	bridgeInfo, err := mapper.NewInfo("Bridge", schema.Table("Bridge"), &bridge)
+	require.NoError(t, err)
+	bridgeRow, err := m.NewRow(bridgeInfo)
 	require.Nil(t, err)
 
 	res, updates := o.Insert("Open_vSwitch", "Bridge", bridgeUUID, bridgeRow)

--- a/server/transact_test.go
+++ b/server/transact_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestMutateOp(t *testing.T) {
-	defDB, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
 		"Bridge":       &bridgeType{}})
 	if err != nil {
@@ -22,7 +22,7 @@ func TestMutateOp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ovsDB := NewInMemoryDatabase(map[string]*model.DBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
 	o, err := NewOvsdbServer(ovsDB, DatabaseModel{
 		Model: defDB, Schema: schema})
 	require.Nil(t, err)
@@ -204,7 +204,7 @@ func TestDiff(t *testing.T) {
 
 func TestOvsdbServerInsert(t *testing.T) {
 	t.Skip("need a helper for comparing rows as map elements aren't in same order")
-	defDB, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
 		"Bridge":       &bridgeType{}})
 	if err != nil {
@@ -214,7 +214,7 @@ func TestOvsdbServerInsert(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ovsDB := NewInMemoryDatabase(map[string]*model.DBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
 	o, err := NewOvsdbServer(ovsDB, DatabaseModel{
 		Model: defDB, Schema: schema})
 	require.Nil(t, err)
@@ -257,7 +257,7 @@ func TestOvsdbServerInsert(t *testing.T) {
 }
 
 func TestOvsdbServerUpdate(t *testing.T) {
-	defDB, err := model.NewDBModel("Open_vSwitch", map[string]model.Model{
+	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
 		"Bridge":       &bridgeType{}})
 	if err != nil {
@@ -267,7 +267,7 @@ func TestOvsdbServerUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ovsDB := NewInMemoryDatabase(map[string]*model.DBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
 	o, err := NewOvsdbServer(ovsDB, DatabaseModel{
 		Model: defDB, Schema: schema})
 	require.Nil(t, err)

--- a/test/ovs/ovs_integration_test.go
+++ b/test/ovs/ovs_integration_test.go
@@ -167,7 +167,7 @@ type queueType struct {
 	DSCP *int   `ovsdb:"dscp"`
 }
 
-var defDB, _ = model.NewDBModel("Open_vSwitch", map[string]model.Model{
+var defDB, _ = model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 	"Open_vSwitch": &ovsType{},
 	"Bridge":       &bridgeType{},
 	"IPFIX":        &ipfixType{},


### PR DESCRIPTION
Right now, the way we use the `dbModel` and the `Schema` is unclean and error prone.

First, we have to hold pointers to them all around the code. Also, we use the `dbModel` to build `Model` instances but use the `schema` to populate their fields which can lead to errors. As an example, if you take the current main branch, build the ovsdb-server and try to use cmd/stress on it, the client will crash with:
```
panic: FieldByColumn: column dpdk_initialized not found in orm info
```

In this case, although validation passes (having partial `Model`s is OK), the cache does not have the `dbModel` handy when it's filling up the fields.

Therefore, IMHO, it's clear that dbModel and schema are two sides of the same coin. The fact that server.go had to define a struct that holds both and is called DatabaseModel is a good proof of this:
https://github.com/ovn-org/libovsdb/blob/f2b3ce238b4e521ebf0e3221f0fbfc9c81c5e6b4/server/server.go#L31-L34

In addition, `model.Info` structures are created all over the code (e.g: api) that then calls `Mapper` functions that create `model.Info`structures all over again.

Try to improve all this by performing the following refactorings:

## Rename current DbModel to ClientDBModel  and introduce an internal DatabaseModel type
After the rename, a `DatabaseModel` type  is introduced that combines both central objects that are core for the library and that supports 2-step initialization to allow the schema to be provided afterwards (on [re-]`Connect()`). Validation is performed on the second step (without modifying the validation logic)

##  `mapper.Mapper` to use `mapper.Info`
Unify the `Mapper` into a more compact API by having `mapper.Mapper` functions accept a `mapper.Info` reference.

## Use the DatabaseModel to optimize the `mapper.Info`creation
Now that we have unified all the model handling inside a single struct (`DatabaseModel`), use it to create `mapper.Info` types. Since the `mapper.Info` is nothing but a metadata object attached to a `Model` pointer, this allows for an optimization: when we validate the schema and the `ClientDBModel` we can create all the metadata objects and cache them. Creating a new `model.Info` object is now faster as the Metadata object has already been created and stored .


Reviewer notes: Although it provides little functionality change, this PR has a lot of modifications. I've tried to split the PR in commits that are easy to review