### PR TITLE
adding Wait to client api

### DIFF
--- a/ovsdb/condition.go
+++ b/ovsdb/condition.go
@@ -7,6 +7,7 @@ import (
 )
 
 type ConditionFunction string
+type WaitCondition string
 
 const (
 	// ConditionLessThan is the less than condition
@@ -25,6 +26,11 @@ const (
 	ConditionIncludes ConditionFunction = "includes"
 	// ConditionExcludes is the excludes condition
 	ConditionExcludes ConditionFunction = "excludes"
+
+	// WaitConditionEqual is the equal condition
+	WaitConditionEqual WaitCondition = "=="
+	// WaitConditionNotEqual is the not equal condition
+	WaitConditionNotEqual WaitCondition = "!="
 )
 
 // Condition is described in RFC 7047: 5.1


### PR DESCRIPTION
Adding client.api to support Wait

Example usage:

```
        lb := &nbdb.LoadBalancer{}
        condition := model.Condition{
            Field:    &lb.Name,
            Function: ovsdb.ConditionEqual,
            Value:    "lbName",
        }
        timeout0 := 0

        client.Where(lb, condition).Wait(
            ovsdb.WaitConditionNotEqual, // Until
            &timeout0, // Timeout
            &lb, // Row (and Table)
            &lb.Name, // Cols (aka fields)
        )
```
Fixes https://github.com/ovn-org/libovsdb/issues/284