### PR TITLE
Fix json encoding of wait method timeout

### DIFF
--- a/ovsdb/notation.go
+++ b/ovsdb/notation.go
@@ -35,7 +35,7 @@ type Operation struct {
 	Rows      []Row       `json:"rows,omitempty"`
 	Columns   []string    `json:"columns,omitempty"`
 	Mutations []Mutation  `json:"mutations,omitempty"`
-	Timeout   int         `json:"timeout,omitempty"`
+	Timeout   *int        `json:"timeout,omitempty"`
 	Where     []Condition `json:"where,omitempty"`
 	Until     string      `json:"until,omitempty"`
 	Durable   *bool       `json:"durable,omitempty"`

--- a/ovsdb/rpc_test.go
+++ b/ovsdb/rpc_test.go
@@ -15,6 +15,18 @@ func TestNewGetSchemaArgs(t *testing.T) {
 	}
 }
 
+func TestNewWaitTransactArgs(t *testing.T) {
+	database := "Open_vSwitch"
+	i := 0
+	operation := Operation{Op: "wait", Table: "Bridge", Timeout: &i}
+	args := NewTransactArgs(database, operation)
+	argString, _ := json.Marshal(args)
+	expected := `["Open_vSwitch",{"op":"wait","table":"Bridge","timeout":0}]`
+	if string(argString) != expected {
+		t.Error("Expected: ", expected, " Got: ", string(argString))
+	}
+}
+
 func TestNewTransactArgs(t *testing.T) {
 	database := "Open_vSwitch"
 	operation := Operation{Op: "insert", Table: "Bridge"}

--- a/server/transact.go
+++ b/server/transact.go
@@ -514,7 +514,7 @@ func (t *Transaction) Delete(database, table string, where []ovsdb.Condition) (o
 		}
 }
 
-func (t *Transaction) Wait(database, table string, timeout int, conditions []ovsdb.Condition, columns []string, until string, rows []ovsdb.Row) ovsdb.OperationResult {
+func (t *Transaction) Wait(database, table string, timeout *int, conditions []ovsdb.Condition, columns []string, until string, rows []ovsdb.Row) ovsdb.OperationResult {
 	e := ovsdb.NotSupported{}
 	return ovsdb.OperationResult{Error: e.Error()}
 }


### PR DESCRIPTION
Timeout was set as an int so during encoding of a specified 0 value it
would be omitted from the RPC call.

Signed-off-by: Tim Rozet <trozet@redhat.com>