### PR TITLE
monitor: keep model in TableMonitor when using Fields

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -865,13 +865,20 @@ func (o *ovsdbClient) monitor(ctx context.Context, cookie MonitorCookie, reconne
 	typeMap := db.model.Types()
 	requests := make(map[string]ovsdb.MonitorRequest)
 	for _, o := range monitor.Tables {
+		var err error
 		_, ok := typeMap[o.Table]
 		if !ok {
 			return fmt.Errorf("type for table %s does not exist in model", o.Table)
 		}
-		model, err := db.model.NewModel(o.Table)
-		if err != nil {
-			return err
+		model := o.Model
+		if model == nil {
+			if len(o.Fields) > 0 {
+				return fmt.Errorf("fields for monitoring table %s provided without a model", o.Table)
+			}
+			model, err = db.model.NewModel(o.Table)
+			if err != nil {
+				return err
+			}
 		}
 		info, err := db.model.NewModelInfo(model)
 		if err != nil {

--- a/client/monitor.go
+++ b/client/monitor.go
@@ -63,6 +63,9 @@ type TableMonitor struct {
 	Table string
 	// Condition is the condition under which the table should be monitored
 	Condition model.Condition
+	// ORM model of the table being monitored. This is required when specififc
+	// Fields (below) are used.
+	Model model.Model
 	// Fields are the fields in the model to monitor
 	// If none are supplied, all fields will be used
 	Fields []interface{}
@@ -76,6 +79,7 @@ func WithTable(m model.Model, fields ...interface{}) MonitorOption {
 		}
 		tableMonitor := TableMonitor{
 			Table:  tableName,
+			Model:  m,
 			Fields: fields,
 		}
 		monitor.Tables = append(monitor.Tables, tableMonitor)
@@ -92,6 +96,7 @@ func WithConditionalTable(m model.Model, condition model.Condition, fields ...in
 		tableMonitor := TableMonitor{
 			Table:     tableName,
 			Condition: condition,
+			Model:     m,
 			Fields:    fields,
 		}
 		monitor.Tables = append(monitor.Tables, tableMonitor)

--- a/client/monitor_test.go
+++ b/client/monitor_test.go
@@ -17,3 +17,18 @@ func TestWithTable(t *testing.T) {
 
 	assert.Equal(t, 1, len(m.Tables))
 }
+
+func TestWithTableAndFields(t *testing.T) {
+	client, err := newOVSDBClient(defDB)
+	assert.NoError(t, err)
+	m := newMonitor()
+	ovs := OpenvSwitch{}
+	opt := WithTable(&ovs, &ovs.Bridges, &ovs.CurCfg)
+
+	err = opt(client, m)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(m.Tables))
+	assert.Equal(t, &ovs, m.Tables[0].Model)
+	assert.Equal(t, 2, len(m.Tables[0].Fields))
+}


### PR DESCRIPTION
When monitoring certain fields of a table, the model is needed since their values are obtained as an offset.

Fixes #303

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>