### PR TITLE
Protect cache integrity during reads

### DIFF
--- a/client/api_test.go
+++ b/client/api_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -95,7 +96,7 @@ func TestAPIListSimple(t *testing.T) {
 				result = make([]testLogicalSwitch, tt.initialCap)
 			}
 			api := newAPI(tcache, &discardLogger)
-			err := api.List(&result)
+			err := api.List(context.Background(), &result)
 			if tt.err {
 				assert.NotNil(t, err)
 			} else {
@@ -111,14 +112,14 @@ func TestAPIListSimple(t *testing.T) {
 	t.Run("ApiList: Error wrong type", func(t *testing.T) {
 		var result []string
 		api := newAPI(tcache, &discardLogger)
-		err := api.List(&result)
+		err := api.List(context.Background(), &result)
 		assert.NotNil(t, err)
 	})
 
 	t.Run("ApiList: Type Selection", func(t *testing.T) {
 		var result []testLogicalSwitchPort
 		api := newAPI(tcache, &discardLogger)
-		err := api.List(&result)
+		err := api.List(context.Background(), &result)
 		assert.Nil(t, err)
 		assert.Len(t, result, 0, "Should be empty since cache is empty")
 	})
@@ -126,7 +127,7 @@ func TestAPIListSimple(t *testing.T) {
 	t.Run("ApiList: Empty List", func(t *testing.T) {
 		result := []testLogicalSwitch{}
 		api := newAPI(tcache, &discardLogger)
-		err := api.List(&result)
+		err := api.List(context.Background(), &result)
 		assert.Nil(t, err)
 		assert.Len(t, result, len(lscacheList))
 	})
@@ -213,7 +214,7 @@ func TestAPIListPredicate(t *testing.T) {
 			var result []testLogicalSwitch
 			api := newAPI(tcache, &discardLogger)
 			cond := api.WhereCache(tt.predicate)
-			err := cond.List(&result)
+			err := cond.List(context.Background(), &result)
 			if tt.err {
 				assert.NotNil(t, err)
 			} else {
@@ -301,7 +302,7 @@ func TestAPIListFields(t *testing.T) {
 			// Clean object
 			testObj = testLogicalSwitchPort{}
 			api := newAPI(tcache, &discardLogger)
-			err := api.Where(&testObj).List(&result)
+			err := api.Where(&testObj).List(context.Background(), &result)
 			if tt.err {
 				assert.NotNil(t, err)
 			} else {
@@ -319,7 +320,7 @@ func TestAPIListFields(t *testing.T) {
 			UUID: aUUID0,
 		}
 
-		err := api.Where(&obj).List(&result)
+		err := api.Where(&obj).List(context.Background(), &result)
 		assert.NotNil(t, err)
 	})
 }
@@ -502,7 +503,7 @@ func TestAPIGet(t *testing.T) {
 			var result testLogicalSwitchPort
 			tt.prepare(&result)
 			api := newAPI(tcache, &discardLogger)
-			err := api.Get(&result)
+			err := api.Get(context.Background(), &result)
 			if tt.err {
 				assert.NotNil(t, err)
 			} else {

--- a/cmd/stress/stress.go
+++ b/cmd/stress/stress.go
@@ -77,7 +77,7 @@ func cleanup(ctx context.Context) {
 
 	// Remove all existing bridges
 	var bridges []bridgeType
-	if err := ovs.List(&bridges); err == nil {
+	if err := ovs.List(context.Background(), &bridges); err == nil {
 		log.Printf("%d existing bridges found", len(bridges))
 		for _, bridge := range bridges {
 			deleteBridge(ctx, ovs, rootUUID, &bridge)

--- a/example/play_with_ovs/main.go
+++ b/example/play_with_ovs/main.go
@@ -37,7 +37,7 @@ func play(ovs client.Client) {
 		} else {
 			fmt.Printf("Current list of bridges:\n")
 			var bridges []vswitchd.Bridge
-			if err := ovs.List(&bridges); err != nil {
+			if err := ovs.List(context.Background(), &bridges); err != nil {
 				log.Fatal(err)
 			}
 			for _, b := range bridges {

--- a/server/server_integration_test.go
+++ b/server/server_integration_test.go
@@ -145,12 +145,12 @@ func TestClientServerInsert(t *testing.T) {
 	uuid := reply[0].UUID.GoUUID
 	require.Eventually(t, func() bool {
 		br := &bridgeType{UUID: uuid}
-		err := ovs.Get(br)
+		err := ovs.Get(context.Background(), br)
 		return err == nil
 	}, 2*time.Second, 500*time.Millisecond)
 
 	br := &bridgeType{UUID: uuid}
-	err = ovs.Get(br)
+	err = ovs.Get(context.Background(), br)
 	require.NoError(t, err)
 
 	assert.Equal(t, bridgeRow.Name, br.Name)
@@ -335,7 +335,7 @@ func TestClientServerInsertAndDelete(t *testing.T) {
 	uuid := reply[0].UUID.GoUUID
 	assert.Eventually(t, func() bool {
 		br := &bridgeType{UUID: uuid}
-		err := ovs.Get(br)
+		err := ovs.Get(context.Background(), br)
 		return err == nil
 	}, 2*time.Second, 500*time.Millisecond)
 
@@ -457,7 +457,7 @@ func TestClientServerInsertAndUpdate(t *testing.T) {
 	uuid := reply[0].UUID.GoUUID
 	assert.Eventually(t, func() bool {
 		br := &bridgeType{UUID: uuid}
-		err := ovs.Get(br)
+		err := ovs.Get(context.Background(), br)
 		return err == nil
 	}, 2*time.Second, 500*time.Millisecond)
 
@@ -482,7 +482,7 @@ func TestClientServerInsertAndUpdate(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		br := &bridgeType{UUID: uuid}
-		err = ovs.Get(br)
+		err = ovs.Get(context.Background(), br)
 		if err != nil {
 			return false
 		}
@@ -500,7 +500,7 @@ func TestClientServerInsertAndUpdate(t *testing.T) {
 
 	assert.Eventually(t, func() bool {
 		br := &bridgeType{UUID: uuid}
-		err = ovs.Get(br)
+		err = ovs.Get(context.Background(), br)
 		if err != nil {
 			return false
 		}
@@ -508,7 +508,7 @@ func TestClientServerInsertAndUpdate(t *testing.T) {
 	}, 2*time.Second, 500*time.Millisecond)
 
 	br := &bridgeType{UUID: uuid}
-	err = ovs.Get(br)
+	err = ovs.Get(context.Background(), br)
 	assert.NoError(t, err)
 
 	assert.Equal(t, bridgeRow, br)


### PR DESCRIPTION
During an invalid cache state, the client will disconnect, then attempt
reconnect to each endpoint. During this process reads against the cache
is are not prohibited. This means a client could be reading stale data
from the cache.

During reconnect we use the meta db.cacheMutex (not the cache mutex) to
control resetting the db's cache. This patch leverages that to guard
reads to the cache based on the same mutex. Additionally, it tries to
ensure that the cache will be in a consistent state when the read takes
place. The db.cacheMutex is not held for the entire reconnect process,
so we need to make some attempt to wait for a signal that a reconnect is
complete... a best effort attempt to give the client an accurate cache
read.

Signed-off-by: Tim Rozet <trozet@redhat.com>