### PR TITLE
client: don't reconnect to same db after leader change

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -74,14 +74,21 @@ type bufferedUpdate struct {
 	lastTxnID string
 }
 
+type epInfo struct {
+	address  string
+	serverID string
+}
+
 // ovsdbClient is an OVSDB client
 type ovsdbClient struct {
-	options        *options
-	metrics        metrics
-	connected      bool
-	rpcClient      *rpc2.Client
-	rpcMutex       sync.RWMutex
-	activeEndpoint string
+	options   *options
+	metrics   metrics
+	connected bool
+	rpcClient *rpc2.Client
+	rpcMutex  sync.RWMutex
+	// endpoints contains all possible endpoints; the first element is
+	// the active endpoint if connected=true
+	endpoints []*epInfo
 
 	// The name of the "primary" database - that is to say, the DB
 	// that the user expects to interact with.
@@ -146,6 +153,9 @@ func newOVSDBClient(clientDBModel model.ClientDBModel, opts ...Option) (*ovsdbCl
 	if err != nil {
 		return nil, err
 	}
+	for _, address := range ovs.options.endpoints {
+		ovs.endpoints = append(ovs.endpoints, &epInfo{address: address})
+	}
 
 	if ovs.options.logger == nil {
 		// create a new logger to log to stdout
@@ -199,6 +209,21 @@ func (o *ovsdbClient) Connect(ctx context.Context) error {
 	return nil
 }
 
+// moveEndpointFirst makes the endpoint requested by active the first element
+// in the endpoints slice, indicating it is the active endpoint
+func (o *ovsdbClient) moveEndpointFirst(i int) {
+	firstEp := o.endpoints[i]
+	othereps := append(o.endpoints[:i], o.endpoints[i+1:]...)
+	o.endpoints = append([]*epInfo{firstEp}, othereps...)
+}
+
+// moveEndpointLast moves the requested endpoint to the end of the list
+func (o *ovsdbClient) moveEndpointLast(i int) {
+	lastEp := o.endpoints[i]
+	othereps := append(o.endpoints[:i], o.endpoints[i+1:]...)
+	o.endpoints = append(othereps, lastEp)
+}
+
 func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 	o.rpcMutex.Lock()
 	defer o.rpcMutex.Unlock()
@@ -208,18 +233,19 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 
 	connected := false
 	connectErrors := []error{}
-	for _, endpoint := range o.options.endpoints {
-		u, err := url.Parse(endpoint)
+	for i, endpoint := range o.endpoints {
+		u, err := url.Parse(endpoint.address)
 		if err != nil {
 			return err
 		}
-		if err := o.tryEndpoint(ctx, u); err != nil {
+		if sid, err := o.tryEndpoint(ctx, u); err != nil {
 			connectErrors = append(connectErrors,
-				fmt.Errorf("failed to connect to %s: %w", endpoint, err))
+				fmt.Errorf("failed to connect to %s: %w", endpoint.address, err))
 			continue
 		} else {
-			o.logger.V(3).Info("successfully connected", "endpoint", endpoint)
-			o.activeEndpoint = endpoint
+			o.logger.V(3).Info("successfully connected", "endpoint", endpoint.address, "sid", sid)
+			endpoint.serverID = sid
+			o.moveEndpointFirst(i)
 			connected = true
 			break
 		}
@@ -264,7 +290,9 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 	return nil
 }
 
-func (o *ovsdbClient) tryEndpoint(ctx context.Context, u *url.URL) error {
+// tryEndpoint connects to a single database endpoint. Returns the
+// server ID (if clustered) on success, or an error.
+func (o *ovsdbClient) tryEndpoint(ctx context.Context, u *url.URL) (string, error) {
 	o.logger.V(5).Info("trying to connect", "endpoint", fmt.Sprintf("%v", u))
 	var dialer net.Dialer
 	var err error
@@ -285,7 +313,7 @@ func (o *ovsdbClient) tryEndpoint(ctx context.Context, u *url.URL) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to open connection: %w", err)
+		return "", fmt.Errorf("failed to open connection: %w", err)
 	}
 
 	o.createRPC2Client(c)
@@ -294,7 +322,7 @@ func (o *ovsdbClient) tryEndpoint(ctx context.Context, u *url.URL) error {
 	if err != nil {
 		o.rpcClient.Close()
 		o.rpcClient = nil
-		return err
+		return "", err
 	}
 
 	// for every requested database, ensure the DB exists in the server and
@@ -312,7 +340,7 @@ func (o *ovsdbClient) tryEndpoint(ctx context.Context, u *url.URL) error {
 			err = fmt.Errorf("target database %s not found", dbName)
 			o.rpcClient.Close()
 			o.rpcClient = nil
-			return err
+			return "", err
 		}
 
 		// load and validate the schema
@@ -320,7 +348,7 @@ func (o *ovsdbClient) tryEndpoint(ctx context.Context, u *url.URL) error {
 		if err != nil {
 			o.rpcClient.Close()
 			o.rpcClient = nil
-			return err
+			return "", err
 		}
 
 		db.modelMutex.Lock()
@@ -336,7 +364,7 @@ func (o *ovsdbClient) tryEndpoint(ctx context.Context, u *url.URL) error {
 				strings.Join(combined, ". "))
 			o.rpcClient.Close()
 			o.rpcClient = nil
-			return err
+			return "", err
 		}
 
 		db.cacheMutex.Lock()
@@ -346,7 +374,7 @@ func (o *ovsdbClient) tryEndpoint(ctx context.Context, u *url.URL) error {
 				db.cacheMutex.Unlock()
 				o.rpcClient.Close()
 				o.rpcClient = nil
-				return err
+				return "", err
 			}
 			db.api = newAPI(db.cache, o.logger)
 		} else {
@@ -356,22 +384,23 @@ func (o *ovsdbClient) tryEndpoint(ctx context.Context, u *url.URL) error {
 	}
 
 	// check that this is the leader
+	var sid string
 	if o.options.leaderOnly {
 		var leader bool
-		leader, err = o.isEndpointLeader(ctx)
+		leader, sid, err = o.isEndpointLeader(ctx)
 		if err != nil {
 			o.rpcClient.Close()
 			o.rpcClient = nil
-			return err
+			return "", err
 		}
 		if !leader {
 			err = fmt.Errorf("endpoint is not leader")
 			o.rpcClient.Close()
 			o.rpcClient = nil
-			return err
+			return "", err
 		}
 	}
-	return nil
+	return sid, nil
 }
 
 // createRPC2Client creates an rpcClient using the provided connection
@@ -396,9 +425,11 @@ func (o *ovsdbClient) createRPC2Client(conn net.Conn) {
 	go o.rpcClient.Run()
 }
 
-// isEndpointLeader returns true if the currently connected endpoint is leader.
-// assumes rpcMutex is held
-func (o *ovsdbClient) isEndpointLeader(ctx context.Context) (bool, error) {
+// isEndpointLeader returns true if the currently connected endpoint is leader,
+// otherwise false or an error. If the currently connected endpoint is the leader
+// and the database is clustered, also returns the database's Server ID.
+// Assumes rpcMutex is held.
+func (o *ovsdbClient) isEndpointLeader(ctx context.Context) (bool, string, error) {
 	op := ovsdb.Operation{
 		Op:      ovsdb.OperationSelect,
 		Table:   "Database",
@@ -406,21 +437,21 @@ func (o *ovsdbClient) isEndpointLeader(ctx context.Context) (bool, error) {
 	}
 	results, err := o.transact(ctx, serverDB, op)
 	if err != nil {
-		return false, fmt.Errorf("could not check if server was leader: %w", err)
+		return false, "", fmt.Errorf("could not check if server was leader: %w", err)
 	}
 	// for now, if no rows are returned, just accept this server
 	if len(results) != 1 {
-		return true, nil
+		return true, "", nil
 	}
 	result := results[0]
 	if len(result.Rows) == 0 {
-		return true, nil
+		return true, "", nil
 	}
 
 	for _, row := range result.Rows {
 		dbName, ok := row["name"].(string)
 		if !ok {
-			return false, fmt.Errorf("could not parse name")
+			return false, "", fmt.Errorf("could not parse name")
 		}
 		if dbName != o.primaryDBName {
 			continue
@@ -428,26 +459,33 @@ func (o *ovsdbClient) isEndpointLeader(ctx context.Context) (bool, error) {
 
 		model, ok := row["model"].(string)
 		if !ok {
-			return false, fmt.Errorf("could not parse model")
+			return false, "", fmt.Errorf("could not parse model")
 		}
 
 		// the database reports whether or not it is part of a cluster via the
 		// "model" column. If it's not clustered, it is by definition leader.
 		if model != serverdb.DatabaseModelClustered {
-			return true, nil
+			return true, "", nil
+		}
+
+		// Clustered database must have a Server ID
+		sid, ok := row["sid"].(ovsdb.UUID)
+		if !ok {
+			return false, "", fmt.Errorf("could not parse server id")
 		}
 
 		leader, ok := row["leader"].(bool)
 		if !ok {
-			return false, fmt.Errorf("could not parse leader")
+			return false, "", fmt.Errorf("could not parse leader")
 		}
-		return leader, nil
+
+		return leader, sid.GoUUID, nil
 	}
 
 	// Extremely unlikely: there is no _Server row for the desired DB (which we made sure existed)
 	// for now, just continue
 	o.logger.V(3).Info("Couldn't find a row in _Server for our database. Continuing without leader detection", "database", o.primaryDBName)
-	return true, nil
+	return true, "", nil
 }
 
 func (o *ovsdbClient) primaryDB() *database {
@@ -497,7 +535,7 @@ func (o *ovsdbClient) CurrentEndpoint() string {
 	if o.rpcClient == nil {
 		return ""
 	}
-	return o.activeEndpoint
+	return o.endpoints[0].address
 }
 
 // DisconnectNotify returns a channel which will notify the caller when the
@@ -983,10 +1021,37 @@ func (o *ovsdbClient) watchForLeaderChange() error {
 				continue
 			}
 
-			if dbInfo.Model == serverdb.DatabaseModelClustered && !dbInfo.Leader && o.Connected() {
-				o.logger.V(3).Info("endpoint lost leader, reconnecting", "endpoint", o.activeEndpoint)
-				o.Disconnect()
+			// Only handle leadership changes for clustered databases
+			if dbInfo.Model != serverdb.DatabaseModelClustered {
+				continue
 			}
+
+			// Clustered database servers must have a valid Server ID
+			var sid string
+			if dbInfo.Sid != nil {
+				sid = *dbInfo.Sid
+			}
+			if sid == "" {
+				o.logger.V(3).Info("clustered database update contained invalid server ID")
+				continue
+			}
+
+			o.rpcMutex.Lock()
+			if !dbInfo.Leader && o.connected {
+				activeEndpoint := o.endpoints[0]
+				if sid == activeEndpoint.serverID {
+					o.logger.V(3).Info("endpoint lost leader, reconnecting",
+						"endpoint", activeEndpoint.address, "sid", sid)
+					// don't immediately reconnect to the active endpoint since it's no longer leader
+					o.moveEndpointLast(0)
+					o._disconnect()
+				} else {
+					o.logger.V(3).Info("endpoint lost leader but had unexpected server ID",
+						"endpoint", activeEndpoint.address,
+						"expected", activeEndpoint.serverID, "found", sid)
+				}
+			}
+			o.rpcMutex.Unlock()
 		}
 	}()
 	return nil
@@ -1051,7 +1116,7 @@ func (o *ovsdbClient) handleDisconnectNotification() {
 			suppressionCounter++
 			return err
 		}
-		o.logger.V(3).Info("connection lost, reconnecting", "endpoint", o.activeEndpoint)
+		o.logger.V(3).Info("connection lost, reconnecting", "endpoint", o.endpoints[0].address)
 		err := backoff.Retry(connect, o.options.backoff)
 		if err != nil {
 			// TODO: We should look at passing this back to the
@@ -1096,17 +1161,24 @@ func (o *ovsdbClient) handleDisconnectNotification() {
 	}
 }
 
+// _disconnect will close the connection to the OVSDB server
+// If the client was created with WithReconnect then the client
+// will reconnect afterwards. Assumes rpcMutex is held.
+func (o *ovsdbClient) _disconnect() {
+	o.connected = false
+	if o.rpcClient == nil {
+		return
+	}
+	o.rpcClient.Close()
+}
+
 // Disconnect will close the connection to the OVSDB server
 // If the client was created with WithReconnect then the client
 // will reconnect afterwards
 func (o *ovsdbClient) Disconnect() {
 	o.rpcMutex.Lock()
 	defer o.rpcMutex.Unlock()
-	o.connected = false
-	if o.rpcClient == nil {
-		return
-	}
-	o.rpcClient.Close()
+	o._disconnect()
 }
 
 // Close will close the connection to the OVSDB server

--- a/server/server.go
+++ b/server/server.go
@@ -71,6 +71,11 @@ func NewOvsdbServer(db Database, models ...model.DatabaseModel) (*OvsdbServer, e
 	return o, nil
 }
 
+// OnConnect registers a function to run when a client connects.
+func (o *OvsdbServer) OnConnect(f func(*rpc2.Client)) {
+	o.srv.OnConnect(f)
+}
+
 // Serve starts the OVSDB server on the given path and protocol
 func (o *OvsdbServer) Serve(protocol string, path string) error {
 	var err error


### PR DESCRIPTION
If the active endpoint changed leadership and the client is following
leadership, don't reconnect to the same endpoint (which is no longer
the leader) until we've exhausted all other options. Doing so
prolongs the reconnect process for two reasons:

a) the same endpoint is no longer leader so we'll just disconnect
immediately anyway
b) the same endpoint may be compacting its database, which is why it
transferred leadership, and won't respond to our connection attempt
until it's done

@jcaamano @dave-tucker 