### PR TITLE
server: allow calling Close() without Serve()

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -100,7 +100,10 @@ func (o *OvsdbServer) Close() {
 	o.readyMutex.Lock()
 	o.ready = false
 	o.readyMutex.Unlock()
-	o.listener.Close()
+	// Only close the listener if Serve() has been called
+	if o.listener != nil {
+		o.listener.Close()
+	}
 	close(o.done)
 }
 


### PR DESCRIPTION
Useful for CI tests in other projects where a BeforeEach()
might create the server for multiple tests, but one or more
tests doesn't actually use it and thus doesn't call Serve().