### PR TITLE
Make Columns and Tables Optional

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/gob"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -877,6 +878,10 @@ func (t *TableCache) ApplyModifications(tableName string, base model.Model, upda
 
 		current, err := info.FieldByColumn(k)
 		if err != nil {
+			if errors.Is(err, mapper.ErrOmitted) {
+				// skip fields that aren't supported by the runtime schema
+				continue
+			}
 			return err
 		}
 

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -81,7 +81,7 @@ func TestRowCache_Rows(t *testing.T) {
 
 func TestRowCacheCreate(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
-	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}}, nil)
 	require.Nil(t, err)
 	err = json.Unmarshal([]byte(`
 		 {"name": "Open_vSwitch",
@@ -170,7 +170,7 @@ func TestRowCacheCreate(t *testing.T) {
 
 func TestRowCacheCreateMultiIndex(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
-	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}}, nil)
 	require.Nil(t, err)
 	err = json.Unmarshal([]byte(`
 		 {"name": "Open_vSwitch",
@@ -264,7 +264,7 @@ func TestRowCacheCreateMultiIndex(t *testing.T) {
 
 func TestRowCacheUpdate(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
-	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}}, nil)
 	require.Nil(t, err)
 	err = json.Unmarshal([]byte(`
 		 {"name": "Open_vSwitch",
@@ -348,7 +348,7 @@ func TestRowCacheUpdate(t *testing.T) {
 
 func TestRowCacheUpdateMultiIndex(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
-	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}}, nil)
 	require.Nil(t, err)
 	err = json.Unmarshal([]byte(`
 		 {"name": "Open_vSwitch",
@@ -431,7 +431,7 @@ func TestRowCacheUpdateMultiIndex(t *testing.T) {
 
 func TestRowCacheDelete(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
-	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}}, nil)
 	require.Nil(t, err)
 	err = json.Unmarshal([]byte(`
 		 {"name": "Open_vSwitch",
@@ -629,7 +629,7 @@ func TestEventHandlerFuncs_OnDelete(t *testing.T) {
 }
 
 func TestTableCacheTable(t *testing.T) {
-	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}}, nil)
 	assert.Nil(t, err)
 	var schema ovsdb.DatabaseSchema
 	err = json.Unmarshal([]byte(`
@@ -687,7 +687,7 @@ func TestTableCacheTables(t *testing.T) {
 		map[string]model.Model{
 			"test1": &testModel{},
 			"test2": &testModel{},
-			"test3": &testModel{}})
+			"test3": &testModel{}}, nil)
 	assert.Nil(t, err)
 	var schema ovsdb.DatabaseSchema
 	err = json.Unmarshal([]byte(`
@@ -762,7 +762,7 @@ func TestTableCacheTables(t *testing.T) {
 
 func TestTableCache_populate(t *testing.T) {
 	t.Log("Create")
-	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}}, nil)
 	assert.Nil(t, err)
 	var schema ovsdb.DatabaseSchema
 	err = json.Unmarshal([]byte(`
@@ -832,7 +832,7 @@ func TestTableCache_populate(t *testing.T) {
 
 func TestTableCachePopulate(t *testing.T) {
 	t.Log("Create")
-	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}}, nil)
 	assert.Nil(t, err)
 	var schema ovsdb.DatabaseSchema
 	err = json.Unmarshal([]byte(`
@@ -901,7 +901,7 @@ func TestTableCachePopulate(t *testing.T) {
 }
 
 func TestTableCachePopulate2(t *testing.T) {
-	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}}, nil)
 	assert.Nil(t, err)
 	var schema ovsdb.DatabaseSchema
 	err = json.Unmarshal([]byte(`
@@ -1026,7 +1026,7 @@ func TestIndex(t *testing.T) {
 		Bar  string `ovsdb:"bar"`
 		Baz  int    `ovsdb:"baz"`
 	}
-	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &indexTestModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &indexTestModel{}}, nil)
 	assert.Nil(t, err)
 	var schema ovsdb.DatabaseSchema
 	err = json.Unmarshal([]byte(`
@@ -1123,7 +1123,7 @@ func TestIndex(t *testing.T) {
 
 func TestTableCacheRowByModelSingleIndex(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
-	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}}, nil)
 	require.Nil(t, err)
 	err = json.Unmarshal([]byte(`
 		 {"name": "Open_vSwitch",
@@ -1174,7 +1174,7 @@ func TestTableCacheRowByModelSingleIndex(t *testing.T) {
 
 func TestTableCacheRowByModelTwoIndexes(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
-	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}}, nil)
 	require.Nil(t, err)
 	err = json.Unmarshal([]byte(`
 		 {"name": "Open_vSwitch",
@@ -1227,7 +1227,7 @@ func TestTableCacheRowByModelTwoIndexes(t *testing.T) {
 
 func TestTableCacheRowByModelMultiIndex(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
-	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}}, nil)
 	require.Nil(t, err)
 	err = json.Unmarshal([]byte(`
 		 {"name": "Open_vSwitch",
@@ -1379,7 +1379,7 @@ func TestTableCacheApplyModifications(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testDBModel{}})
+			db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testDBModel{}}, nil)
 			assert.Nil(t, err)
 			var schema ovsdb.DatabaseSchema
 			err = json.Unmarshal([]byte(`

--- a/client/api_test_model.go
+++ b/client/api_test_model.go
@@ -157,7 +157,7 @@ func apiTestCache(t *testing.T, data map[string]map[string]model.Model) *cache.T
 	var schema ovsdb.DatabaseSchema
 	err := json.Unmarshal(apiTestSchema, &schema)
 	assert.Nil(t, err)
-	db, err := model.NewClientDBModel("OVN_Northbound", map[string]model.Model{"Logical_Switch": &testLogicalSwitch{}, "Logical_Switch_Port": &testLogicalSwitchPort{}})
+	db, err := model.NewClientDBModel("OVN_Northbound", map[string]model.Model{"Logical_Switch": &testLogicalSwitch{}, "Logical_Switch_Port": &testLogicalSwitchPort{}}, nil)
 	assert.Nil(t, err)
 	dbModel, errs := model.NewDatabaseModel(schema, db)
 	assert.Empty(t, errs)

--- a/client/client.go
+++ b/client/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/go-logr/stdr"
 	"github.com/ovn-org/libovsdb/cache"
+	"github.com/ovn-org/libovsdb/mapper"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/ovn-org/libovsdb/ovsdb/serverdb"
@@ -1120,4 +1121,36 @@ func (o *ovsdbClient) WhereAll(m model.Model, conditions ...model.Condition) Con
 //WhereCache implements the API interface's WhereCache function
 func (o *ovsdbClient) WhereCache(predicate interface{}) ConditionalAPI {
 	return o.primaryDB().api.WhereCache(predicate)
+}
+
+// IsTableSupported checks whether a provided Model is supported by the
+// runtime schema
+func (o *ovsdbClient) IsTableSupported(m model.Model) bool {
+	o.primaryDB().modelMutex.RLock()
+	defer o.primaryDB().modelMutex.RUnlock()
+	tableName := o.primaryDB().model.FindTable(reflect.TypeOf(m))
+	if _, ok := o.primaryDB().model.Schema.Tables[tableName]; ok {
+		return true
+	}
+	return false
+}
+
+// IsColumnSupported checks whether a provided column (derived via field Pointer in a Model)
+// is supported by the runtime schema
+func (o *ovsdbClient) IsColumnSupported(m model.Model, fieldPtr interface{}) bool {
+	o.primaryDB().modelMutex.RLock()
+	defer o.primaryDB().modelMutex.RUnlock()
+	tableName := o.primaryDB().model.FindTable(reflect.TypeOf(m))
+	tSchema, ok := o.primaryDB().model.Schema.Tables[tableName]
+	if !ok {
+		return false
+	}
+	info, err := mapper.NewInfo(tableName, &tSchema, m)
+	if err != nil {
+		return false
+	}
+	if _, err := info.ColumnByPtr(fieldPtr); err != nil {
+		return false
+	}
+	return true
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -92,6 +92,7 @@ var defDB, _ = model.NewClientDBModel("Open_vSwitch",
 		"Open_vSwitch": &OpenvSwitch{},
 		"Bridge":       &Bridge{},
 	},
+	nil,
 )
 
 var schema = `{
@@ -562,7 +563,7 @@ func BenchmarkUpdate1(b *testing.B) {
 	clientDBModel, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Bridge":       &Bridge{},
 		"Open_vSwitch": &OpenvSwitch{},
-	})
+	}, nil)
 	require.NoError(b, err)
 	dbModel, errs := model.NewDatabaseModel(s, clientDBModel)
 	require.Empty(b, errs)
@@ -588,7 +589,7 @@ func BenchmarkUpdate2(b *testing.B) {
 	clientDBModel, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Bridge":       &Bridge{},
 		"Open_vSwitch": &OpenvSwitch{},
-	})
+	}, nil)
 	require.NoError(b, err)
 	dbModel, errs := model.NewDatabaseModel(s, clientDBModel)
 	require.Empty(b, errs)
@@ -615,7 +616,7 @@ func BenchmarkUpdate3(b *testing.B) {
 	clientDBModel, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Bridge":       &Bridge{},
 		"Open_vSwitch": &OpenvSwitch{},
-	})
+	}, nil)
 	require.NoError(b, err)
 	dbModel, errs := model.NewDatabaseModel(s, clientDBModel)
 	require.Empty(b, errs)
@@ -643,7 +644,7 @@ func BenchmarkUpdate5(b *testing.B) {
 	clientDBModel, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Bridge":       &Bridge{},
 		"Open_vSwitch": &OpenvSwitch{},
-	})
+	}, nil)
 	require.NoError(b, err)
 	dbModel, errs := model.NewDatabaseModel(s, clientDBModel)
 	require.Empty(b, errs)
@@ -673,7 +674,7 @@ func BenchmarkUpdate8(b *testing.B) {
 	clientDBModel, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Bridge":       &Bridge{},
 		"Open_vSwitch": &OpenvSwitch{},
-	})
+	}, nil)
 	require.NoError(b, err)
 	dbModel, errs := model.NewDatabaseModel(s, clientDBModel)
 	require.Empty(b, errs)
@@ -720,7 +721,7 @@ func TestUpdate(t *testing.T) {
 	clientDBModel, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Bridge":       &Bridge{},
 		"Open_vSwitch": &OpenvSwitch{},
-	})
+	}, nil)
 	require.NoError(t, err)
 	dbModel, errs := model.NewDatabaseModel(s, clientDBModel)
 	require.Empty(t, errs)

--- a/cmd/stress/stress.go
+++ b/cmd/stress/stress.go
@@ -249,7 +249,7 @@ func main() {
 	}
 
 	var err error
-	clientDBModel, err = model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &ovsType{}, "Bridge": &bridgeType{}})
+	clientDBModel, err = model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &ovsType{}, "Bridge": &bridgeType{}}, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example/play_with_ovs/main.go
+++ b/example/play_with_ovs/main.go
@@ -98,7 +98,7 @@ func main() {
 	update = make(chan model.Model)
 
 	clientDBModel, err := model.NewClientDBModel("Open_vSwitch",
-		map[string]model.Model{bridgeTable: &vswitchd.Bridge{}, ovsTable: &vswitchd.OpenvSwitch{}})
+		map[string]model.Model{bridgeTable: &vswitchd.Bridge{}, ovsTable: &vswitchd.OpenvSwitch{}}, nil)
 	if err != nil {
 		log.Fatal("Unable to create DB model ", err)
 	}

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -1,6 +1,7 @@
 package mapper
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -74,7 +75,7 @@ func (m Mapper) getData(ovsData ovsdb.Row, result *Info) error {
 				result.Metadata.TableName, name, err.Error())
 		}
 
-		if err := result.SetField(name, nativeElem); err != nil {
+		if err := result.SetField(name, nativeElem); err != nil && !errors.Is(err, ErrOmitted) {
 			return err
 		}
 	}
@@ -94,7 +95,9 @@ func (m Mapper) NewRow(data *Info, fields ...interface{}) (ovsdb.Row, error) {
 	for name, column := range columns {
 		nativeElem, err := data.FieldByColumn(name)
 		if err != nil {
-			// If provided struct does not have a field to hold this value, skip it
+			// If provided struct does not have a field to hold this value
+			// Or it does have a field but it's not supported by the runtime schema,
+			// skip it
 			continue
 		}
 

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -50,7 +50,7 @@ func TestClientDBModel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("TestNewModel_%s", tt.name), func(t *testing.T) {
-			db, err := NewClientDBModel(tt.name, tt.obj)
+			db, err := NewClientDBModel(tt.name, tt.obj, nil)
 			if tt.valid {
 				assert.Nil(t, err)
 				assert.Len(t, db.types, len(tt.obj))
@@ -63,7 +63,7 @@ func TestClientDBModel(t *testing.T) {
 }
 
 func TestNewModel(t *testing.T) {
-	db, err := NewClientDBModel("testTable", map[string]Model{"Test_A": &modelA{}, "Test_B": &modelB{}})
+	db, err := NewClientDBModel("testTable", map[string]Model{"Test_A": &modelA{}, "Test_B": &modelB{}}, nil)
 	assert.Nil(t, err)
 	_, err = db.newModel("Unknown")
 	assert.NotNilf(t, err, "Creating model from unknown table should fail")
@@ -95,7 +95,7 @@ func TestValidate(t *testing.T) {
 			aSet    []string          `ovsdb:"aSet"`
 			aMap    map[string]string `ovsdb:"aMap"`
 		}{},
-	})
+	}, nil)
 	assert.Nil(t, err)
 
 	tests := []struct {
@@ -333,6 +333,109 @@ func TestValidate(t *testing.T) {
 		})
 	}
 
+}
+func TestValidateOptional(t *testing.T) {
+	model, err := NewClientDBModel("TestDB", map[string]Model{
+		"TestTable": &struct {
+			aUUID   string            `ovsdb:"_uuid"`
+			aString string            `ovsdb:"aString"`
+			aInt    int               `ovsdb:"aInt"`
+			aFloat  float64           `ovsdb:"aFloat"`
+			aSet    []string          `ovsdb:"aSet"`
+			aMap    map[string]string `ovsdb:"aMap"`
+		}{},
+		"OptionalTable": &struct {
+			aUUID   string `ovsdb:"_uuid"`
+			aString string `ovsdb:"aString"`
+		}{},
+	}, map[string]bool{"OptionalTable": true})
+	assert.Nil(t, err)
+
+	tests := []struct {
+		name   string
+		schema []byte
+		err    bool
+	}{
+		{
+			name: "wrong name",
+			schema: []byte(`{
+			    "name": "Wrong"
+			}`),
+			err: true,
+		},
+		{
+			name: "full support",
+			schema: []byte(`{
+			    "name": "TestDB",
+  			    "tables": {
+  			      "TestTable": {
+  			        "columns": {
+  			          "aString": { "type": "string" },
+  			          "aInt": { "type": "integer" },
+  			          "aFloat": { "type": "real" } ,
+  			          "aSet": { "type": {
+  			              "key": "string",
+  			              "max": "unlimited",
+  			              "min": 0
+  			            } },
+  			          "aMap": {
+  			            "type": {
+  			              "key": "string",
+  			              "max": "unlimited",
+  			              "min": 0,
+  			              "value": "string"
+  			            }
+  			          }
+  			        },
+					"OptionalTable": { "columns": { "aString": { "type": "string" }}}
+  			      }
+				}
+			}`),
+			err: false,
+		},
+		{
+			name: "missing optional table",
+			schema: []byte(`{
+			    "name": "TestDB",
+  			    "tables": {
+  			      "TestTable": {
+  			        "columns": {
+  			          "aString": { "type": "string" },
+  			          "aInt": { "type": "integer" },
+  			          "aFloat": { "type": "real" } ,
+  			          "aSet": { "type": {
+  			              "key": "string",
+  			              "max": "unlimited",
+  			              "min": 0
+  			            } },
+  			          "aMap": {
+  			            "type": {
+  			              "key": "string",
+  			              "max": "unlimited",
+  			              "min": 0,
+  			              "value": "string"
+  			            }
+  			          }
+  			        }
+  			      }
+			    }
+			}`),
+			err: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("TestValidate %s", tt.name), func(t *testing.T) {
+			var schema ovsdb.DatabaseSchema
+			err := json.Unmarshal(tt.schema, &schema)
+			assert.Nil(t, err)
+			errors := model.validate(schema)
+			if tt.err {
+				assert.Greater(t, len(errors), 0)
+			} else {
+				assert.Len(t, errors, 0)
+			}
+		})
+	}
 }
 
 func TestClone(t *testing.T) {

--- a/modelgen/dbmodel.go
+++ b/modelgen/dbmodel.go
@@ -44,7 +44,7 @@ func FullDatabaseModel() (model.ClientDBModel, error) {
 	return model.NewClientDBModel("{{ index . "DatabaseName" }}", map[string]model.Model{
     {{ range index . "Tables" }} "{{ .TableName }}" : &{{ .StructName }}{}, 
     {{ end }}
-	})
+	}, nil)
 }
 
 var schema = {{ index . "Schema" | escape }}

--- a/modelgen/dbmodel_test.go
+++ b/modelgen/dbmodel_test.go
@@ -62,7 +62,7 @@ import (
 func FullDatabaseModel() (model.ClientDBModel, error) {
 	return model.NewClientDBModel("AtomicDB", map[string]model.Model{
 		"atomicTable": &AtomicTable{},
-	})
+	}, nil)
 }
 ` + `
 var schema = ` + "`" + `{

--- a/ovsdb/serverdb/model.go
+++ b/ovsdb/serverdb/model.go
@@ -14,7 +14,7 @@ import (
 func FullDatabaseModel() (model.ClientDBModel, error) {
 	return model.NewClientDBModel("_Server", map[string]model.Model{
 		"Database": &Database{},
-	})
+	}, nil)
 }
 
 var schema = `{

--- a/server/server_integration_test.go
+++ b/server/server_integration_test.go
@@ -58,7 +58,7 @@ func getSchema() (ovsdb.DatabaseSchema, error) {
 func TestClientServerEcho(t *testing.T) {
 	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
-		"Bridge":       &bridgeType{}})
+		"Bridge":       &bridgeType{}}, nil)
 	require.Nil(t, err)
 
 	schema, err := getSchema()
@@ -95,7 +95,7 @@ func TestClientServerEcho(t *testing.T) {
 func TestClientServerInsert(t *testing.T) {
 	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
-		"Bridge":       &bridgeType{}})
+		"Bridge":       &bridgeType{}}, nil)
 	require.Nil(t, err)
 
 	schema, err := getSchema()
@@ -162,7 +162,7 @@ func TestClientServerInsert(t *testing.T) {
 func TestClientServerMonitor(t *testing.T) {
 	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
-		"Bridge":       &bridgeType{}})
+		"Bridge":       &bridgeType{}}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -288,7 +288,7 @@ func TestClientServerMonitor(t *testing.T) {
 func TestClientServerInsertAndDelete(t *testing.T) {
 	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
-		"Bridge":       &bridgeType{}})
+		"Bridge":       &bridgeType{}}, nil)
 	require.Nil(t, err)
 
 	schema, err := getSchema()
@@ -354,7 +354,7 @@ func TestClientServerInsertDuplicate(t *testing.T) {
 	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
 		"Bridge":       &bridgeType{},
-	})
+	}, nil)
 	require.Nil(t, err)
 
 	schema, err := getSchema()
@@ -408,7 +408,7 @@ func TestClientServerInsertDuplicate(t *testing.T) {
 func TestClientServerInsertAndUpdate(t *testing.T) {
 	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
-		"Bridge":       &bridgeType{}})
+		"Bridge":       &bridgeType{}}, nil)
 	require.Nil(t, err)
 
 	schema, err := getSchema()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -68,7 +68,7 @@ func TestExpandNamedUUID(t *testing.T) {
 func TestOvsdbServerMonitor(t *testing.T) {
 	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
-		"Bridge":       &bridgeType{}})
+		"Bridge":       &bridgeType{}}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/transact_test.go
+++ b/server/transact_test.go
@@ -14,7 +14,7 @@ import (
 func TestMutateOp(t *testing.T) {
 	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
-		"Bridge":       &bridgeType{}})
+		"Bridge":       &bridgeType{}}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -213,7 +213,7 @@ func TestOvsdbServerInsert(t *testing.T) {
 	t.Skip("need a helper for comparing rows as map elements aren't in same order")
 	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
-		"Bridge":       &bridgeType{}})
+		"Bridge":       &bridgeType{}}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -271,7 +271,7 @@ func TestOvsdbServerInsert(t *testing.T) {
 func TestOvsdbServerUpdate(t *testing.T) {
 	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
-		"Bridge":       &bridgeType{}})
+		"Bridge":       &bridgeType{}}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -357,7 +357,7 @@ func TestOvsdbServerUpdate(t *testing.T) {
 func TestMultipleOps(t *testing.T) {
 	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
-		"Bridge":       &bridgeType{}})
+		"Bridge":       &bridgeType{}}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/ovs/ovs_integration_test.go
+++ b/test/ovs/ovs_integration_test.go
@@ -172,7 +172,7 @@ var defDB, _ = model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 	"Bridge":       &bridgeType{},
 	"IPFIX":        &ipfixType{},
 	"Queue":        &queueType{},
-})
+}, nil)
 
 func (suite *OVSIntegrationSuite) TestConnectReconnect() {
 	assert.True(suite.T(), suite.client.Connected())


### PR DESCRIPTION
This allows for Columns to be declared optional via the
ClientDatabaseModel.

Fields may be marked as optional within the struct tag.

This allows a connection when a mapped table (and columns that reference it) aren't available at runtime to support upgrades.

To allow a user to easily see which Tables and Columns are supported two
new APIs were added.

IsTableSupported and IsColumnSupported

Fixes: #235 