### PR TITLE
Mapper: FieldByColumn error message shall contain table name

### DIFF
--- a/mapper/info.go
+++ b/mapper/info.go
@@ -25,7 +25,7 @@ type Metadata struct {
 func (i *Info) FieldByColumn(column string) (interface{}, error) {
 	fieldName, ok := i.Metadata.Fields[column]
 	if !ok {
-		return nil, fmt.Errorf("FieldByColumn: column %s not found in orm info", column)
+		return nil, fmt.Errorf("FieldByColumn: column %s not found in orm info for table %s", column, i.Metadata.TableName)
 	}
 	return reflect.ValueOf(i.Obj).Elem().FieldByName(fieldName).Interface(), nil
 }


### PR DESCRIPTION
When FieldByColumn cannot find a column in the orm info, make sure to
report the table name as well.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>