### PR TITLE
Fix cache error handling

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -673,7 +673,7 @@ func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) error {
 				modified := model.Clone(existing)
 				err := t.ApplyModifications(table, modified, *row.Modify)
 				if err != nil {
-					return fmt.Errorf("unable to apply row modifications: %v", err)
+					return fmt.Errorf("unable to apply row modifications: %w", err)
 				}
 				if !model.Equal(modified, existing) {
 					logger.V(5).Info("updating row", "old", fmt.Sprintf("%+v", existing), "new", fmt.Sprintf("%+v", modified))

--- a/client/client.go
+++ b/client/client.go
@@ -95,10 +95,13 @@ type ovsdbClient struct {
 	primaryDBName string
 	databases     map[string]*database
 
+	errorCh       chan error
 	stopCh        chan struct{}
 	disconnect    chan struct{}
 	shutdown      bool
 	shutdownMutex sync.Mutex
+
+	handlerShutdown *sync.WaitGroup
 
 	logger *logr.Logger
 }
@@ -146,7 +149,9 @@ func newOVSDBClient(clientDBModel model.ClientDBModel, opts ...Option) (*ovsdbCl
 				deferredUpdates: make([]*bufferedUpdate, 0),
 			},
 		},
-		disconnect: make(chan struct{}),
+		errorCh:         make(chan error),
+		handlerShutdown: &sync.WaitGroup{},
+		disconnect:      make(chan struct{}),
 	}
 	var err error
 	ovs.options, err = newOptions(opts...)
@@ -289,8 +294,15 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 
 	go o.handleDisconnectNotification()
 	for _, db := range o.databases {
-		go o.handleCacheErrors(o.stopCh, db.cache.Errors())
-		go db.cache.Run(o.stopCh)
+		o.handlerShutdown.Add(1)
+		eventStopChan := make(chan struct{})
+		go o.handleClientErrors(eventStopChan)
+		o.handlerShutdown.Add(1)
+		go func(db *database) {
+			defer o.handlerShutdown.Done()
+			db.cache.Run(o.stopCh)
+			close(eventStopChan)
+		}(db)
 	}
 
 	o.connected = true
@@ -580,6 +592,10 @@ func (o *ovsdbClient) update(params []json.RawMessage, reply *[]interface{}) err
 	err = db.cache.Update(cookie.ID, updates)
 	db.cacheMutex.RUnlock()
 
+	if err != nil {
+		o.errorCh <- err
+	}
+
 	return err
 }
 
@@ -616,6 +632,10 @@ func (o *ovsdbClient) update2(params []json.RawMessage, reply *[]interface{}) er
 	db.cacheMutex.RLock()
 	err = db.cache.Update2(cookie, updates)
 	db.cacheMutex.RUnlock()
+
+	if err != nil {
+		o.errorCh <- err
+	}
 
 	return err
 }
@@ -1046,12 +1066,13 @@ func (o *ovsdbClient) watchForLeaderChange() error {
 	return nil
 }
 
-func (o *ovsdbClient) handleCacheErrors(stopCh <-chan struct{}, errorChan <-chan error) {
+func (o *ovsdbClient) handleClientErrors(stopCh <-chan struct{}) {
+	defer o.handlerShutdown.Done()
 	for {
 		select {
 		case <-stopCh:
 			return
-		case err := <-errorChan:
+		case err := <-o.errorCh:
 			if errors.Is(err, &cache.ErrCacheInconsistent{}) || errors.Is(err, &cache.ErrIndexExists{}) {
 				// trigger a reconnect, which will purge the cache
 				// hopefully a rebuild will fix any inconsistency
@@ -1078,6 +1099,8 @@ func (o *ovsdbClient) handleDisconnectNotification() {
 	// close the stopCh, which will stop the cache event processor
 	close(o.stopCh)
 	o.metrics.numDisconnects.Inc()
+	// wait for client related handlers to shutdown
+	o.handlerShutdown.Wait()
 	o.rpcMutex.Lock()
 	if o.options.reconnect && !o.shutdown {
 		o.rpcClient = nil

--- a/mapper/info.go
+++ b/mapper/info.go
@@ -7,6 +7,24 @@ import (
 	"github.com/ovn-org/libovsdb/ovsdb"
 )
 
+// ErrColumnNotFound is an error that can occur when the column does not exist for a table
+type ErrColumnNotFound struct {
+	column string
+	table  string
+}
+
+// Error implements the error interface
+func (e *ErrColumnNotFound) Error() string {
+	return fmt.Sprintf("column: %s not found in table: %s", e.column, e.table)
+}
+
+func NewErrColumnNotFound(column, table string) *ErrColumnNotFound {
+	return &ErrColumnNotFound{
+		column: column,
+		table:  table,
+	}
+}
+
 // Info is a struct that wraps an object with its metadata
 type Info struct {
 	// FieldName indexed by column
@@ -25,7 +43,7 @@ type Metadata struct {
 func (i *Info) FieldByColumn(column string) (interface{}, error) {
 	fieldName, ok := i.Metadata.Fields[column]
 	if !ok {
-		return nil, fmt.Errorf("FieldByColumn: column %s not found in orm info for table %s", column, i.Metadata.TableName)
+		return nil, NewErrColumnNotFound(column, i.Metadata.TableName)
 	}
 	return reflect.ValueOf(i.Obj).Elem().FieldByName(fieldName).Interface(), nil
 }


### PR DESCRIPTION
In OVNK downstream we see a problem where a cache update is stalled
because it is unable to send the error to the table error channel. This
causes deadlock as well because none of the other goroutines (including
the disconnectHandler) can proceed while the cache is locked. I'm not
totally sure why the channel is blocked, according to a core dump it
looks like the send channel and the receive channel in
handleCacheErrors may be different.

However, there is an obvious race with client handlers (like
handleCacheErrors) running in goroutines and
handleDisconnectNotification. On Disconnect the stop channel is closed,
which will shutdown the handleCacheErrors goroutine. However, the cache
update may still be executing. It is not immediately shutdown while
still processing a monitor udpate. Therefore it may be unable to send an
error to the unbuffered errorChan and we could be deadlocked.

Additionally, the primary purpose of running handleCacheErrors is to
disconnect/reconnect the client in case some critical error happens. It
makes sense to move this error handling to the client rather than the
table cache. This help us remove the dependency on the cache lock. Also,
this commit adds protection to wait on disconnect for all the handlers
to shutdown before trying to reconnect.
