### PR TITLE
Ensure Cache Indexes Don't Get Corrupted

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -285,7 +285,12 @@ func (r *RowCache) Delete(uuid string) error {
 		if err != nil {
 			return err
 		}
-		delete(r.indexes[index], oldVal)
+		// only remove the index if it is pointing to this uuid
+		// otherwise we can cause a consistency issue if we've processed
+		// updates out of order
+		if r.indexes[index][oldVal] == uuid {
+			delete(r.indexes[index], oldVal)
+		}
 	}
 	delete(r.cache, uuid)
 	return nil

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -134,7 +134,7 @@ func (r *RowCache) RowByModel(m model.Model) model.Model {
 }
 
 // Create writes the provided content to the cache
-func (r *RowCache) Create(uuid string, m model.Model) error {
+func (r *RowCache) Create(uuid string, m model.Model, checkIndexes bool) error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 	if _, ok := r.cache[uuid]; ok {
@@ -154,7 +154,7 @@ func (r *RowCache) Create(uuid string, m model.Model) error {
 			return err
 		}
 
-		if existing, ok := r.indexes[index][val]; ok {
+		if existing, ok := r.indexes[index][val]; ok && checkIndexes {
 			return NewIndexExistsError(r.name, val, string(index), uuid, existing)
 		}
 
@@ -172,7 +172,7 @@ func (r *RowCache) Create(uuid string, m model.Model) error {
 }
 
 // Update updates the content in the cache
-func (r *RowCache) Update(uuid string, m model.Model) error {
+func (r *RowCache) Update(uuid string, m model.Model, checkIndexes bool) error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 	if _, ok := r.cache[uuid]; !ok {
@@ -209,7 +209,7 @@ func (r *RowCache) Update(uuid string, m model.Model) error {
 		// old and new values are NOT the same
 
 		// check that there are no conflicts
-		if conflict, ok := r.indexes[index][newVal]; ok && conflict != uuid {
+		if conflict, ok := r.indexes[index][newVal]; ok && checkIndexes && conflict != uuid {
 			errs = append(errs, NewIndexExistsError(
 				r.name,
 				newVal,
@@ -460,7 +460,7 @@ func NewTableCache(dbModel model.DatabaseModel, data Data, logger *logr.Logger) 
 			return nil, fmt.Errorf("table %s is not in schema", table)
 		}
 		for uuid, row := range rowData {
-			if err := cache[table].Create(uuid, row); err != nil {
+			if err := cache[table].Create(uuid, row, true); err != nil {
 				return nil, err
 			}
 		}
@@ -574,7 +574,7 @@ func (t *TableCache) Populate(tableUpdates ovsdb.TableUpdates) error {
 				if existing := tCache.Row(uuid); existing != nil {
 					if !reflect.DeepEqual(newModel, existing) {
 						logger.V(5).Info("updating row", "old:", fmt.Sprintf("%+v", existing), "new", fmt.Sprintf("%+v", newModel))
-						if err := tCache.Update(uuid, newModel); err != nil {
+						if err := tCache.Update(uuid, newModel, false); err != nil {
 							return err
 						}
 						t.eventProcessor.AddEvent(updateEvent, table, existing, newModel)
@@ -583,7 +583,7 @@ func (t *TableCache) Populate(tableUpdates ovsdb.TableUpdates) error {
 					continue
 				}
 				logger.V(5).Info("creating row", "model", fmt.Sprintf("%+v", newModel))
-				if err := tCache.Create(uuid, newModel); err != nil {
+				if err := tCache.Create(uuid, newModel, false); err != nil {
 					return err
 				}
 				t.eventProcessor.AddEvent(addEvent, table, nil, newModel)
@@ -625,7 +625,7 @@ func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) error {
 					return err
 				}
 				logger.V(5).Info("creating row", "model", fmt.Sprintf("%+v", m))
-				if err := tCache.Create(uuid, m); err != nil {
+				if err := tCache.Create(uuid, m, false); err != nil {
 					return err
 				}
 				t.eventProcessor.AddEvent(addEvent, table, nil, m)
@@ -634,8 +634,8 @@ func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) error {
 				if err != nil {
 					return err
 				}
-				logger.V(5).Info("inserting row", "model", fmt.Sprintf("%+v", m))
-				if err := tCache.Create(uuid, m); err != nil {
+				logger.V(5).Info("creating row", "model", fmt.Sprintf("%+v", m))
+				if err := tCache.Create(uuid, m, false); err != nil {
 					return err
 				}
 				t.eventProcessor.AddEvent(addEvent, table, nil, m)
@@ -651,7 +651,7 @@ func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) error {
 				}
 				if !reflect.DeepEqual(modified, existing) {
 					logger.V(5).Info("updating row", "old", fmt.Sprintf("%+v", existing), "new", fmt.Sprintf("%+v", modified))
-					if err := tCache.Update(uuid, modified); err != nil {
+					if err := tCache.Update(uuid, modified, false); err != nil {
 						return err
 					}
 					t.eventProcessor.AddEvent(updateEvent, table, existing, modified)

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -90,11 +90,11 @@ func TestRowCacheCreate(t *testing.T) {
 			  "indexes": [["foo"]],
 		      "columns": {
 		        "foo": {
-			      "type": "string"
-			    },
-			    "bar": {
-				  "type": "string"
-			    }
+			  "type": "string"
+			},
+			"bar": {
+				"type": "string"
+			  }
 		      }
 		    }
 		 }
@@ -111,15 +111,17 @@ func TestRowCacheCreate(t *testing.T) {
 	require.Nil(t, err)
 
 	tests := []struct {
-		name    string
-		uuid    string
-		model   *testModel
-		wantErr bool
+		name       string
+		uuid       string
+		model      *testModel
+		checkIndex bool
+		wantErr    bool
 	}{
 		{
 			"inserts a new row",
 			"foo",
 			&testModel{Foo: "foo"},
+			true,
 			false,
 		},
 		{
@@ -127,25 +129,35 @@ func TestRowCacheCreate(t *testing.T) {
 			"bar",
 			&testModel{Foo: "foo"},
 			true,
+			true,
 		},
 		{
 			"error duplicate index",
 			"baz",
 			&testModel{Foo: "bar"},
 			true,
+			true,
 		},
 		{
-			"error duplicate uuid and index",
+			"error duplicate uuid, no index check",
 			"bar",
 			&testModel{Foo: "bar"},
+			false,
 			true,
+		},
+		{
+			"no error duplicate index",
+			"baz",
+			&testModel{Foo: "bar"},
+			false,
+			false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rc := tc.Table("Open_vSwitch")
 			require.NotNil(t, rc)
-			err := rc.Create(tt.uuid, tt.model)
+			err := rc.Create(tt.uuid, tt.model, tt.checkIndex)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -167,11 +179,11 @@ func TestRowCacheCreateMultiIndex(t *testing.T) {
 			  "indexes": [["foo", "bar"]],
 		      "columns": {
 		        "foo": {
-			      "type": "string"
-			    },
-			    "bar": {
-				  "type": "string"
-			    }
+			  "type": "string"
+			},
+			"bar": {
+				"type": "string"
+			  }
 		      }
 		    }
 		 }
@@ -232,7 +244,7 @@ func TestRowCacheCreateMultiIndex(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			rc := tc.Table("Open_vSwitch")
 			require.NotNil(t, rc)
-			err := rc.Create(tt.uuid, tt.model)
+			err := rc.Create(tt.uuid, tt.model, true)
 			if tt.wantErr {
 				assert.Error(t, err)
 				if tt.wantIndexExistsErr {
@@ -261,11 +273,11 @@ func TestRowCacheUpdate(t *testing.T) {
 			  "indexes": [["foo"]],
 		      "columns": {
 		        "foo": {
-			      "type": "string"
-			    },
-			    "bar": {
-				  "type": "string"
-			    }
+			  "type": "string"
+			},
+			"bar": {
+				"type": "string"
+			  }
 		      }
 		    }
 		 }
@@ -284,21 +296,24 @@ func TestRowCacheUpdate(t *testing.T) {
 	require.Nil(t, err)
 
 	tests := []struct {
-		name    string
-		uuid    string
-		model   *testModel
-		wantErr bool
+		name       string
+		uuid       string
+		model      *testModel
+		checkIndex bool
+		wantErr    bool
 	}{
 		{
 			"error if row does not exist",
 			"foo",
 			&testModel{Foo: "foo"},
 			true,
+			true,
 		},
 		{
 			"update",
 			"bar",
 			&testModel{Foo: "baz"},
+			true,
 			false,
 		},
 		{
@@ -306,13 +321,21 @@ func TestRowCacheUpdate(t *testing.T) {
 			"bar",
 			&testModel{Foo: "foobar"},
 			true,
+			true,
+		},
+		{
+			"no error new index would cause duplicate",
+			"bar",
+			&testModel{Foo: "foobar"},
+			false,
+			false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rc := tc.Table("Open_vSwitch")
 			require.NotNil(t, rc)
-			err := rc.Update(tt.uuid, tt.model)
+			err := rc.Update(tt.uuid, tt.model, tt.checkIndex)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -334,11 +357,11 @@ func TestRowCacheUpdateMultiIndex(t *testing.T) {
 			  "indexes": [["foo", "bar"]],
 		      "columns": {
 		        "foo": {
-			      "type": "string"
-			    },
-			    "bar": {
-				  "type": "string"
-			    }
+			  "type": "string"
+			},
+			"bar": {
+				"type": "string"
+			  }
 		      }
 		    }
 		 }
@@ -391,7 +414,7 @@ func TestRowCacheUpdateMultiIndex(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			rc := tc.Table("Open_vSwitch")
 			require.NotNil(t, rc)
-			err := rc.Update(tt.uuid, tt.model)
+			err := rc.Update(tt.uuid, tt.model, true)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -417,11 +440,11 @@ func TestRowCacheDelete(t *testing.T) {
 			  "indexes": [["foo"]],
 		      "columns": {
 		        "foo": {
-			      "type": "string"
-			    },
-			    "bar": {
-				  "type": "string"
-			    }
+			  "type": "string"
+			},
+			"bar": {
+				"type": "string"
+			  }
 		      }
 		    }
 		 }
@@ -616,11 +639,11 @@ func TestTableCacheTable(t *testing.T) {
 			  "indexes": [["foo"]],
 		      "columns": {
 		        "foo": {
-			      "type": "string"
-			    },
-			    "bar": {
-				  "type": "string"
-			    }
+			  "type": "string"
+			},
+			"bar": {
+				"type": "string"
+			  }
 		      }
 		    }
 		 }
@@ -673,31 +696,31 @@ func TestTableCacheTables(t *testing.T) {
 		    "test1": {
 		      "columns": {
 		        "foo": {
-			      "type": "string"
-			    },
-			    "bar": {
-				  "type": "string"
-			    }
+			  "type": "string"
+			},
+			"bar": {
+				"type": "string"
+			  }
 		      }
 		    },
 		    "test2": {
 		      "columns": {
 		        "foo": {
-			      "type": "string"
-			    },
-			    "bar": {
-				  "type": "string"
-			    }
+			  "type": "string"
+			},
+			"bar": {
+				"type": "string"
+			  }
 		      }
 		    },
 		    "test3": {
 		      "columns": {
 		        "foo": {
-			      "type": "string"
-			    },
-			    "bar": {
-				  "type": "string"
-			    }
+			  "type": "string"
+			},
+			"bar": {
+				"type": "string"
+			  }
 		      }
 		    }
 		 }
@@ -749,11 +772,11 @@ func TestTableCache_populate(t *testing.T) {
 			  "indexes": [["foo"]],
 		      "columns": {
 		        "foo": {
-			      "type": "string"
-			    },
-			    "bar": {
-				  "type": "string"
-			    }
+			  "type": "string"
+			},
+			"bar": {
+				"type": "string"
+			  }
 		      }
 		    }
 		 }
@@ -819,11 +842,11 @@ func TestTableCachePopulate(t *testing.T) {
 			  "indexes": [["foo"]],
 		      "columns": {
 		        "foo": {
-			      "type": "string"
-			    },
-			    "bar": {
-				  "type": "string"
-			    }
+			  "type": "string"
+			},
+			"bar": {
+				"type": "string"
+			  }
 		      }
 		    }
 		 }
@@ -888,11 +911,11 @@ func TestTableCachePopulate2(t *testing.T) {
 			  "indexes": [["foo"]],
 		      "columns": {
 		        "foo": {
-			      "type": "string"
-			    },
-			    "bar": {
-				  "type": "string"
-			    }
+			  "type": "string"
+			},
+			"bar": {
+				"type": "string"
+			  }
 		      }
 		    }
 		 }
@@ -1013,14 +1036,14 @@ func TestIndex(t *testing.T) {
 			  "indexes": [["foo"], ["bar","baz"]],
 		      "columns": {
 		        "foo": {
-			      "type": "string"
-			    },
-			    "bar": {
-				  "type": "string"
-		    	},
-			    "baz": {
-				  "type": "integer"
-			    }
+			  "type": "string"
+			},
+			"bar": {
+				"type": "string"
+			},
+			"baz": {
+				"type": "integer"
+			}
 		      }
 		    }
 		 }
@@ -1039,7 +1062,7 @@ func TestIndex(t *testing.T) {
 	}
 	table := tc.Table("Open_vSwitch")
 
-	err = table.Create(obj.UUID, obj)
+	err = table.Create(obj.UUID, obj, true)
 	assert.Nil(t, err)
 	t.Run("Index by single column", func(t *testing.T) {
 		idx, err := table.Index("foo")
@@ -1109,11 +1132,11 @@ func TestTableCacheRowByModelSingleIndex(t *testing.T) {
 			  "indexes": [["foo"]],
 		      "columns": {
 		        "foo": {
-			      "type": "string"
-			    },
-			    "bar": {
-				  "type": "string"
-			    }
+			  "type": "string"
+			},
+			"bar": {
+				"type": "string"
+			  }
 		      }
 		    }
 		 }
@@ -1160,11 +1183,11 @@ func TestTableCacheRowByModelTwoIndexes(t *testing.T) {
 			  "indexes": [["foo"], ["bar"]],
 		      "columns": {
 		        "foo": {
-			      "type": "string"
-			    },
-			    "bar": {
-				  "type": "string"
-			    }
+			  "type": "string"
+			},
+			"bar": {
+				"type": "string"
+			  }
 		      }
 		    }
 		 }
@@ -1213,11 +1236,11 @@ func TestTableCacheRowByModelMultiIndex(t *testing.T) {
 			  "indexes": [["foo", "bar"]],
 		      "columns": {
 		        "foo": {
-			      "type": "string"
-			    },
-			    "bar": {
-				  "type": "string"
-			    }
+			  "type": "string"
+			},
+			"bar": {
+				"type": "string"
+			  }
 		      }
 		    }
 		 }

--- a/server/transact.go
+++ b/server/transact.go
@@ -111,7 +111,7 @@ func (t *Transaction) rowsFromTransactionCacheAndDatabase(table string, where []
 			rows[rowUUID] = txnRow
 		} else {
 			// warm the transaction cache with the current contents of the row
-			if err := t.Cache.Table(table).Create(rowUUID, row); err != nil {
+			if err := t.Cache.Table(table).Create(rowUUID, row, false); err != nil {
 				return nil, fmt.Errorf("failed warming transaction cache row %s %v for table %s: %v", rowUUID, row, table, err)
 			}
 			txnRows[rowUUID] = row


### PR DESCRIPTION
These commits:

1. Revert #263 since there are no guarantees from ovsdb-server that indexes won't break in a monitor reply
2. Adds a test to catch the case that was causing issue in ovn-k, where we processed an insert for a row where the indexes matched and existing one... and when the original was deleted, so were the indexes.
3. Adds a commit to check that indexes on deletion so we only remove indexes that point to a row that is being deleted