### PR TITLE
Fix connection leak and the cache inconsistency errors caused by it.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -246,6 +246,7 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 			for id, request := range db.monitors {
 				err := o.monitor(ctx, MonitorCookie{DatabaseName: dbName, ID: id}, true, request)
 				if err != nil {
+					o.rpcClient.Close()
 					o.rpcClient = nil
 					return err
 				}


### PR DESCRIPTION
When reconnecting to a server, if the connection is created but starting
the monitors failed, the rpcClient is not closed, so the connection
leaks. This causes error logging for every update message received,
because multiple connection handlers are operating on the same cache.

This was observed at large scale environment when monitor request for the
initial result set exceeded the connection timeout.

client.go:1044] "msg"="failed to reconnect" "error"="context deadline exceeded" "database"="OVN_Northbound"

And then below errors were flooding:

client.go:1015] "msg"="error updating cache" "error"="cache inconsistent: cache inconsistent: row with uuid 18e837b5-cae6-49b4-a1aa-eb70606e62eb does not exist" "database"="OVN_Northbound"

When the reconnection and monitor creation timeout happen several times,
more and more connections leak and the ovnkube-master may get blocked
forever. With this fix, the problem disappears.

Signed-off-by: Han Zhou <hzhou@ovn.org>