### PR TITLE
client: export OvsdbClient (but not its fields)

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -489,7 +489,7 @@ func testOvsMap(t *testing.T, set interface{}) ovsdb.OvsMap {
 	return oMap
 }
 
-func updateBenchmark(ovs *ovsdbClient, updates []byte, b *testing.B) {
+func updateBenchmark(ovs *OvsdbClient, updates []byte, b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		params := []json.RawMessage{[]byte(`{"databaseName":"Open_vSwitch","id":"v1"}`), updates}
 		var reply []interface{}

--- a/client/metrics.go
+++ b/client/metrics.go
@@ -64,7 +64,7 @@ func (m *metrics) register(r prometheus.Registerer) {
 	)
 }
 
-func (o *ovsdbClient) registerMetrics() {
+func (o *OvsdbClient) registerMetrics() {
 	if !o.options.shouldRegisterMetrics || o.options.registry == nil {
 		return
 	}

--- a/client/monitor.go
+++ b/client/monitor.go
@@ -29,7 +29,7 @@ func newMonitor() *Monitor {
 }
 
 // NewMonitor creates a new Monitor with the provided options
-func (o *ovsdbClient) NewMonitor(opts ...MonitorOption) *Monitor {
+func (o *OvsdbClient) NewMonitor(opts ...MonitorOption) *Monitor {
 	m := newMonitor()
 	for _, opt := range opts {
 		err := opt(o, m)
@@ -41,7 +41,7 @@ func (o *ovsdbClient) NewMonitor(opts ...MonitorOption) *Monitor {
 }
 
 // MonitorOption adds Tables to a Monitor
-type MonitorOption func(o *ovsdbClient, m *Monitor) error
+type MonitorOption func(o *OvsdbClient, m *Monitor) error
 
 // MonitorCookie is the struct we pass to correlate from updates back to their
 // originating Monitor request.
@@ -69,7 +69,7 @@ type TableMonitor struct {
 }
 
 func WithTable(m model.Model, fields ...interface{}) MonitorOption {
-	return func(o *ovsdbClient, monitor *Monitor) error {
+	return func(o *OvsdbClient, monitor *Monitor) error {
 		tableName := o.primaryDB().model.FindTable(reflect.TypeOf(m))
 		if tableName == "" {
 			return fmt.Errorf("object of type %s is not part of the ClientDBModel", reflect.TypeOf(m))
@@ -84,7 +84,7 @@ func WithTable(m model.Model, fields ...interface{}) MonitorOption {
 }
 
 func WithConditionalTable(m model.Model, condition model.Condition, fields ...interface{}) MonitorOption {
-	return func(o *ovsdbClient, monitor *Monitor) error {
+	return func(o *OvsdbClient, monitor *Monitor) error {
 		tableName := o.primaryDB().model.FindTable(reflect.TypeOf(m))
 		if tableName == "" {
 			return fmt.Errorf("object of type %s is not part of the ClientDBModel", reflect.TypeOf(m))


### PR DESCRIPTION
Allows consumers to embed the client while preserving data
encapsulation. As long as none of the members are exported
consumers can't mess around with the data, but at least can
wrap the struct with embedding.

@dave-tucker @trozet 