### PR TITLE
server: implement column filters in Select()

### DIFF
--- a/ovsdb/set.go
+++ b/ovsdb/set.go
@@ -21,6 +21,10 @@ type OvsSet struct {
 func NewOvsSet(obj interface{}) (OvsSet, error) {
 	var v reflect.Value
 	if reflect.TypeOf(obj).Kind() == reflect.Ptr {
+		if reflect.ValueOf(obj).IsZero() {
+			// Empty set
+			return OvsSet{make([]interface{}, 0)}, nil
+		}
 		v = reflect.ValueOf(obj).Elem()
 	} else {
 		v = reflect.ValueOf(obj)

--- a/server/server.go
+++ b/server/server.go
@@ -277,7 +277,8 @@ func (o *OvsdbServer) Monitor(client *rpc2.Client, args []json.RawMessage, reply
 
 	tableUpdates := make(ovsdb.TableUpdates)
 	for t, request := range request {
-		rows := transaction.Select(t, nil, request.Columns)
+		// FIXME: don't include _uuid in results if client didn't request it
+		rows := transaction.Select(t, nil, true, request.Columns)
 		for i := range rows.Rows {
 			tu := make(ovsdb.TableUpdate)
 			uuid := rows.Rows[i]["_uuid"].(ovsdb.UUID).GoUUID
@@ -324,7 +325,8 @@ func (o *OvsdbServer) MonitorCond(client *rpc2.Client, args []json.RawMessage, r
 
 	tableUpdates := make(ovsdb.TableUpdates2)
 	for t, request := range request {
-		rows := transaction.Select(t, nil, request.Columns)
+		// FIXME: don't include _uuid in results if client didn't request it
+		rows := transaction.Select(t, nil, true, request.Columns)
 		for i := range rows.Rows {
 			tu := make(ovsdb.TableUpdate2)
 			uuid := rows.Rows[i]["_uuid"].(ovsdb.UUID).GoUUID
@@ -369,7 +371,8 @@ func (o *OvsdbServer) MonitorCondSince(client *rpc2.Client, args []json.RawMessa
 
 	tableUpdates := make(ovsdb.TableUpdates2)
 	for t, request := range request {
-		rows := transaction.Select(t, nil, request.Columns)
+		// FIXME: don't include _uuid in results if client didn't request it
+		rows := transaction.Select(t, nil, true, request.Columns)
 		for i := range rows.Rows {
 			tu := make(ovsdb.TableUpdate2)
 			uuid := rows.Rows[i]["_uuid"].(ovsdb.UUID).GoUUID

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -65,6 +65,14 @@ func TestExpandNamedUUID(t *testing.T) {
 	}
 }
 
+func emptyOvsMap() ovsdb.OvsMap {
+	return ovsdb.OvsMap{GoMap: make(map[interface{}]interface{})}
+}
+
+func emptyOvsSet() ovsdb.OvsSet {
+	return ovsdb.OvsSet{GoSet: make([]interface{}, 0)}
+}
+
 func TestOvsdbServerMonitor(t *testing.T) {
 	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
 		"Open_vSwitch": &ovsType{},
@@ -124,26 +132,50 @@ func TestOvsdbServerMonitor(t *testing.T) {
 		"Bridge": {
 			fooUUID: &ovsdb.RowUpdate{
 				New: &ovsdb.Row{
-					"_uuid": ovsdb.UUID{GoUUID: fooUUID},
-					"name":  "foo",
+					"_uuid":         ovsdb.UUID{GoUUID: fooUUID},
+					"name":          "foo",
+					"datapath_id":   emptyOvsSet(),
+					"datapath_type": "",
+					"external_ids":  emptyOvsMap(),
+					"other_config":  emptyOvsMap(),
+					"ports":         emptyOvsSet(),
+					"status":        emptyOvsMap(),
 				},
 			},
 			barUUID: &ovsdb.RowUpdate{
 				New: &ovsdb.Row{
-					"_uuid": ovsdb.UUID{GoUUID: barUUID},
-					"name":  "bar",
+					"_uuid":         ovsdb.UUID{GoUUID: barUUID},
+					"name":          "bar",
+					"datapath_id":   emptyOvsSet(),
+					"datapath_type": "",
+					"external_ids":  emptyOvsMap(),
+					"other_config":  emptyOvsMap(),
+					"ports":         emptyOvsSet(),
+					"status":        emptyOvsMap(),
 				},
 			},
 			bazUUID: &ovsdb.RowUpdate{
 				New: &ovsdb.Row{
-					"_uuid": ovsdb.UUID{GoUUID: bazUUID},
-					"name":  "baz",
+					"_uuid":         ovsdb.UUID{GoUUID: bazUUID},
+					"name":          "baz",
+					"datapath_id":   emptyOvsSet(),
+					"datapath_type": "",
+					"external_ids":  emptyOvsMap(),
+					"other_config":  emptyOvsMap(),
+					"ports":         emptyOvsSet(),
+					"status":        emptyOvsMap(),
 				},
 			},
 			quuxUUID: &ovsdb.RowUpdate{
 				New: &ovsdb.Row{
-					"_uuid": ovsdb.UUID{GoUUID: quuxUUID},
-					"name":  "quux",
+					"_uuid":         ovsdb.UUID{GoUUID: quuxUUID},
+					"name":          "quux",
+					"datapath_id":   emptyOvsSet(),
+					"datapath_type": "",
+					"external_ids":  emptyOvsMap(),
+					"other_config":  emptyOvsMap(),
+					"ports":         emptyOvsSet(),
+					"status":        emptyOvsMap(),
 				},
 			},
 		},

--- a/server/transact.go
+++ b/server/transact.go
@@ -43,7 +43,7 @@ func (o *OvsdbServer) transact(name string, operations []ovsdb.Operation) ([]ovs
 				}
 			}
 		case ovsdb.OperationSelect:
-			r := transaction.Select(op.Table, op.Where, op.Columns)
+			r := transaction.Select(op.Table, op.Where, false, op.Columns)
 			results = append(results, r)
 		case ovsdb.OperationUpdate:
 			r, tu := transaction.Update(name, op.Table, op.Where, op.Row)
@@ -207,7 +207,7 @@ func (t *Transaction) Insert(table string, rowUUID string, row ovsdb.Row) (ovsdb
 	}
 }
 
-func (t *Transaction) Select(table string, where []ovsdb.Condition, columns []string) ovsdb.OperationResult {
+func (t *Transaction) Select(table string, where []ovsdb.Condition, alwaysIncludeUUID bool, columns []string) ovsdb.OperationResult {
 	var results []ovsdb.Row
 	dbModel := t.Model
 
@@ -222,7 +222,7 @@ func (t *Transaction) Select(table string, where []ovsdb.Condition, columns []st
 		if err != nil {
 			panic(err)
 		}
-		resultRow, err := m.NewRow(info)
+		resultRow, err := m.NewRowWithColumns(info, alwaysIncludeUUID, columns...)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Since the unit test for Monitor() requests all columns,
we now have to expect empty fields for those columns in
the response.

Previously Select() just ignored the columns that
Monitor() requested and thus elided empty columns from
the result.

@trozet @dave-tucker @jcaamano 