### PR TITLE
cache: clone model for modification rather than do another lookup

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -655,7 +655,7 @@ func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) error {
 				if existing == nil {
 					return NewErrCacheInconsistent(fmt.Sprintf("row with uuid %s does not exist", uuid))
 				}
-				modified := tCache.Row(uuid)
+				modified := model.Clone(existing)
 				err := t.ApplyModifications(table, modified, *row.Modify)
 				if err != nil {
 					return fmt.Errorf("unable to apply row modifications: %v", err)


### PR DESCRIPTION
Instead of grabbing another read lock on the row cache just to look
up the same model, clone the one we just got.

@dave-tucker @jcaamano