### PR TITLE
Always enforce checking all indexes

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -90,11 +90,11 @@ func TestRowCacheCreate(t *testing.T) {
 			  "indexes": [["foo"]],
 		      "columns": {
 		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
+			      "type": "string"
+			    },
+			    "bar": {
+				  "type": "string"
+			    }
 		      }
 		    }
 		 }
@@ -111,17 +111,15 @@ func TestRowCacheCreate(t *testing.T) {
 	require.Nil(t, err)
 
 	tests := []struct {
-		name       string
-		uuid       string
-		model      *testModel
-		checkIndex bool
-		wantErr    bool
+		name    string
+		uuid    string
+		model   *testModel
+		wantErr bool
 	}{
 		{
 			"inserts a new row",
 			"foo",
 			&testModel{Foo: "foo"},
-			true,
 			false,
 		},
 		{
@@ -129,35 +127,25 @@ func TestRowCacheCreate(t *testing.T) {
 			"bar",
 			&testModel{Foo: "foo"},
 			true,
-			true,
 		},
 		{
 			"error duplicate index",
 			"baz",
 			&testModel{Foo: "bar"},
 			true,
-			true,
 		},
 		{
-			"error duplicate uuid, no index check",
+			"error duplicate uuid and index",
 			"bar",
 			&testModel{Foo: "bar"},
-			false,
 			true,
-		},
-		{
-			"no error duplicate index",
-			"baz",
-			&testModel{Foo: "bar"},
-			false,
-			false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rc := tc.Table("Open_vSwitch")
 			require.NotNil(t, rc)
-			err := rc.Create(tt.uuid, tt.model, tt.checkIndex)
+			err := rc.Create(tt.uuid, tt.model)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -179,11 +167,11 @@ func TestRowCacheCreateMultiIndex(t *testing.T) {
 			  "indexes": [["foo", "bar"]],
 		      "columns": {
 		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
+			      "type": "string"
+			    },
+			    "bar": {
+				  "type": "string"
+			    }
 		      }
 		    }
 		 }
@@ -244,7 +232,7 @@ func TestRowCacheCreateMultiIndex(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			rc := tc.Table("Open_vSwitch")
 			require.NotNil(t, rc)
-			err := rc.Create(tt.uuid, tt.model, true)
+			err := rc.Create(tt.uuid, tt.model)
 			if tt.wantErr {
 				assert.Error(t, err)
 				if tt.wantIndexExistsErr {
@@ -273,11 +261,11 @@ func TestRowCacheUpdate(t *testing.T) {
 			  "indexes": [["foo"]],
 		      "columns": {
 		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
+			      "type": "string"
+			    },
+			    "bar": {
+				  "type": "string"
+			    }
 		      }
 		    }
 		 }
@@ -296,24 +284,21 @@ func TestRowCacheUpdate(t *testing.T) {
 	require.Nil(t, err)
 
 	tests := []struct {
-		name       string
-		uuid       string
-		model      *testModel
-		checkIndex bool
-		wantErr    bool
+		name    string
+		uuid    string
+		model   *testModel
+		wantErr bool
 	}{
 		{
 			"error if row does not exist",
 			"foo",
 			&testModel{Foo: "foo"},
 			true,
-			true,
 		},
 		{
 			"update",
 			"bar",
 			&testModel{Foo: "baz"},
-			true,
 			false,
 		},
 		{
@@ -321,21 +306,13 @@ func TestRowCacheUpdate(t *testing.T) {
 			"bar",
 			&testModel{Foo: "foobar"},
 			true,
-			true,
-		},
-		{
-			"no error new index would cause duplicate",
-			"bar",
-			&testModel{Foo: "foobar"},
-			false,
-			false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rc := tc.Table("Open_vSwitch")
 			require.NotNil(t, rc)
-			err := rc.Update(tt.uuid, tt.model, tt.checkIndex)
+			err := rc.Update(tt.uuid, tt.model)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -357,11 +334,11 @@ func TestRowCacheUpdateMultiIndex(t *testing.T) {
 			  "indexes": [["foo", "bar"]],
 		      "columns": {
 		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
+			      "type": "string"
+			    },
+			    "bar": {
+				  "type": "string"
+			    }
 		      }
 		    }
 		 }
@@ -414,7 +391,7 @@ func TestRowCacheUpdateMultiIndex(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			rc := tc.Table("Open_vSwitch")
 			require.NotNil(t, rc)
-			err := rc.Update(tt.uuid, tt.model, true)
+			err := rc.Update(tt.uuid, tt.model)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -440,11 +417,11 @@ func TestRowCacheDelete(t *testing.T) {
 			  "indexes": [["foo"]],
 		      "columns": {
 		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
+			      "type": "string"
+			    },
+			    "bar": {
+				  "type": "string"
+			    }
 		      }
 		    }
 		 }
@@ -639,11 +616,11 @@ func TestTableCacheTable(t *testing.T) {
 			  "indexes": [["foo"]],
 		      "columns": {
 		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
+			      "type": "string"
+			    },
+			    "bar": {
+				  "type": "string"
+			    }
 		      }
 		    }
 		 }
@@ -696,31 +673,31 @@ func TestTableCacheTables(t *testing.T) {
 		    "test1": {
 		      "columns": {
 		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
+			      "type": "string"
+			    },
+			    "bar": {
+				  "type": "string"
+			    }
 		      }
 		    },
 		    "test2": {
 		      "columns": {
 		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
+			      "type": "string"
+			    },
+			    "bar": {
+				  "type": "string"
+			    }
 		      }
 		    },
 		    "test3": {
 		      "columns": {
 		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
+			      "type": "string"
+			    },
+			    "bar": {
+				  "type": "string"
+			    }
 		      }
 		    }
 		 }
@@ -772,11 +749,11 @@ func TestTableCache_populate(t *testing.T) {
 			  "indexes": [["foo"]],
 		      "columns": {
 		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
+			      "type": "string"
+			    },
+			    "bar": {
+				  "type": "string"
+			    }
 		      }
 		    }
 		 }
@@ -842,11 +819,11 @@ func TestTableCachePopulate(t *testing.T) {
 			  "indexes": [["foo"]],
 		      "columns": {
 		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
+			      "type": "string"
+			    },
+			    "bar": {
+				  "type": "string"
+			    }
 		      }
 		    }
 		 }
@@ -911,11 +888,11 @@ func TestTableCachePopulate2(t *testing.T) {
 			  "indexes": [["foo"]],
 		      "columns": {
 		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
+			      "type": "string"
+			    },
+			    "bar": {
+				  "type": "string"
+			    }
 		      }
 		    }
 		 }
@@ -1036,14 +1013,14 @@ func TestIndex(t *testing.T) {
 			  "indexes": [["foo"], ["bar","baz"]],
 		      "columns": {
 		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			},
-			"baz": {
-				"type": "integer"
-			}
+			      "type": "string"
+			    },
+			    "bar": {
+				  "type": "string"
+		    	},
+			    "baz": {
+				  "type": "integer"
+			    }
 		      }
 		    }
 		 }
@@ -1062,7 +1039,7 @@ func TestIndex(t *testing.T) {
 	}
 	table := tc.Table("Open_vSwitch")
 
-	err = table.Create(obj.UUID, obj, true)
+	err = table.Create(obj.UUID, obj)
 	assert.Nil(t, err)
 	t.Run("Index by single column", func(t *testing.T) {
 		idx, err := table.Index("foo")
@@ -1132,11 +1109,11 @@ func TestTableCacheRowByModelSingleIndex(t *testing.T) {
 			  "indexes": [["foo"]],
 		      "columns": {
 		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
+			      "type": "string"
+			    },
+			    "bar": {
+				  "type": "string"
+			    }
 		      }
 		    }
 		 }
@@ -1183,11 +1160,11 @@ func TestTableCacheRowByModelTwoIndexes(t *testing.T) {
 			  "indexes": [["foo"], ["bar"]],
 		      "columns": {
 		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
+			      "type": "string"
+			    },
+			    "bar": {
+				  "type": "string"
+			    }
 		      }
 		    }
 		 }
@@ -1236,11 +1213,11 @@ func TestTableCacheRowByModelMultiIndex(t *testing.T) {
 			  "indexes": [["foo", "bar"]],
 		      "columns": {
 		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
+			      "type": "string"
+			    },
+			    "bar": {
+				  "type": "string"
+			    }
 		      }
 		    }
 		 }

--- a/server/transact.go
+++ b/server/transact.go
@@ -111,7 +111,7 @@ func (t *Transaction) rowsFromTransactionCacheAndDatabase(table string, where []
 			rows[rowUUID] = txnRow
 		} else {
 			// warm the transaction cache with the current contents of the row
-			if err := t.Cache.Table(table).Create(rowUUID, row, false); err != nil {
+			if err := t.Cache.Table(table).Create(rowUUID, row); err != nil {
 				return nil, fmt.Errorf("failed warming transaction cache row %s %v for table %s: %v", rowUUID, row, table, err)
 			}
 			txnRows[rowUUID] = row


### PR DESCRIPTION
There can be a case with ovsdb-server where we receive multiple creates
in a row for an object that has different UUIDs, but the same named
index. An example of this was seen with OVN and logical router ports,
where we received a create for two of the same named ports. In this case
the create should fail, and we should reconnect and reinitialize the
cache.

On the client side, we should always validate the cache population is
legit, and if not, reconnect and try to re-init the cache.

Signed-off-by: Tim Rozet <trozet@redhat.com>