### PR TITLE
monitor: Use strings instead of interfaces for Fields

### DIFF
--- a/client/monitor_test.go
+++ b/client/monitor_test.go
@@ -1,8 +1,11 @@
 package client
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/ovn-org/libovsdb/model"
+	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,4 +19,34 @@ func TestWithTable(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, len(m.Tables))
+}
+
+func populateClientModel(t *testing.T, client *ovsdbClient) {
+	var s ovsdb.DatabaseSchema
+	err := json.Unmarshal([]byte(schema), &s)
+	assert.NoError(t, err)
+	clientDBModel, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
+		"Bridge":       &Bridge{},
+		"Open_vSwitch": &OpenvSwitch{},
+	})
+	assert.NoError(t, err)
+	dbModel, errs := model.NewDatabaseModel(s, clientDBModel)
+	assert.Empty(t, errs)
+	client.primaryDB().model = dbModel
+	assert.NoError(t, err)
+}
+
+func TestWithTableAndFields(t *testing.T) {
+	client, err := newOVSDBClient(defDB)
+	assert.NoError(t, err)
+	populateClientModel(t, client)
+
+	m := newMonitor()
+	ovs := OpenvSwitch{}
+	opt := WithTable(&ovs, &ovs.Bridges, &ovs.CurCfg)
+	err = opt(client, m)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(m.Tables))
+	assert.ElementsMatch(t, []string{"bridges", "cur_cfg"}, m.Tables[0].Fields)
 }

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -319,16 +319,10 @@ func (m Mapper) equalIndexes(one, other *Info, indexes ...string) (bool, error) 
 // NewMonitorRequest returns a monitor request for the provided tableName
 // If fields is provided, the request will be constrained to the provided columns
 // If no fields are provided, all columns will be used
-func (m *Mapper) NewMonitorRequest(data *Info, fields []interface{}) (*ovsdb.MonitorRequest, error) {
+func (m *Mapper) NewMonitorRequest(data *Info, fields []string) (*ovsdb.MonitorRequest, error) {
 	var columns []string
 	if len(fields) > 0 {
-		for _, f := range fields {
-			column, err := data.ColumnByPtr(f)
-			if err != nil {
-				return nil, err
-			}
-			columns = append(columns, column)
-		}
+		columns = append(columns, fields...)
 	} else {
 		for c := range data.Metadata.TableSchema.Columns {
 			columns = append(columns, c)

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -1124,7 +1124,7 @@ func TestNewMonitorRequest(t *testing.T) {
 	mr, err := mapper.NewMonitorRequest(info, nil)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, mr.Columns, []string{"name", "config", "composed_1", "composed_2", "int1", "int2"})
-	mr2, err := mapper.NewMonitorRequest(info, []interface{}{&testTable.Int1, &testTable.MyName})
+	mr2, err := mapper.NewMonitorRequest(info, []string{"int1", "name"})
 	require.NoError(t, err)
 	assert.ElementsMatch(t, mr2.Columns, []string{"int1", "name"})
 }


### PR DESCRIPTION
When monitoring certain fields of a table, the model is
needed since their values are obtained as an offset.
Since the model is not kept in TableMonitor, this change
will convert the fields to strings sooner.

Fixes #303

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>