### PR TITLE
Change default logleve for reconnect and transact operation

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -322,7 +322,7 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 // tryEndpoint connects to a single database endpoint. Returns the
 // server ID (if clustered) on success, or an error.
 func (o *ovsdbClient) tryEndpoint(ctx context.Context, u *url.URL) (string, error) {
-	o.logger.V(5).Info("trying to connect", "endpoint", fmt.Sprintf("%v", u))
+	o.logger.V(3).Info("trying to connect", "endpoint", fmt.Sprintf("%v", u))
 	var dialer net.Dialer
 	var err error
 	var c net.Conn
@@ -778,7 +778,7 @@ func (o *ovsdbClient) transact(ctx context.Context, dbName string, operation ...
 	if o.rpcClient == nil {
 		return nil, ErrNotConnected
 	}
-	o.logger.V(5).Info("transacting operations", "database", dbName, "operations", fmt.Sprintf("%+v", operation))
+	o.logger.V(4).Info("transacting operations", "database", dbName, "operations", fmt.Sprintf("%+v", operation))
 	err := o.rpcClient.CallWithContext(ctx, "transact", args, &reply)
 	if err != nil {
 		if err == rpc2.ErrShutdown {


### PR DESCRIPTION
V(5) heavily used for ovsdb cache sync, it may flood log.
In custom logger we usually set log threshold less than 5.

refer to https://github.com/kubernetes/community/blob/51c8f51900f2cbec7060d364bff44cc5a4006f78/contributors/devel/sig-instrumentation/logging.md

  * klog.V(0) - Generally useful for this to ALWAYS be visible to an operator
    * Programmer errors
    * Logging extra info about a panic
    * CLI argument handling
  * klog.V(1) - A reasonable default log level if you don't want verbosity.
    * Information about config (listening on X, watching Y)
    * Errors that repeat frequently that relate to conditions that can be corrected (pod detected as unhealthy)
  * klog.V(2) - Useful steady state information about the service and important log messages that may correlate to significant changes in the system.  This is the recommended default log level for most systems.
    * Logging HTTP requests and their exit code
    * System state changing (killing pod)
    * Controller state change events (starting pods)
    * Scheduler log messages
  * klog.V(3) - Extended information about changes
    * More info about system state changes
  * klog.V(4) - Debug level verbosity
    * Logging in particularly thorny parts of code where you may want to come back later and check it
  * klog.V(5) - Trace level verbosity
    * Context to understand the steps leading up to errors and warnings
    * More information for troubleshooting reported issues