### PR TITLE
client: don't clone objects when passing to predicate functions

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -316,6 +316,21 @@ func (r *RowCache) Rows() map[string]model.Model {
 	return result
 }
 
+// RowsShallow returns a clone'd list of f all Rows in the cache, but does not
+// clone the underlying objects. Therefore, the objects returned are READ ONLY.
+// This is, however, thread safe, as the cached objects are cloned before being updated
+// when modifications come in.
+func (r *RowCache) RowsShallow() map[string]model.Model {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	result := make(map[string]model.Model, len(r.cache))
+	for k, v := range r.cache {
+		result[k] = v
+	}
+	return result
+}
+
 func (r *RowCache) RowsByCondition(conditions []ovsdb.Condition) (map[string]model.Model, error) {
 	results := make(map[string]model.Model)
 	schema := r.dbModel.Schema.Table(r.name)

--- a/client/api.go
+++ b/client/api.go
@@ -126,7 +126,7 @@ func (a api) List(ctx context.Context, result interface{}) error {
 	}
 	i := resultVal.Len()
 
-	for _, row := range tableCache.Rows() {
+	for _, row := range tableCache.RowsShallow() {
 		if i >= resultVal.Cap() {
 			break
 		}
@@ -138,8 +138,10 @@ func (a api) List(ctx context.Context, result interface{}) error {
 				continue
 			}
 		}
+		// clone only the models that match the predicate
+		m := model.Clone(row)
 
-		resultVal.Set(reflect.Append(resultVal, reflect.Indirect(reflect.ValueOf(row))))
+		resultVal.Set(reflect.Append(resultVal, reflect.Indirect(reflect.ValueOf(m))))
 		i++
 	}
 	return nil

--- a/client/api_test_model.go
+++ b/client/api_test_model.go
@@ -153,7 +153,7 @@ func (*testLogicalSwitchPort) Table() string {
 	return "Logical_Switch_Port"
 }
 
-func apiTestCache(t *testing.T, data map[string]map[string]model.Model) *cache.TableCache {
+func apiTestCache(t testing.TB, data map[string]map[string]model.Model) *cache.TableCache {
 	var schema ovsdb.DatabaseSchema
 	err := json.Unmarshal(apiTestSchema, &schema)
 	assert.Nil(t, err)


### PR DESCRIPTION
This is a significant memory optimization in the case where lists of
large tables only return a few objects. Rather than deep-copying the
cache, just shallow-copy the list. Predicate functions get the uncloned
object. Then, only clone for objects that match the predicate.

This is safe over updates because updated objects are cloned before
being mutated.

Signed-off-by: Casey Callendrello <cdc@redhat.com>