### PR TITLE
Make transactions block when using WithReconnect

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -97,7 +97,9 @@ func WithLeaderOnly(leaderOnly bool) Option {
 // WithReconnect tells the client to automatically reconnect when
 // disconnected. The timeout is used to construct the context on
 // each call to Connect, while backoff dictates the backoff
-// algorithm to use
+// algorithm to use. Using WithReconnect implies that
+// requested transactions will block until the client has fully reconnected,
+// rather than immediately returning an error if there is no connection.
 func WithReconnect(timeout time.Duration, backoff backoff.BackOff) Option {
 	return func(o *options) error {
 		o.reconnect = true


### PR DESCRIPTION
When creating a client using WithReconnect any requested Transact method
will block if the client is currently disconnected, and wait until it is
reconnected to execute the transaction (within a given context).

Signed-off-by: Tim Rozet <trozet@redhat.com>