### PR TITLE
Refactor: Reduce Use Of Pointers

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -89,7 +89,7 @@ func newIndex(columns ...string) index {
 // RowCache is a collections of Models hashed by UUID
 type RowCache struct {
 	name     string
-	dbModel  *model.DatabaseModel
+	dbModel  model.DatabaseModel
 	dataType reflect.Type
 	cache    map[string]model.Model
 	indexes  columnToValue
@@ -147,7 +147,7 @@ func (r *RowCache) Create(uuid string, m model.Model, checkIndexes bool) error {
 	if err != nil {
 		return err
 	}
-	newIndexes := newColumnToValue(r.dbModel.Schema().Table(r.name).Indexes)
+	newIndexes := newColumnToValue(r.dbModel.Schema.Table(r.name).Indexes)
 	for index := range r.indexes {
 		val, err := valueFromIndex(info, index)
 		if err != nil {
@@ -187,7 +187,7 @@ func (r *RowCache) Update(uuid string, m model.Model, checkIndexes bool) error {
 	if err != nil {
 		return err
 	}
-	indexes := r.dbModel.Schema().Table(r.name).Indexes
+	indexes := r.dbModel.Schema.Table(r.name).Indexes
 	newIndexes := newColumnToValue(indexes)
 	oldIndexes := newColumnToValue(indexes)
 	var errs []error
@@ -304,7 +304,7 @@ func (r *RowCache) Rows() map[string]model.Model {
 
 func (r *RowCache) RowsByCondition(conditions []ovsdb.Condition) (map[string]model.Model, error) {
 	results := make(map[string]model.Model)
-	schema := r.dbModel.Schema().Table(r.name)
+	schema := r.dbModel.Schema.Table(r.name)
 	if len(conditions) == 0 {
 		for uuid, row := range r.Rows() {
 			results[uuid] = row
@@ -427,7 +427,7 @@ func (e *EventHandlerFuncs) OnDelete(table string, row model.Model) {
 type TableCache struct {
 	cache          map[string]*RowCache
 	eventProcessor *eventProcessor
-	dbModel        *model.DatabaseModel
+	dbModel        model.DatabaseModel
 	errorChan      chan error
 	ovsdb.NotificationHandler
 	mutex  sync.RWMutex
@@ -438,7 +438,7 @@ type TableCache struct {
 type Data map[string]map[string]model.Model
 
 // NewTableCache creates a new TableCache
-func NewTableCache(dbModel *model.DatabaseModel, data Data, logger *logr.Logger) (*TableCache, error) {
+func NewTableCache(dbModel model.DatabaseModel, data Data, logger *logr.Logger) (*TableCache, error) {
 	if !dbModel.Valid() {
 		return nil, fmt.Errorf("tablecache without valid databasemodel cannot be populated")
 	}
@@ -452,11 +452,11 @@ func NewTableCache(dbModel *model.DatabaseModel, data Data, logger *logr.Logger)
 	eventProcessor := newEventProcessor(bufferSize, logger)
 	cache := make(map[string]*RowCache)
 	tableTypes := dbModel.Types()
-	for name := range dbModel.Schema().Tables {
+	for name := range dbModel.Schema.Tables {
 		cache[name] = newRowCache(name, dbModel, tableTypes[name])
 	}
 	for table, rowData := range data {
-		if _, ok := dbModel.Schema().Tables[table]; !ok {
+		if _, ok := dbModel.Schema.Tables[table]; !ok {
 			return nil, fmt.Errorf("table %s is not in schema", table)
 		}
 		for uuid, row := range rowData {
@@ -476,12 +476,12 @@ func NewTableCache(dbModel *model.DatabaseModel, data Data, logger *logr.Logger)
 }
 
 // Mapper returns the mapper
-func (t *TableCache) Mapper() *mapper.Mapper {
-	return t.dbModel.Mapper()
+func (t *TableCache) Mapper() mapper.Mapper {
+	return t.dbModel.Mapper
 }
 
 // DatabaseModel returns the DatabaseModelRequest
-func (t *TableCache) DatabaseModel() *model.DatabaseModel {
+func (t *TableCache) DatabaseModel() model.DatabaseModel {
 	return t.dbModel
 }
 
@@ -676,12 +676,12 @@ func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) error {
 
 // Purge drops all data in the cache and reinitializes it using the
 // provided database model
-func (t *TableCache) Purge(dbModel *model.DatabaseModel) {
+func (t *TableCache) Purge(dbModel model.DatabaseModel) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 	t.dbModel = dbModel
 	tableTypes := t.dbModel.Types()
-	for name := range t.dbModel.Schema().Tables {
+	for name := range t.dbModel.Schema.Tables {
 		t.cache[name] = newRowCache(name, t.dbModel, tableTypes[name])
 	}
 }
@@ -708,11 +708,11 @@ func (t *TableCache) Errors() <-chan error {
 
 // newRowCache creates a new row cache with the provided data
 // if the data is nil, and empty RowCache will be created
-func newRowCache(name string, dbModel *model.DatabaseModel, dataType reflect.Type) *RowCache {
+func newRowCache(name string, dbModel model.DatabaseModel, dataType reflect.Type) *RowCache {
 	r := &RowCache{
 		name:     name,
 		dbModel:  dbModel,
-		indexes:  newColumnToValue(dbModel.Schema().Table(name).Indexes),
+		indexes:  newColumnToValue(dbModel.Schema.Table(name).Indexes),
 		dataType: dataType,
 		cache:    make(map[string]model.Model),
 		mutex:    sync.RWMutex{},
@@ -824,7 +824,7 @@ func (t *TableCache) CreateModel(tableName string, row *ovsdb.Row, uuid string) 
 		return nil, fmt.Errorf("database model not valid")
 	}
 
-	table := t.dbModel.Schema().Table(tableName)
+	table := t.dbModel.Schema.Table(tableName)
 	if table == nil {
 		return nil, fmt.Errorf("table %s not found", tableName)
 	}
@@ -836,7 +836,7 @@ func (t *TableCache) CreateModel(tableName string, row *ovsdb.Row, uuid string) 
 	if err != nil {
 		return nil, err
 	}
-	err = t.dbModel.Mapper().GetRowData(row, info)
+	err = t.dbModel.Mapper.GetRowData(row, info)
 	if err != nil {
 		return nil, err
 	}
@@ -856,11 +856,11 @@ func (t *TableCache) ApplyModifications(tableName string, base model.Model, upda
 	if !t.dbModel.Valid() {
 		return fmt.Errorf("database model not valid")
 	}
-	table := t.dbModel.Schema().Table(tableName)
+	table := t.dbModel.Schema.Table(tableName)
 	if table == nil {
 		return fmt.Errorf("table %s not found", tableName)
 	}
-	schema := t.dbModel.Schema().Table(tableName)
+	schema := t.dbModel.Schema.Table(tableName)
 	if schema == nil {
 		return fmt.Errorf("no schema for table %s", tableName)
 	}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -640,7 +640,7 @@ func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) error {
 			case row.Modify != nil:
 				existing := tCache.Row(uuid)
 				if existing == nil {
-					return fmt.Errorf("row with uuid %s does not exist", uuid)
+					return NewErrCacheInconsistent(fmt.Sprintf("row with uuid %s does not exist", uuid))
 				}
 				modified := tCache.Row(uuid)
 				err := t.ApplyModifications(table, modified, *row.Modify)
@@ -661,7 +661,7 @@ func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) error {
 				// no value on the wire), then process a delete
 				m := tCache.Row(uuid)
 				if m == nil {
-					return fmt.Errorf("row with uuid %s does not exist", uuid)
+					return NewErrCacheInconsistent(fmt.Sprintf("row with uuid %s does not exist", uuid))
 				}
 				t.logger.V(5).Info("deleting row", "uuid", uuid, "model", fmt.Sprintf("%+v", m))
 				if err := tCache.Delete(uuid); err != nil {

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -105,7 +105,7 @@ func TestRowCacheCreate(t *testing.T) {
 		"Open_vSwitch": map[string]model.Model{"bar": &testModel{Foo: "bar"}},
 	}
 
-	dbModel, errs := model.NewDatabaseModel(&schema, db)
+	dbModel, errs := model.NewDatabaseModel(schema, db)
 	require.Empty(t, errs)
 	tc, err := NewTableCache(dbModel, testData, nil)
 	require.Nil(t, err)
@@ -193,7 +193,7 @@ func TestRowCacheCreateMultiIndex(t *testing.T) {
 	testData := Data{
 		"Open_vSwitch": map[string]model.Model{"bar": &testModel{Foo: "bar", Bar: "bar"}},
 	}
-	dbModel, errs := model.NewDatabaseModel(&schema, db)
+	dbModel, errs := model.NewDatabaseModel(schema, db)
 	require.Empty(t, errs)
 	tc, err := NewTableCache(dbModel, testData, nil)
 	require.Nil(t, err)
@@ -290,7 +290,7 @@ func TestRowCacheUpdate(t *testing.T) {
 			"foobar": &testModel{Foo: "foobar"},
 		},
 	}
-	dbModel, errs := model.NewDatabaseModel(&schema, db)
+	dbModel, errs := model.NewDatabaseModel(schema, db)
 	require.Empty(t, errs)
 	tc, err := NewTableCache(dbModel, testData, nil)
 	require.Nil(t, err)
@@ -374,7 +374,7 @@ func TestRowCacheUpdateMultiIndex(t *testing.T) {
 			"foobar": &testModel{Foo: "foobar", Bar: "foobar"},
 		},
 	}
-	dbModel, errs := model.NewDatabaseModel(&schema, db)
+	dbModel, errs := model.NewDatabaseModel(schema, db)
 	assert.Empty(t, errs)
 	tc, err := NewTableCache(dbModel, testData, nil)
 	require.Nil(t, err)
@@ -456,7 +456,7 @@ func TestRowCacheDelete(t *testing.T) {
 			"bar": &testModel{Foo: "bar"},
 		},
 	}
-	dbModel, errs := model.NewDatabaseModel(&schema, db)
+	dbModel, errs := model.NewDatabaseModel(schema, db)
 	require.Empty(t, errs)
 	tc, err := NewTableCache(dbModel, testData, nil)
 	require.Nil(t, err)
@@ -650,7 +650,7 @@ func TestTableCacheTable(t *testing.T) {
 	     }
 	`), &schema)
 	assert.Nil(t, err)
-	dbModel, errs := model.NewDatabaseModel(&schema, db)
+	dbModel, errs := model.NewDatabaseModel(schema, db)
 	require.Empty(t, errs)
 	tests := []struct {
 		name  string
@@ -727,7 +727,7 @@ func TestTableCacheTables(t *testing.T) {
 	     }
 	`), &schema)
 	assert.Nil(t, err)
-	dbModel, errs := model.NewDatabaseModel(&schema, db)
+	dbModel, errs := model.NewDatabaseModel(schema, db)
 	require.Empty(t, errs)
 	tests := []struct {
 		name  string
@@ -783,7 +783,7 @@ func TestTableCache_populate(t *testing.T) {
 	     }
 	`), &schema)
 	assert.Nil(t, err)
-	dbModel, errs := model.NewDatabaseModel(&schema, db)
+	dbModel, errs := model.NewDatabaseModel(schema, db)
 	require.Empty(t, errs)
 	tc, err := NewTableCache(dbModel, nil, nil)
 	assert.Nil(t, err)
@@ -853,7 +853,7 @@ func TestTableCachePopulate(t *testing.T) {
 	     }
 	`), &schema)
 	assert.Nil(t, err)
-	dbModel, errs := model.NewDatabaseModel(&schema, db)
+	dbModel, errs := model.NewDatabaseModel(schema, db)
 	require.Empty(t, errs)
 	tc, err := NewTableCache(dbModel, nil, nil)
 	assert.Nil(t, err)
@@ -922,7 +922,7 @@ func TestTableCachePopulate2(t *testing.T) {
 	     }
 	`), &schema)
 	assert.Nil(t, err)
-	dbModel, errs := model.NewDatabaseModel(&schema, db)
+	dbModel, errs := model.NewDatabaseModel(schema, db)
 	require.Empty(t, errs)
 	tc, err := NewTableCache(dbModel, nil, nil)
 	assert.Nil(t, err)
@@ -1050,7 +1050,7 @@ func TestIndex(t *testing.T) {
 	     }
 	`), &schema)
 	assert.Nil(t, err)
-	dbModel, errs := model.NewDatabaseModel(&schema, db)
+	dbModel, errs := model.NewDatabaseModel(schema, db)
 	assert.Empty(t, errs)
 	tc, err := NewTableCache(dbModel, nil, nil)
 	assert.Nil(t, err)
@@ -1150,7 +1150,7 @@ func TestTableCacheRowByModelSingleIndex(t *testing.T) {
 			"bar": &testModel{Foo: "bar", Bar: "bar"},
 		},
 	}
-	dbModel, errs := model.NewDatabaseModel(&schema, db)
+	dbModel, errs := model.NewDatabaseModel(schema, db)
 	require.Empty(t, errs)
 	tc, err := NewTableCache(dbModel, testData, nil)
 	require.NoError(t, err)
@@ -1201,7 +1201,7 @@ func TestTableCacheRowByModelTwoIndexes(t *testing.T) {
 			"bar": &testModel{Foo: "bar", Bar: "bar"},
 		},
 	}
-	dbModel, errs := model.NewDatabaseModel(&schema, db)
+	dbModel, errs := model.NewDatabaseModel(schema, db)
 	require.Empty(t, errs)
 	tc, err := NewTableCache(dbModel, testData, nil)
 	require.NoError(t, err)
@@ -1251,7 +1251,7 @@ func TestTableCacheRowByModelMultiIndex(t *testing.T) {
 	testData := Data{
 		"Open_vSwitch": map[string]model.Model{"foo": myFoo, "bar": &testModel{Foo: "bar", Bar: "bar"}},
 	}
-	dbModel, errs := model.NewDatabaseModel(&schema, db)
+	dbModel, errs := model.NewDatabaseModel(schema, db)
 	require.Empty(t, errs)
 	tc, err := NewTableCache(dbModel, testData, nil)
 	require.NoError(t, err)
@@ -1400,7 +1400,7 @@ func TestTableCacheApplyModifications(t *testing.T) {
 			  }
 			`), &schema)
 			require.NoError(t, err)
-			dbModel, errs := model.NewDatabaseModel(&schema, db)
+			dbModel, errs := model.NewDatabaseModel(schema, db)
 			require.Empty(t, errs)
 			tc, err := NewTableCache(dbModel, nil, nil)
 			assert.Nil(t, err)

--- a/client/api_test_model.go
+++ b/client/api_test_model.go
@@ -159,7 +159,7 @@ func apiTestCache(t *testing.T, data map[string]map[string]model.Model) *cache.T
 	assert.Nil(t, err)
 	db, err := model.NewClientDBModel("OVN_Northbound", map[string]model.Model{"Logical_Switch": &testLogicalSwitch{}, "Logical_Switch_Port": &testLogicalSwitchPort{}})
 	assert.Nil(t, err)
-	dbModel, errs := model.NewDatabaseModel(&schema, db)
+	dbModel, errs := model.NewDatabaseModel(schema, db)
 	assert.Empty(t, errs)
 	cache, err := cache.NewTableCache(dbModel, data, nil)
 	assert.Nil(t, err)

--- a/client/condition.go
+++ b/client/condition.go
@@ -26,7 +26,7 @@ type Conditional interface {
 // The conditions are based on the equality of the first available index.
 // The priority of indexes is: uuid, {schema index}
 type equalityConditional struct {
-	dbModel   *model.DatabaseModel
+	dbModel   model.DatabaseModel
 	tableName string
 	info      *mapper.Info
 	singleOp  bool
@@ -37,7 +37,7 @@ func (c *equalityConditional) Matches(m model.Model) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return c.dbModel.Mapper().EqualFields(c.info, info)
+	return c.dbModel.Mapper.EqualFields(c.info, info)
 }
 
 func (c *equalityConditional) Table() string {
@@ -48,7 +48,7 @@ func (c *equalityConditional) Table() string {
 func (c *equalityConditional) Generate() ([][]ovsdb.Condition, error) {
 	var result [][]ovsdb.Condition
 
-	conds, err := c.dbModel.Mapper().NewEqualityCondition(c.info)
+	conds, err := c.dbModel.Mapper.NewEqualityCondition(c.info)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func (c *equalityConditional) Generate() ([][]ovsdb.Condition, error) {
 }
 
 // NewEqualityCondition creates a new equalityConditional
-func newEqualityConditional(dbModel *model.DatabaseModel, table string, all bool, model model.Model, fields ...interface{}) (Conditional, error) {
+func newEqualityConditional(dbModel model.DatabaseModel, table string, all bool, model model.Model, fields ...interface{}) (Conditional, error) {
 	info, err := dbModel.NewModelInfo(model)
 	if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func newEqualityConditional(dbModel *model.DatabaseModel, table string, all bool
 
 // explicitConditional generates conditions based on the provided Condition list
 type explicitConditional struct {
-	dbModel    *model.DatabaseModel
+	dbModel    model.DatabaseModel
 	tableName  string
 	info       *mapper.Info
 	conditions []model.Condition
@@ -99,7 +99,7 @@ func (c *explicitConditional) Generate() ([][]ovsdb.Condition, error) {
 	var conds []ovsdb.Condition
 
 	for _, cond := range c.conditions {
-		ovsdbCond, err := c.dbModel.Mapper().NewCondition(c.info, cond.Field, cond.Function, cond.Value)
+		ovsdbCond, err := c.dbModel.Mapper.NewCondition(c.info, cond.Field, cond.Function, cond.Value)
 		if err != nil {
 			return nil, err
 		}
@@ -117,7 +117,7 @@ func (c *explicitConditional) Generate() ([][]ovsdb.Condition, error) {
 }
 
 // newIndexCondition creates a new equalityConditional
-func newExplicitConditional(dbModel *model.DatabaseModel, table string, all bool, model model.Model, cond ...model.Condition) (Conditional, error) {
+func newExplicitConditional(dbModel model.DatabaseModel, table string, all bool, model model.Model, cond ...model.Condition) (Conditional, error) {
 	info, err := dbModel.NewModelInfo(model)
 	if err != nil {
 		return nil, err

--- a/client/options.go
+++ b/client/options.go
@@ -2,14 +2,11 @@ package client
 
 import (
 	"crypto/tls"
-	stdlog "log"
 	"net/url"
-	"os"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/go-logr/logr"
-	"github.com/go-logr/stdr"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -43,12 +40,6 @@ func newOptions(opts ...Option) (*options, error) {
 	// if no endpoints are supplied, use the default unix socket
 	if len(o.endpoints) == 0 {
 		o.endpoints = []string{defaultUnixEndpoint}
-	}
-
-	if o.logger == nil {
-		l := stdr.NewWithOptions(stdlog.New(os.Stderr, "", stdlog.LstdFlags), stdr.Options{LogCaller: stdr.All}).WithName("libovsdb")
-		stdr.SetVerbosity(5)
-		o.logger = &l
 	}
 	return o, nil
 }

--- a/cmd/modelgen/main.go
+++ b/cmd/modelgen/main.go
@@ -81,7 +81,7 @@ func main() {
 		}
 	}
 	dbTemplate := modelgen.NewDBTemplate()
-	dbArgs := modelgen.GetDBTemplateData(pkgName, &dbSchema)
+	dbArgs := modelgen.GetDBTemplateData(pkgName, dbSchema)
 	if err := gen.Generate(filepath.Join(outDir, "model.go"), dbTemplate, dbArgs); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/stress/stress.go
+++ b/cmd/stress/stress.go
@@ -43,7 +43,7 @@ var (
 	parallel      = flag.Bool("parallel", false, "run clients in parallel")
 	verbose       = flag.Bool("verbose", false, "Be verbose")
 	connection    = flag.String("ovsdb", "unix:/var/run/openvswitch/db.sock", "OVSDB connection string")
-	clientDBModel *model.ClientDBModel
+	clientDBModel model.ClientDBModel
 )
 
 type result struct {

--- a/example/ovsdb-server/main.go
+++ b/example/ovsdb-server/main.go
@@ -57,7 +57,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	ovsDB := server.NewInMemoryDatabase(map[string]*model.ClientDBModel{
+	ovsDB := server.NewInMemoryDatabase(map[string]model.ClientDBModel{
 		schema.Name: clientDBModel,
 	})
 

--- a/mapper/info.go
+++ b/mapper/info.go
@@ -11,7 +11,7 @@ import (
 type Info struct {
 	// FieldName indexed by column
 	Obj      interface{}
-	Metadata *Metadata
+	Metadata Metadata
 }
 
 // Metadata represents the information needed to know how to map OVSDB columns into an objetss fields
@@ -152,7 +152,7 @@ func NewInfo(tableName string, table *ovsdb.TableSchema, obj interface{}) (*Info
 
 	return &Info{
 		Obj: obj,
-		Metadata: &Metadata{
+		Metadata: Metadata{
 			Fields:      fields,
 			TableSchema: table,
 			TableName:   tableName,

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -19,7 +19,7 @@ import (
 //  	Name string `ovsdb:"name"`
 //  }
 type Mapper struct {
-	Schema *ovsdb.DatabaseSchema
+	Schema ovsdb.DatabaseSchema
 }
 
 // ErrMapper describes an error in an Mapper type
@@ -37,8 +37,8 @@ func (e *ErrMapper) Error() string {
 }
 
 // NewMapper returns a new mapper
-func NewMapper(schema *ovsdb.DatabaseSchema) *Mapper {
-	return &Mapper{
+func NewMapper(schema ovsdb.DatabaseSchema) Mapper {
+	return Mapper{
 		Schema: schema,
 	}
 }

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -222,7 +222,7 @@ func TestMapperGetData(t *testing.T) {
 		t.Error(err)
 	}
 
-	mapper := NewMapper(&schema)
+	mapper := NewMapper(schema)
 	test := ormTestType{
 		NonTagged: "something",
 	}
@@ -344,7 +344,7 @@ func TestMapperNewRow(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("NewRow: %s", test.name), func(t *testing.T) {
-			mapper := NewMapper(&schema)
+			mapper := NewMapper(schema)
 			info, err := NewInfo("TestTable", schema.Table("TestTable"), test.objInput)
 			assert.NoError(t, err)
 			row, err := mapper.NewRow(info)
@@ -430,7 +430,7 @@ func TestMapperNewRowFields(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("NewRow: %s", test.name), func(t *testing.T) {
-			mapper := NewMapper(&schema)
+			mapper := NewMapper(schema)
 			// Clean the test object
 			testObj.MyString = ""
 			testObj.MyMap = nil
@@ -497,7 +497,7 @@ func TestMapperCondition(t *testing.T) {
 	if err := json.Unmarshal(testSchema, &schema); err != nil {
 		t.Fatal(err)
 	}
-	mapper := NewMapper(&schema)
+	mapper := NewMapper(schema)
 
 	type Test struct {
 		name     string
@@ -671,7 +671,7 @@ func TestMapperEqualIndexes(t *testing.T) {
 	if err := json.Unmarshal(testSchema, &schema); err != nil {
 		t.Fatal(err)
 	}
-	mapper := NewMapper(&schema)
+	mapper := NewMapper(schema)
 
 	type Test struct {
 		name     string
@@ -938,7 +938,7 @@ func TestMapperMutation(t *testing.T) {
 	if err := json.Unmarshal(testSchema, &schema); err != nil {
 		t.Fatal(err)
 	}
-	mapper := NewMapper(&schema)
+	mapper := NewMapper(schema)
 
 	type Test struct {
 		name     string
@@ -1117,7 +1117,7 @@ func TestNewMonitorRequest(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
 	err := json.Unmarshal(testSchema, &schema)
 	require.NoError(t, err)
-	mapper := NewMapper(&schema)
+	mapper := NewMapper(schema)
 	testTable := &testType{}
 	info, err := NewInfo("TestTable", schema.Table("TestTable"), testTable)
 	assert.NoError(t, err)

--- a/model/client.go
+++ b/model/client.go
@@ -31,7 +31,7 @@ func (db ClientDBModel) Name() string {
 
 // Validate validates the DatabaseModel against the input schema
 // Returns all the errors detected
-func (db ClientDBModel) validate(schema *ovsdb.DatabaseSchema) []error {
+func (db ClientDBModel) validate(schema ovsdb.DatabaseSchema) []error {
 	var errors []error
 	if db.name != schema.Name {
 		errors = append(errors, fmt.Errorf("database model name (%s) does not match schema (%s)",
@@ -57,12 +57,12 @@ func (db ClientDBModel) validate(schema *ovsdb.DatabaseSchema) []error {
 }
 
 // NewClientDBModel constructs a ClientDBModel based on a database name and dictionary of models indexed by table name
-func NewClientDBModel(name string, models map[string]Model) (*ClientDBModel, error) {
+func NewClientDBModel(name string, models map[string]Model) (ClientDBModel, error) {
 	types := make(map[string]reflect.Type, len(models))
 	for table, model := range models {
 		modelType := reflect.TypeOf(model)
 		if modelType.Kind() != reflect.Ptr || modelType.Elem().Kind() != reflect.Struct {
-			return nil, fmt.Errorf("model is expected to be a pointer to struct")
+			return ClientDBModel{}, fmt.Errorf("model is expected to be a pointer to struct")
 		}
 		hasUUID := false
 		for i := 0; i < modelType.Elem().NumField(); i++ {
@@ -72,12 +72,12 @@ func NewClientDBModel(name string, models map[string]Model) (*ClientDBModel, err
 			}
 		}
 		if !hasUUID {
-			return nil, fmt.Errorf("model is expected to have a string field called uuid")
+			return ClientDBModel{}, fmt.Errorf("model is expected to have a string field called uuid")
 		}
 
 		types[table] = reflect.TypeOf(model)
 	}
-	return &ClientDBModel{
+	return ClientDBModel{
 		types: types,
 		name:  name,
 	}, nil

--- a/model/database.go
+++ b/model/database.go
@@ -3,7 +3,6 @@ package model
 import (
 	"fmt"
 	"reflect"
-	"sync"
 
 	"github.com/ovn-org/libovsdb/mapper"
 	"github.com/ovn-org/libovsdb/ovsdb"
@@ -12,85 +11,51 @@ import (
 // A DatabaseModel represents libovsdb's metadata about the database.
 // It's the result of combining the client's ClientDBModel and the server's Schema
 type DatabaseModel struct {
-	client   *ClientDBModel
-	schema   *ovsdb.DatabaseSchema
-	mapper   *mapper.Mapper
-	mutex    sync.RWMutex
-	metadata map[reflect.Type]*mapper.Metadata
+	client   ClientDBModel
+	Schema   ovsdb.DatabaseSchema
+	Mapper   mapper.Mapper
+	metadata map[reflect.Type]mapper.Metadata
 }
 
 // NewDatabaseModel returns a new DatabaseModel
-func NewDatabaseModel(schema *ovsdb.DatabaseSchema, client *ClientDBModel) (*DatabaseModel, []error) {
-	dbModel := NewPartialDatabaseModel(client)
-	errs := dbModel.SetSchema(schema)
-	if len(errs) > 0 {
-		return nil, errs
+func NewDatabaseModel(schema ovsdb.DatabaseSchema, client ClientDBModel) (DatabaseModel, []error) {
+	dbModel := &DatabaseModel{
+		Schema: schema,
+		client: client,
 	}
-	return dbModel, nil
+	errs := client.validate(schema)
+	if len(errs) > 0 {
+		return DatabaseModel{}, errs
+	}
+	dbModel.Mapper = mapper.NewMapper(schema)
+	var metadata map[reflect.Type]mapper.Metadata
+	metadata, errs = generateModelInfo(schema, client.types)
+	if len(errs) > 0 {
+		return DatabaseModel{}, errs
+	}
+	dbModel.metadata = metadata
+	return *dbModel, nil
 }
 
 // NewPartialDatabaseModel returns a DatabaseModel what does not have a schema yet
-func NewPartialDatabaseModel(client *ClientDBModel) *DatabaseModel {
-	return &DatabaseModel{
+func NewPartialDatabaseModel(client ClientDBModel) DatabaseModel {
+	return DatabaseModel{
 		client: client,
 	}
 }
 
 // Valid returns whether the DatabaseModel is fully functional
-func (db *DatabaseModel) Valid() bool {
-	db.mutex.RLock()
-	defer db.mutex.RUnlock()
-	return db.schema != nil
-}
-
-// SetSchema adds the Schema to the DatabaseModel making it valid if it was not before
-func (db *DatabaseModel) SetSchema(schema *ovsdb.DatabaseSchema) []error {
-	db.mutex.Lock()
-	defer db.mutex.Unlock()
-	errors := db.client.validate(schema)
-	if len(errors) > 0 {
-		return errors
-	}
-	db.schema = schema
-	db.mapper = mapper.NewMapper(schema)
-	errs := db.generateModelInfo()
-	if len(errs) > 0 {
-		db.schema = nil
-		db.mapper = nil
-		return errs
-	}
-	return []error{}
-}
-
-// ClearSchema removes the Schema from the DatabaseModel making it not valid
-func (db *DatabaseModel) ClearSchema() {
-	db.mutex.Lock()
-	defer db.mutex.Unlock()
-	db.schema = nil
-	db.mapper = nil
+func (db DatabaseModel) Valid() bool {
+	return !reflect.DeepEqual(db.Schema, ovsdb.DatabaseSchema{})
 }
 
 // Client returns the DatabaseModel's client dbModel
-func (db *DatabaseModel) Client() *ClientDBModel {
+func (db DatabaseModel) Client() ClientDBModel {
 	return db.client
 }
 
-// Schema returns the DatabaseModel's schema
-func (db *DatabaseModel) Schema() *ovsdb.DatabaseSchema {
-	db.mutex.RLock()
-	defer db.mutex.RUnlock()
-	return db.schema
-}
-
-// Mapper returns the DatabaseModel's mapper
-func (db *DatabaseModel) Mapper() *mapper.Mapper {
-	db.mutex.RLock()
-	defer db.mutex.RUnlock()
-	return db.mapper
-}
-
 // NewModel returns a new instance of a model from a specific string
-func (db *DatabaseModel) NewModel(table string) (Model, error) {
+func (db DatabaseModel) NewModel(table string) (Model, error) {
 	mtype, ok := db.client.types[table]
 	if !ok {
 		return nil, fmt.Errorf("table %s not found in database model", string(table))
@@ -103,12 +68,12 @@ func (db *DatabaseModel) NewModel(table string) (Model, error) {
 // the DatabaseModel types is a map of reflect.Types indexed by string
 // The reflect.Type is a pointer to a struct that contains 'ovs' tags
 // as described above. Such pointer to struct also implements the Model interface
-func (db *DatabaseModel) Types() map[string]reflect.Type {
+func (db DatabaseModel) Types() map[string]reflect.Type {
 	return db.client.types
 }
 
 // FindTable returns the string associated with a reflect.Type or ""
-func (db *DatabaseModel) FindTable(mType reflect.Type) string {
+func (db DatabaseModel) FindTable(mType reflect.Type) string {
 	for table, tType := range db.client.types {
 		if tType == mType {
 			return table
@@ -119,20 +84,22 @@ func (db *DatabaseModel) FindTable(mType reflect.Type) string {
 
 // generateModelMetadata creates metadata objects from all models included in the
 // database and caches them for future re-use
-func (db *DatabaseModel) generateModelInfo() []error {
+func generateModelInfo(dbSchema ovsdb.DatabaseSchema, modelTypes map[string]reflect.Type) (map[reflect.Type]mapper.Metadata, []error) {
 	errors := []error{}
-	metadata := make(map[reflect.Type]*mapper.Metadata, len(db.client.types))
-	for tableName, tType := range db.client.types {
-		tableSchema := db.schema.Table(tableName)
+	metadata := make(map[reflect.Type]mapper.Metadata, len(modelTypes))
+	for tableName, tType := range modelTypes {
+		tableSchema := dbSchema.Table(tableName)
 		if tableSchema == nil {
-			errors = append(errors, fmt.Errorf("Database Model contains model for table %s which is not present in schema", tableName))
+			errors = append(errors, fmt.Errorf("database Model contains model for table %s which is not present in schema", tableName))
 			continue
 		}
-		obj, err := db.NewModel(tableName)
-		if err != nil {
-			errors = append(errors, err)
+
+		mtype, ok := modelTypes[tableName]
+		if !ok {
+			errors = append(errors, fmt.Errorf("table %s not found in database model", tableName))
 			continue
 		}
+		obj := reflect.New(mtype.Elem()).Interface().(Model)
 		info, err := mapper.NewInfo(tableName, tableSchema, obj)
 		if err != nil {
 			errors = append(errors, err)
@@ -140,12 +107,11 @@ func (db *DatabaseModel) generateModelInfo() []error {
 		}
 		metadata[tType] = info.Metadata
 	}
-	db.metadata = metadata
-	return errors
+	return metadata, errors
 }
 
 // NewModelInfo returns a mapper.Info object based on a provided model
-func (db *DatabaseModel) NewModelInfo(obj interface{}) (*mapper.Info, error) {
+func (db DatabaseModel) NewModelInfo(obj interface{}) (*mapper.Info, error) {
 	meta, ok := db.metadata[reflect.TypeOf(obj)]
 	if !ok {
 		return nil, ovsdb.NewErrWrongType("NewModelInfo", "type that is part of the DatabaseModel", obj)

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -324,7 +324,7 @@ func TestValidate(t *testing.T) {
 			var schema ovsdb.DatabaseSchema
 			err := json.Unmarshal(tt.schema, &schema)
 			assert.Nil(t, err)
-			errors := model.validate(&schema)
+			errors := model.validate(schema)
 			if tt.err {
 				assert.Greater(t, len(errors), 0)
 			} else {

--- a/modelgen/dbmodel.go
+++ b/modelgen/dbmodel.go
@@ -40,7 +40,7 @@ package {{ index . "PackageName" }}
 {{ template "preDBDefinitions" }}
 
 // FullDatabaseModel returns the DatabaseModel object to be used in libovsdb
-func FullDatabaseModel() (*model.ClientDBModel, error) {
+func FullDatabaseModel() (model.ClientDBModel, error) {
 	return model.NewClientDBModel("{{ index . "DatabaseName" }}", map[string]model.Model{
     {{ range index . "Tables" }} "{{ .TableName }}" : &{{ .StructName }}{}, 
     {{ end }}
@@ -72,7 +72,7 @@ type TableInfo struct {
 // DatabaseName: (string) the database name
 // PackageName : (string) the package name
 // Tables: []Table list of Tables that form the Model
-func GetDBTemplateData(pkg string, schema *ovsdb.DatabaseSchema) map[string]interface{} {
+func GetDBTemplateData(pkg string, schema ovsdb.DatabaseSchema) map[string]interface{} {
 	data := map[string]interface{}{}
 	data["DatabaseName"] = schema.Name
 	data["PackageName"] = pkg

--- a/modelgen/dbmodel_test.go
+++ b/modelgen/dbmodel_test.go
@@ -59,7 +59,7 @@ import (
 )
 
 // FullDatabaseModel returns the DatabaseModel object to be used in libovsdb
-func FullDatabaseModel() (*model.ClientDBModel, error) {
+func FullDatabaseModel() (model.ClientDBModel, error) {
 	return model.NewClientDBModel("AtomicDB", map[string]model.Model{
 		"atomicTable": &AtomicTable{},
 	})
@@ -129,7 +129,7 @@ func Schema() ovsdb.DatabaseSchema {
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpl := NewDBTemplate()
-			data := GetDBTemplateData("test", &schema)
+			data := GetDBTemplateData("test", schema)
 			if tt.err {
 				assert.NotNil(t, err)
 			} else {

--- a/ovsdb/schema.go
+++ b/ovsdb/schema.go
@@ -47,18 +47,17 @@ func (schema DatabaseSchema) Print(w io.Writer) {
 }
 
 // SchemaFromFile returns a DatabaseSchema from a file
-func SchemaFromFile(f *os.File) (*DatabaseSchema, error) {
+func SchemaFromFile(f *os.File) (DatabaseSchema, error) {
 	data, err := ioutil.ReadAll(f)
 	if err != nil {
-		return nil, err
+		return DatabaseSchema{}, err
 	}
 	var schema DatabaseSchema
 	err = json.Unmarshal(data, &schema)
 	if err != nil {
-		return nil, err
+		return DatabaseSchema{}, err
 	}
-
-	return &schema, nil
+	return schema, nil
 }
 
 // ValidateOperations performs basic validation for operations against a DatabaseSchema

--- a/ovsdb/serverdb/model.go
+++ b/ovsdb/serverdb/model.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FullDatabaseModel returns the DatabaseModel object to be used in libovsdb
-func FullDatabaseModel() (*model.ClientDBModel, error) {
+func FullDatabaseModel() (model.ClientDBModel, error) {
 	return model.NewClientDBModel("_Server", map[string]model.Model{
 		"Database": &Database{},
 	})

--- a/server/server.go
+++ b/server/server.go
@@ -22,29 +22,29 @@ type OvsdbServer struct {
 	db           Database
 	ready        bool
 	readyMutex   sync.RWMutex
-	models       map[string]*model.DatabaseModel
+	models       map[string]model.DatabaseModel
 	modelsMutex  sync.RWMutex
 	monitors     map[*rpc2.Client]*connectionMonitors
 	monitorMutex sync.RWMutex
 }
 
 // NewOvsdbServer returns a new OvsdbServer
-func NewOvsdbServer(db Database, models ...*model.DatabaseModel) (*OvsdbServer, error) {
+func NewOvsdbServer(db Database, models ...model.DatabaseModel) (*OvsdbServer, error) {
 	o := &OvsdbServer{
 		done:         make(chan struct{}, 1),
 		db:           db,
-		models:       make(map[string]*model.DatabaseModel),
+		models:       make(map[string]model.DatabaseModel),
 		modelsMutex:  sync.RWMutex{},
 		monitors:     make(map[*rpc2.Client]*connectionMonitors),
 		monitorMutex: sync.RWMutex{},
 	}
 	o.modelsMutex.Lock()
 	for _, model := range models {
-		o.models[model.Schema().Name] = model
+		o.models[model.Schema.Name] = model
 	}
 	o.modelsMutex.Unlock()
 	for database, model := range o.models {
-		if err := o.db.CreateDatabase(database, model.Schema()); err != nil {
+		if err := o.db.CreateDatabase(database, model.Schema); err != nil {
 			return nil, err
 		}
 	}
@@ -108,7 +108,7 @@ func (o *OvsdbServer) ListDatabases(client *rpc2.Client, args []interface{}, rep
 	dbs := []string{}
 	o.modelsMutex.RLock()
 	for _, db := range o.models {
-		dbs = append(dbs, db.Schema().Name)
+		dbs = append(dbs, db.Schema.Name)
 	}
 	o.modelsMutex.RUnlock()
 	*reply = dbs
@@ -127,7 +127,7 @@ func (o *OvsdbServer) GetSchema(client *rpc2.Client, args []interface{}, reply *
 		return fmt.Errorf("database %s does not exist", db)
 	}
 	o.modelsMutex.RUnlock()
-	*reply = *model.Schema()
+	*reply = model.Schema
 	return nil
 }
 
@@ -136,7 +136,7 @@ type Transaction struct {
 	Cache *cache.TableCache
 }
 
-func NewTransaction(model *model.DatabaseModel) Transaction {
+func NewTransaction(model model.DatabaseModel) Transaction {
 	cache, err := cache.NewTableCache(model, nil, nil)
 	if err != nil {
 		panic(err)

--- a/server/server_integration_test.go
+++ b/server/server_integration_test.go
@@ -37,20 +37,20 @@ type ovsType struct {
 	Bridges []string `ovsdb:"bridges"`
 }
 
-func getSchema() (*ovsdb.DatabaseSchema, error) {
+func getSchema() (ovsdb.DatabaseSchema, error) {
 	wd, err := os.Getwd()
 	if err != nil {
-		return nil, err
+		return ovsdb.DatabaseSchema{}, err
 	}
 	path := filepath.Join(wd, "testdata", "ovslite.json")
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, err
+		return ovsdb.DatabaseSchema{}, err
 	}
 	defer f.Close()
 	schema, err := ovsdb.SchemaFromFile(f)
 	if err != nil {
-		return nil, err
+		return ovsdb.DatabaseSchema{}, err
 	}
 	return schema, nil
 }
@@ -64,7 +64,7 @@ func TestClientServerEcho(t *testing.T) {
 	schema, err := getSchema()
 	require.Nil(t, err)
 
-	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]model.ClientDBModel{"Open_vSwitch": defDB})
 
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
@@ -101,7 +101,7 @@ func TestClientServerInsert(t *testing.T) {
 	schema, err := getSchema()
 	require.Nil(t, err)
 
-	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]model.ClientDBModel{"Open_vSwitch": defDB})
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
@@ -172,7 +172,7 @@ func TestClientServerMonitor(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]model.ClientDBModel{"Open_vSwitch": defDB})
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
@@ -294,7 +294,7 @@ func TestClientServerInsertAndDelete(t *testing.T) {
 	schema, err := getSchema()
 	require.Nil(t, err)
 
-	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]model.ClientDBModel{"Open_vSwitch": defDB})
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
@@ -360,7 +360,7 @@ func TestClientServerInsertDuplicate(t *testing.T) {
 	schema, err := getSchema()
 	require.Nil(t, err)
 
-	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]model.ClientDBModel{"Open_vSwitch": defDB})
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)
@@ -414,7 +414,7 @@ func TestClientServerInsertAndUpdate(t *testing.T) {
 	schema, err := getSchema()
 	require.Nil(t, err)
 
-	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]model.ClientDBModel{"Open_vSwitch": defDB})
 	rand.Seed(time.Now().UnixNano())
 	tmpfile := fmt.Sprintf("/tmp/ovsdb-%d.sock", rand.Intn(10000))
 	defer os.Remove(tmpfile)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -76,7 +76,7 @@ func TestOvsdbServerMonitor(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]model.ClientDBModel{"Open_vSwitch": defDB})
 	dbModel, errs := model.NewDatabaseModel(schema, defDB)
 	require.Empty(t, errs)
 	o, err := NewOvsdbServer(ovsDB, dbModel)

--- a/server/transact.go
+++ b/server/transact.go
@@ -74,7 +74,7 @@ func (o *OvsdbServer) Insert(database string, table string, rowUUID string, row 
 	dbModel := o.models[database]
 	o.modelsMutex.Unlock()
 
-	m := dbModel.Mapper()
+	m := dbModel.Mapper
 
 	if rowUUID == "" {
 		rowUUID = uuid.NewString()
@@ -153,7 +153,7 @@ func (o *OvsdbServer) Select(database string, table string, where []ovsdb.Condit
 	dbModel := o.models[database]
 	o.modelsMutex.Unlock()
 
-	m := dbModel.Mapper()
+	m := dbModel.Mapper
 
 	var results []ovsdb.Row
 	rows, err := o.db.List(database, table, where...)
@@ -186,8 +186,8 @@ func (o *OvsdbServer) Update(database, table string, where []ovsdb.Condition, ro
 	dbModel := o.models[database]
 	o.modelsMutex.Unlock()
 
-	m := dbModel.Mapper()
-	schema := dbModel.Schema().Table(table)
+	m := dbModel.Mapper
+	schema := dbModel.Schema.Table(table)
 	tableUpdate := make(ovsdb.TableUpdate2)
 	rows, err := o.db.List(database, table, where...)
 	if err != nil {
@@ -315,8 +315,8 @@ func (o *OvsdbServer) Mutate(database, table string, where []ovsdb.Condition, mu
 	dbModel := o.models[database]
 	o.modelsMutex.Unlock()
 
-	m := dbModel.Mapper()
-	schema := dbModel.Schema().Table(table)
+	m := dbModel.Mapper
+	schema := dbModel.Schema.Table(table)
 
 	tableUpdate := make(ovsdb.TableUpdate2)
 
@@ -454,7 +454,7 @@ func (o *OvsdbServer) Delete(database, table string, where []ovsdb.Condition) (o
 	o.modelsMutex.Lock()
 	dbModel := o.models[database]
 	o.modelsMutex.Unlock()
-	m := dbModel.Mapper()
+	m := dbModel.Mapper
 
 	tableUpdate := make(ovsdb.TableUpdate2)
 	rows, err := o.db.List(database, table, where...)

--- a/server/transact_test.go
+++ b/server/transact_test.go
@@ -22,7 +22,7 @@ func TestMutateOp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]model.ClientDBModel{"Open_vSwitch": defDB})
 	dbModel, errs := model.NewDatabaseModel(schema, defDB)
 	require.Empty(t, errs)
 	o, err := NewOvsdbServer(ovsDB, dbModel)
@@ -219,7 +219,7 @@ func TestOvsdbServerInsert(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]model.ClientDBModel{"Open_vSwitch": defDB})
 	dbModel, errs := model.NewDatabaseModel(schema, defDB)
 	require.Empty(t, errs)
 	o, err := NewOvsdbServer(ovsDB, dbModel)
@@ -275,7 +275,7 @@ func TestOvsdbServerUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ovsDB := NewInMemoryDatabase(map[string]*model.ClientDBModel{"Open_vSwitch": defDB})
+	ovsDB := NewInMemoryDatabase(map[string]model.ClientDBModel{"Open_vSwitch": defDB})
 	dbModel, errs := model.NewDatabaseModel(schema, defDB)
 	require.Empty(t, errs)
 	o, err := NewOvsdbServer(ovsDB, dbModel)

--- a/test/ovs/ovs_integration_test.go
+++ b/test/ovs/ovs_integration_test.go
@@ -346,7 +346,7 @@ func (suite *OVSIntegrationSuite) TestWithReconnect() {
 LOOP:
 	for {
 		select {
-		case <-time.After(2 * time.Second):
+		case <-time.After(5 * time.Second):
 			suite.T().Fatal("timed out waiting for bridge")
 		case b := <-brChan:
 			if b.Name == bridgeName {

--- a/test/ovs/ovs_integration_test.go
+++ b/test/ovs/ovs_integration_test.go
@@ -275,7 +275,7 @@ func (suite *OVSIntegrationSuite) TestWithReconnect() {
 
 	// Reconfigure
 	err = suite.client.SetOption(
-		client.WithReconnect(500*time.Millisecond, &backoff.ZeroBackOff{}),
+		client.WithReconnect(2*time.Second, &backoff.ZeroBackOff{}),
 	)
 	require.NoError(suite.T(), err)
 


### PR DESCRIPTION
This commit stops using pointers for a number of structures.
For example: ovsdb.DatabaseSchema, model.DatabaseModel

Pointers are great for values that need to be mutable.
But in all the cases changed, we don't need to mutate these
values.

Also fixes:

1. `deferredUpdates` wasn't cleared on reconnect - only when a client properly shuts down the connection
1. The connect() code path seems to be taking appreciably longer since #254 so the `WithReconnect(500 * time.Milliseconds)` is no longer long enough to process the initial cache + any deferred updates in CI - slow machine - for a database with approximately 10 bridges :scream: 
1. A data race in the code that sets up the logger
