### PR TITLE
Add support for client indexes

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -25,6 +25,7 @@ const (
 	deleteEvent     = "delete"
 	bufferSize      = 65536
 	columnDelimiter = ","
+	keyDelimiter    = "|"
 )
 
 // ErrCacheInconsistent is an error that can occur when an operation
@@ -68,32 +69,77 @@ func NewIndexExistsError(table string, value interface{}, index string, new, exi
 }
 
 // map of unique values to uuids
-type valueToUUID map[interface{}]string
+type valueToUUIDs map[interface{}]uuidset
 
-// map of column name(s) to a unique values, to UUIDs
-type columnToValue map[index]valueToUUID
+// map of column name(s) to unique values, to UUIDs
+type columnToValue map[index]valueToUUIDs
 
 // index is the type used to implement multiple cache indexes
 type index string
 
-// columns returns the columns that conform the index
-func (i index) columns() []string {
-	return strings.Split(string(i), columnDelimiter)
+// indexType is the type of index
+type indexType uint
+
+const (
+	schemaIndexType indexType = iota
+	clientIndexType
+)
+
+// indexSpec contains details about an index
+type indexSpec struct {
+	index     index
+	columns   []model.ColumnKey
+	indexType indexType
+}
+
+func (s indexSpec) isClientIndex() bool {
+	return s.indexType == clientIndexType
+}
+
+func (s indexSpec) isSchemaIndex() bool {
+	return s.indexType == schemaIndexType
 }
 
 // newIndex builds a index from a list of columns
-func newIndex(columns ...string) index {
+func newIndexFromColumns(columns ...string) index {
 	return index(strings.Join(columns, columnDelimiter))
+}
+
+// newIndexFromColumnKeys builds a index from a list of column keys
+func newIndexFromColumnKeys(columns ...model.ColumnKey) index {
+	// RFC 7047 says that Indexes is a [<column-set>] and "Each <column-set> is a set of
+	// columns whose values, taken together within any given row, must be
+	// unique within the table". We'll store the column names, separated by comma
+	// as we'll assume (RFC is not clear), that comma isn't valid in a <id>
+	columnIndexes := make([]string, len(columns))
+	for i, column := range columns {
+		if column.Key != nil {
+			columnIndexes[i] = fmt.Sprintf("%s%s%v", column.Column, keyDelimiter, column.Key)
+		} else {
+			columnIndexes[i] = column.Column
+		}
+	}
+	return newIndexFromColumns(columnIndexes...)
+}
+
+// newColumnKeysFromColumns builds a list of column keys from a list of columns
+func newColumnKeysFromColumns(columns ...string) []model.ColumnKey {
+	columnKeys := make([]model.ColumnKey, len(columns))
+	for i, column := range columns {
+		columnKeys[i] = model.ColumnKey{Column: column}
+	}
+	return columnKeys
 }
 
 // RowCache is a collections of Models hashed by UUID
 type RowCache struct {
-	name     string
-	dbModel  model.DatabaseModel
-	dataType reflect.Type
-	cache    map[string]model.Model
-	indexes  columnToValue
-	mutex    sync.RWMutex
+	name       string
+	dbModel    model.DatabaseModel
+	dataType   reflect.Type
+	cache      map[string]model.Model
+	indexSpecs []indexSpec
+	indexes    columnToValue
+	mutex      sync.RWMutex
 }
 
 // rowByUUID returns one model from the cache by UUID. Caller must hold the row
@@ -112,33 +158,70 @@ func (r *RowCache) Row(uuid string) model.Model {
 	return r.rowByUUID(uuid)
 }
 
-// RowByModel searches the cache using indexes for a provided model. Returns the
-// found Model along with its UUID.
-func (r *RowCache) RowByModel(m model.Model) (string, model.Model) {
+func (r *RowCache) rowsByModel(m model.Model, useClientIndexes bool) map[string]model.Model {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 	if reflect.TypeOf(m) != r.dataType {
-		return "", nil
+		return nil
 	}
 	info, _ := r.dbModel.NewModelInfo(m)
 	field, err := info.FieldByColumn("_uuid")
 	if err != nil {
-		return "", nil
+		return nil
 	}
 	uuid := field.(string)
 	if uuid != "" {
-		return uuid, r.rowByUUID(uuid)
+		row := r.rowByUUID(uuid)
+		if row != nil {
+			return map[string]model.Model{uuid: row}
+		}
 	}
-	for index, vals := range r.indexes {
-		val, err := valueFromIndex(info, index)
+	// indexSpecs are ordered, schema indexes go first, then client indexes
+	for _, indexSpec := range r.indexSpecs {
+		if indexSpec.isClientIndex() && !useClientIndexes {
+			// Given the ordered indexSpecs, we can break here if we reach the
+			// first client index
+			break
+		}
+		val, err := valueFromIndex(info, indexSpec.columns)
 		if err != nil {
 			continue
 		}
-		if uuid, ok := vals[val]; ok {
-			return uuid, r.rowByUUID(uuid)
+		vals := r.indexes[indexSpec.index]
+		uuids, ok := vals[val]
+		if !ok || uuids.empty() {
+			continue
 		}
+		results := make(map[string]model.Model, len(uuids))
+		for uuid := range uuids {
+			results[uuid] = r.rowByUUID(uuid)
+		}
+		return results
+	}
+	return nil
+}
+
+// RowByModel searches the cache by UUID and schema indexes. UUID search is
+// performed first. Schema indexes are evaluated in turn by the same order with
+// which they are defined in the schema. First found Model is returned along
+// with its UUID. An empty string and nil is returned if no Model is found.
+func (r *RowCache) RowByModel(m model.Model) (string, model.Model) {
+	models := r.rowsByModel(m, false)
+	for uuid, model := range models {
+		return uuid, model
 	}
 	return "", nil
+}
+
+// RowsByModel searches the cache by UUID, schema indexes and client indexes.
+// UUID search is performed first. Schema indexes are evaluated next in turn by
+// the same order with which they are defined in the schema. Finnally, client
+// indexes are evaluated in turn by the same order with which they are defined
+// in the client DB model. First found Models are returned, which might be more
+// than 1 if they were found through a client index since in that case
+// uniqueness is not enforced. Nil is returned if no Model is found.
+func (r *RowCache) RowsByModel(m model.Model) map[string]model.Model {
+	return r.rowsByModel(m, true)
 }
 
 // Create writes the provided content to the cache
@@ -155,25 +238,31 @@ func (r *RowCache) Create(uuid string, m model.Model, checkIndexes bool) error {
 	if err != nil {
 		return err
 	}
-	newIndexes := newColumnToValue(r.dbModel.Schema.Table(r.name).Indexes)
-	for index, vals := range r.indexes {
-		val, err := valueFromIndex(info, index)
+	newIndexes := r.newIndexes()
+	for _, indexSpec := range r.indexSpecs {
+		index := indexSpec.index
+		val, err := valueFromIndex(info, indexSpec.columns)
 		if err != nil {
 			return err
 		}
 
-		if existing, ok := vals[val]; ok && checkIndexes {
-			return NewIndexExistsError(r.name, val, string(index), uuid, existing)
+		vals := r.indexes[index]
+		if existing, ok := vals[val]; ok && !existing.empty() && checkIndexes && indexSpec.isSchemaIndex() {
+			return NewIndexExistsError(r.name, val, string(index), uuid, existing.getAny())
 		}
 
-		newIndexes[index][val] = uuid
+		uuidset := newUUIDSet(uuid)
+		if indexSpec.isSchemaIndex() {
+			newIndexes[index][val] = uuidset
+		} else {
+			newIndexes[index][val] = addUUIDSet(r.indexes[index][val], uuidset)
+		}
 	}
 
 	// write indexes
 	for k1, v1 := range newIndexes {
-		vals := r.indexes[k1]
 		for k2, v2 := range v1 {
-			vals[k2] = v2
+			r.indexes[k1][k2] = v2
 		}
 	}
 	r.cache[uuid] = model.Clone(m)
@@ -196,17 +285,16 @@ func (r *RowCache) Update(uuid string, m model.Model, checkIndexes bool) error {
 	if err != nil {
 		return err
 	}
-	indexes := r.dbModel.Schema.Table(r.name).Indexes
-	newIndexes := newColumnToValue(indexes)
-	oldIndexes := newColumnToValue(indexes)
+	newIndexes := r.newIndexes()
 	var errs []error
-	for index, vals := range r.indexes {
+	for _, indexSpec := range r.indexSpecs {
+		index := indexSpec.index
 		var err error
-		oldVal, err := valueFromIndex(oldInfo, index)
+		oldVal, err := valueFromIndex(oldInfo, indexSpec.columns)
 		if err != nil {
 			return err
 		}
-		newVal, err := valueFromIndex(newInfo, index)
+		newVal, err := valueFromIndex(newInfo, indexSpec.columns)
 		if err != nil {
 			return err
 		}
@@ -218,34 +306,37 @@ func (r *RowCache) Update(uuid string, m model.Model, checkIndexes bool) error {
 		// old and new values are NOT the same
 
 		// check that there are no conflicts
-		if conflict, ok := vals[newVal]; ok && checkIndexes && conflict != uuid {
+		vals := r.indexes[index]
+		if existing, ok := vals[newVal]; ok && indexSpec.isSchemaIndex() && checkIndexes && !existing.empty() && !existing.has(uuid) {
 			errs = append(errs, NewIndexExistsError(
 				r.name,
 				newVal,
 				string(index),
 				uuid,
-				conflict,
+				existing.getAny(),
 			))
 		}
 
-		newIndexes[index][newVal] = uuid
-		oldIndexes[index][oldVal] = ""
+		uuidset := newUUIDSet(uuid)
+		if indexSpec.isSchemaIndex() {
+			newIndexes[index][newVal] = uuidset
+			newIndexes[index][oldVal] = nil
+		} else {
+			newIndexes[index][newVal] = addUUIDSet(r.indexes[index][newVal], uuidset)
+			newIndexes[index][oldVal] = substractUUIDSet(r.indexes[index][oldVal], uuidset)
+		}
 	}
 	if len(errs) > 0 {
 		return fmt.Errorf("%+v", errs)
 	}
 	// write indexes
 	for k1, v1 := range newIndexes {
-		vals := r.indexes[k1]
 		for k2, v2 := range v1 {
-			vals[k2] = v2
-		}
-	}
-	// delete old indexes
-	for k1, v1 := range oldIndexes {
-		vals := r.indexes[k1]
-		for k2 := range v1 {
-			delete(vals, k2)
+			if len(v2) == 0 {
+				delete(r.indexes[k1], k2)
+			} else {
+				r.indexes[k1][k2] = v2
+			}
 		}
 	}
 	r.cache[uuid] = model.Clone(m)
@@ -257,22 +348,30 @@ func (r *RowCache) IndexExists(row model.Model) error {
 	if err != nil {
 		return err
 	}
-	uuid, err := info.FieldByColumn("_uuid")
+	field, err := info.FieldByColumn("_uuid")
 	if err != nil {
 		return nil
 	}
-	for index, vals := range r.indexes {
-		val, err := valueFromIndex(info, index)
+	uuid := field.(string)
+	for _, indexSpec := range r.indexSpecs {
+		if !indexSpec.isSchemaIndex() {
+			// Given the ordered indexSpecs, we can break here if we reach the
+			// first non schema index
+			break
+		}
+		index := indexSpec.index
+		val, err := valueFromIndex(info, indexSpec.columns)
 		if err != nil {
 			continue
 		}
-		if existing, ok := vals[val]; ok && existing != uuid.(string) {
+		vals := r.indexes[index]
+		if existing := vals[val]; !existing.empty() && !existing.has(uuid) {
 			return NewIndexExistsError(
 				r.name,
 				val,
 				string(index),
-				uuid.(string),
-				existing,
+				uuid,
+				existing.getAny(),
 			)
 		}
 	}
@@ -291,16 +390,22 @@ func (r *RowCache) Delete(uuid string) error {
 	if err != nil {
 		return err
 	}
-	for index, vals := range r.indexes {
-		oldVal, err := valueFromIndex(oldInfo, index)
+	for _, indexSpec := range r.indexSpecs {
+		index := indexSpec.index
+		oldVal, err := valueFromIndex(oldInfo, indexSpec.columns)
 		if err != nil {
 			return err
 		}
 		// only remove the index if it is pointing to this uuid
 		// otherwise we can cause a consistency issue if we've processed
 		// updates out of order
-		if vals[oldVal] == uuid {
-			delete(vals, oldVal)
+		vals := r.indexes[index]
+		existing, ok := vals[oldVal]
+		if ok {
+			existing.remove(uuid)
+			if len(existing) == 0 {
+				delete(vals, oldVal)
+			}
 		}
 	}
 	delete(r.cache, uuid)
@@ -359,8 +464,8 @@ func (r *RowCache) RowsByCondition(conditions []ovsdb.Condition) (map[string]mod
 					results[rowUUID] = row
 				}
 			}
-		} else if index, err := r.Index(condition.Column); err == nil {
-			for k, rowUUID := range index {
+		} else if index, err := r.indexForColumns(condition.Column); err == nil {
+			for k, uuids := range index {
 				tSchema := schema.Columns[condition.Column]
 				nativeValue, err := ovsdb.OvsToNative(tSchema, condition.Value)
 				if err != nil {
@@ -371,8 +476,10 @@ func (r *RowCache) RowsByCondition(conditions []ovsdb.Condition) (map[string]mod
 					return nil, err
 				}
 				if ok {
-					row := r.Row(rowUUID)
-					results[rowUUID] = row
+					for uuid := range uuids {
+						row := r.Row(uuid)
+						results[uuid] = row
+					}
 				}
 			}
 		} else {
@@ -410,12 +517,27 @@ func (r *RowCache) Len() int {
 	return len(r.cache)
 }
 
-func (r *RowCache) Index(columns ...string) (map[interface{}]string, error) {
+func (r *RowCache) Index(columns ...string) (map[interface{}][]string, error) {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
-	index, ok := r.indexes[newIndex(columns...)]
+	spec := newIndexFromColumns(columns...)
+	index, ok := r.indexes[spec]
 	if !ok {
-		return nil, fmt.Errorf("%s is not an index", index)
+		return nil, fmt.Errorf("%v is not an index", columns)
+	}
+	dbIndex := make(map[interface{}][]string, len(index))
+	for k, v := range index {
+		dbIndex[k] = v.list()
+	}
+	return dbIndex, nil
+}
+
+func (r *RowCache) indexForColumns(columns ...string) (valueToUUIDs, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	index, ok := r.indexes[newIndexFromColumns(columns...)]
+	if !ok {
+		return nil, fmt.Errorf("%v is not an index", columns)
 	}
 	return index, nil
 }
@@ -742,29 +864,49 @@ func (t *TableCache) Run(stopCh <-chan struct{}) {
 // newRowCache creates a new row cache with the provided data
 // if the data is nil, and empty RowCache will be created
 func newRowCache(name string, dbModel model.DatabaseModel, dataType reflect.Type) *RowCache {
+	schemaIndexes := dbModel.Schema.Table(name).Indexes
+	clientIndexes := dbModel.Client().Indexes(name)
+
 	r := &RowCache{
-		name:     name,
-		dbModel:  dbModel,
-		indexes:  newColumnToValue(dbModel.Schema.Table(name).Indexes),
-		dataType: dataType,
-		cache:    make(map[string]model.Model),
-		mutex:    sync.RWMutex{},
+		name:       name,
+		dbModel:    dbModel,
+		indexSpecs: make([]indexSpec, 0, len(schemaIndexes)+len(clientIndexes)),
+		dataType:   dataType,
+		cache:      make(map[string]model.Model),
+		mutex:      sync.RWMutex{},
 	}
+
+	// respect the order of indexes, add first schema indexes, then client
+	// indexes
+	indexes := map[index]indexSpec{}
+	for _, columns := range schemaIndexes {
+		columnKeys := newColumnKeysFromColumns(columns...)
+		index := newIndexFromColumnKeys(columnKeys...)
+		spec := indexSpec{index: index, columns: columnKeys, indexType: schemaIndexType}
+		r.indexSpecs = append(r.indexSpecs, spec)
+		indexes[index] = spec
+	}
+	for _, clientIndex := range clientIndexes {
+		columnKeys := clientIndex.Columns
+		index := newIndexFromColumnKeys(columnKeys...)
+		// if this is already a DB index, ignore
+		if _, ok := indexes[index]; ok {
+			continue
+		}
+		spec := indexSpec{index: index, columns: columnKeys, indexType: clientIndexType}
+		r.indexSpecs = append(r.indexSpecs, spec)
+		indexes[index] = spec
+	}
+
+	r.indexes = r.newIndexes()
 	return r
 }
 
-func newColumnToValue(schemaIndexes [][]string) columnToValue {
-	// RFC 7047 says that Indexes is a [<column-set>] and "Each <column-set> is a set of
-	// columns whose values, taken together within any given row, must be
-	// unique within the table". We'll store the column names, separated by comma
-	// as we'll assume (RFC is not clear), that comma isn't valid in a <id>
-	var indexes []index
-	for i := range schemaIndexes {
-		indexes = append(indexes, newIndex(schemaIndexes[i]...))
-	}
+func (r *RowCache) newIndexes() columnToValue {
 	c := make(columnToValue)
-	for _, index := range indexes {
-		c[index] = make(valueToUUID)
+	for _, indexSpec := range r.indexSpecs {
+		index := indexSpec.index
+		c[index] = make(valueToUUIDs)
 	}
 	return c
 }
@@ -1034,13 +1176,12 @@ func (t *TableCache) ApplyModifications(tableName string, base model.Model, upda
 	return nil
 }
 
-func valueFromIndex(info *mapper.Info, index index) (interface{}, error) {
-	columns := index.columns()
-	if len(columns) > 1 {
+func valueFromIndex(info *mapper.Info, columnKeys []model.ColumnKey) (interface{}, error) {
+	if len(columnKeys) > 1 {
 		var buf bytes.Buffer
 		enc := gob.NewEncoder(&buf)
-		for _, column := range columns {
-			val, err := info.FieldByColumn(column)
+		for _, columnKey := range columnKeys {
+			val, err := valueFromColumnKey(info, columnKey)
 			if err != nil {
 				return "", err
 			}
@@ -1053,9 +1194,37 @@ func valueFromIndex(info *mapper.Info, index index) (interface{}, error) {
 		val := hex.EncodeToString(h.Sum(buf.Bytes()))
 		return val, nil
 	}
-	val, err := info.FieldByColumn(columns[0])
+	val, err := valueFromColumnKey(info, columnKeys[0])
+	if err != nil {
+		return "", err
+	}
+	return val, err
+}
+
+func valueFromColumnKey(info *mapper.Info, columnKey model.ColumnKey) (interface{}, error) {
+	val, err := info.FieldByColumn(columnKey.Column)
 	if err != nil {
 		return nil, err
 	}
+	if columnKey.Key != nil {
+		val, err = valueFromMap(val, columnKey.Key)
+		if err != nil {
+			return "", fmt.Errorf("can't get key value from map: %v", err)
+		}
+	}
 	return val, err
+}
+
+func valueFromMap(aMap interface{}, key interface{}) (interface{}, error) {
+	m := reflect.ValueOf(aMap)
+	if m.Kind() != reflect.Map {
+		return nil, fmt.Errorf("expected map but got %s", m.Kind())
+	}
+	v := m.MapIndex(reflect.ValueOf(key))
+	if !v.IsValid() {
+		// return the zero value for the map value type
+		return reflect.Indirect(reflect.New(m.Type().Elem())).Interface(), nil
+	}
+
+	return v.Interface(), nil
 }

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -164,7 +164,96 @@ func TestRowCacheCreate(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.Nil(t, err)
-				assert.Equal(t, tt.uuid, rc.indexes["foo"][tt.model.Foo])
+				assert.Len(t, rc.indexes["foo"][tt.model.Foo], 1)
+				assert.Equal(t, tt.uuid, rc.indexes["foo"][tt.model.Foo].getAny())
+			}
+		})
+	}
+}
+
+func TestRowCacheCreateClientIndex(t *testing.T) {
+	var schema ovsdb.DatabaseSchema
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	db.SetIndexes(map[string][]model.ClientIndex{
+		"Open_vSwitch": {
+			{
+				Columns: []model.ColumnKey{
+					{
+						Column: "foo",
+					},
+				},
+			},
+		},
+	})
+	require.Nil(t, err)
+	err = json.Unmarshal([]byte(`{
+		"name": "Open_vSwitch",
+		"tables": {
+		  "Open_vSwitch": {
+		    "columns": {
+		      "foo": {
+			    "type": "string"
+			  },
+			  "bar": {
+			    "type": "string"
+			  }
+		    }
+		  }
+		}
+	}`), &schema)
+	require.Nil(t, err)
+	testData := Data{
+		"Open_vSwitch": map[string]model.Model{"bar": &testModel{Foo: "bar"}},
+	}
+
+	dbModel, errs := model.NewDatabaseModel(schema, db)
+	require.Empty(t, errs)
+
+	tests := []struct {
+		name     string
+		uuid     string
+		model    *testModel
+		wantErr  bool
+		expected valueToUUIDs
+	}{
+		{
+			name:    "inserts a new row",
+			uuid:    "foo",
+			model:   &testModel{Foo: "foo"},
+			wantErr: false,
+			expected: valueToUUIDs{
+				"foo": newUUIDSet("foo"),
+				"bar": newUUIDSet("bar"),
+			},
+		},
+		{
+			name:    "error duplicate uuid",
+			uuid:    "bar",
+			model:   &testModel{Foo: "foo"},
+			wantErr: true,
+		},
+		{
+			name:    "inserts duplicate index",
+			uuid:    "baz",
+			model:   &testModel{Foo: "bar"},
+			wantErr: false,
+			expected: valueToUUIDs{
+				"bar": newUUIDSet("bar", "baz"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc, err := NewTableCache(dbModel, testData, nil)
+			require.Nil(t, err)
+			rc := tc.Table("Open_vSwitch")
+			require.NotNil(t, rc)
+			err = rc.Create(tt.uuid, tt.model, true)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.Nil(t, err)
+				require.Equal(t, tt.expected, rc.indexes["foo"])
 			}
 		})
 	}
@@ -256,9 +345,184 @@ func TestRowCacheCreateMultiIndex(t *testing.T) {
 				assert.Nil(t, err)
 				mapperInfo, err := dbModel.NewModelInfo(tt.model)
 				require.Nil(t, err)
-				h, err := valueFromIndex(mapperInfo, newIndex("foo", "bar"))
+				h, err := valueFromIndex(mapperInfo, newColumnKeysFromColumns("foo", "bar"))
 				require.Nil(t, err)
-				assert.Equal(t, tt.uuid, rc.indexes["foo,bar"][h])
+				assert.Len(t, rc.indexes["foo,bar"][h], 1)
+				assert.Equal(t, tt.uuid, rc.indexes["foo,bar"][h].getAny())
+			}
+		})
+	}
+}
+
+func TestRowCacheCreateMultiClientIndex(t *testing.T) {
+	type testModel struct {
+		UUID string            `ovsdb:"_uuid"`
+		Foo  string            `ovsdb:"foo"`
+		Bar  map[string]string `ovsdb:"bar"`
+	}
+	var schema ovsdb.DatabaseSchema
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	require.Nil(t, err)
+
+	db.SetIndexes(map[string][]model.ClientIndex{
+		"Open_vSwitch": {
+			{
+				Columns: []model.ColumnKey{
+					{
+						Column: "foo",
+					},
+					{
+						Column: "bar",
+						Key:    "bar",
+					},
+				},
+			},
+		},
+	})
+	index := newIndexFromColumnKeys(db.Indexes("Open_vSwitch")[0].Columns...)
+
+	err = json.Unmarshal([]byte(`{
+		"name": "Open_vSwitch",
+		"tables": {
+		  "Open_vSwitch": {
+		    "columns": {
+		      "foo": {
+			    "type": "string"
+			  },
+			  "bar": {
+				"type": {
+					"key": "string",
+					"value": "string",
+					"min": 0, 
+					"max": "unlimited"
+				}
+			  }
+		    }
+		  }
+		}
+	}`), &schema)
+	require.Nil(t, err)
+
+	testData := Data{
+		"Open_vSwitch": map[string]model.Model{"bar": &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}}},
+	}
+	dbModel, errs := model.NewDatabaseModel(schema, db)
+	require.Empty(t, errs)
+
+	type expected struct {
+		index model.Model
+		uuids uuidset
+	}
+
+	tests := []struct {
+		name     string
+		uuid     string
+		model    *testModel
+		wantErr  bool
+		expected []expected
+	}{
+		{
+			name:    "inserts a new row",
+			uuid:    "foo",
+			model:   &testModel{Foo: "foo", Bar: map[string]string{"bar": "foo"}},
+			wantErr: false,
+			expected: []expected{
+				{
+					index: &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+					uuids: newUUIDSet("bar"),
+				},
+				{
+					index: &testModel{Foo: "foo", Bar: map[string]string{"bar": "foo"}},
+					uuids: newUUIDSet("foo"),
+				},
+			},
+		},
+		{
+			name:    "error duplicate uuid",
+			uuid:    "bar",
+			model:   &testModel{Foo: "foo", Bar: map[string]string{"bar": "bar"}},
+			wantErr: true,
+		},
+		{
+			name:    "inserts duplicate index",
+			uuid:    "baz",
+			model:   &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+			wantErr: false,
+			expected: []expected{
+				{
+					index: &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+					uuids: newUUIDSet("bar", "baz"),
+				},
+			},
+		},
+		{
+			name:    "new row with one duplicate value",
+			uuid:    "baz",
+			model:   &testModel{Foo: "foo", Bar: map[string]string{"bar": "bar"}},
+			wantErr: false,
+			expected: []expected{
+				{
+					index: &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+					uuids: newUUIDSet("bar"),
+				},
+				{
+					index: &testModel{Foo: "foo", Bar: map[string]string{"bar": "bar"}},
+					uuids: newUUIDSet("baz"),
+				},
+			},
+		},
+		{
+			name:    "new row with other duplicate value",
+			uuid:    "baz",
+			model:   &testModel{Foo: "bar", Bar: map[string]string{"bar": "foo"}},
+			wantErr: false,
+			expected: []expected{
+				{
+					index: &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+					uuids: newUUIDSet("bar"),
+				},
+				{
+					index: &testModel{Foo: "bar", Bar: map[string]string{"bar": "foo"}},
+					uuids: newUUIDSet("baz"),
+				},
+			},
+		},
+		{
+			name:    "new row with nil map index",
+			uuid:    "baz",
+			model:   &testModel{Foo: "bar"},
+			wantErr: false,
+			expected: []expected{
+				{
+					index: &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+					uuids: newUUIDSet("bar"),
+				},
+				{
+					index: &testModel{Foo: "bar"},
+					uuids: newUUIDSet("baz"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc, err := NewTableCache(dbModel, testData, nil)
+			require.Nil(t, err)
+			rc := tc.Table("Open_vSwitch")
+			require.NotNil(t, rc)
+			err = rc.Create(tt.uuid, tt.model, true)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.Nil(t, err)
+				require.Len(t, rc.indexes[index], len(tt.expected))
+				for _, expected := range tt.expected {
+					mapperInfo, err := dbModel.NewModelInfo(expected.index)
+					require.Nil(t, err)
+					h, err := valueFromIndex(mapperInfo, db.Indexes("Open_vSwitch")[0].Columns)
+					require.Nil(t, err)
+					require.Equal(t, expected.uuids, rc.indexes[index][h], expected.index)
+				}
 			}
 		})
 	}
@@ -342,7 +606,119 @@ func TestRowCacheUpdate(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.Nil(t, err)
-				assert.Equal(t, tt.uuid, rc.indexes["foo"][tt.model.Foo])
+				assert.Len(t, rc.indexes["foo"][tt.model.Foo], 1)
+				assert.Equal(t, tt.uuid, rc.indexes["foo"][tt.model.Foo].getAny())
+			}
+		})
+	}
+}
+
+func TestRowCacheUpdateClientIndex(t *testing.T) {
+	var schema ovsdb.DatabaseSchema
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	require.Nil(t, err)
+	db.SetIndexes(map[string][]model.ClientIndex{
+		"Open_vSwitch": {
+			{
+				Columns: []model.ColumnKey{
+					{
+						Column: "foo",
+					},
+				},
+			},
+		},
+	})
+	err = json.Unmarshal([]byte(`{
+		"name": "Open_vSwitch",
+		"tables": {
+		  "Open_vSwitch": {
+		    "columns": {
+		      "foo": {
+			    "type": "string"
+			  },
+			  "bar": {
+			    "type": "string"
+			  }
+		    }
+		  }
+		}
+	}`), &schema)
+	require.Nil(t, err)
+	testData := Data{
+		"Open_vSwitch": map[string]model.Model{
+			"foo":    &testModel{Foo: "foo", Bar: "foo"},
+			"bar":    &testModel{Foo: "bar", Bar: "bar"},
+			"foobar": &testModel{Foo: "bar", Bar: "foobar"},
+		},
+	}
+	dbModel, errs := model.NewDatabaseModel(schema, db)
+	require.Empty(t, errs)
+
+	tests := []struct {
+		name     string
+		uuid     string
+		model    *testModel
+		wantErr  bool
+		expected valueToUUIDs
+	}{
+		{
+			name:    "error if row does not exist",
+			uuid:    "baz",
+			model:   &testModel{Foo: "baz"},
+			wantErr: true,
+		},
+		{
+			name:    "update non-index",
+			uuid:    "foo",
+			model:   &testModel{Foo: "foo", Bar: "bar"},
+			wantErr: false,
+			expected: valueToUUIDs{
+				"foo": newUUIDSet("foo"),
+				"bar": newUUIDSet("bar", "foobar"),
+			},
+		},
+		{
+			name:    "update unique index to new index",
+			uuid:    "foo",
+			model:   &testModel{Foo: "baz"},
+			wantErr: false,
+			expected: valueToUUIDs{
+				"baz": newUUIDSet("foo"),
+				"bar": newUUIDSet("bar", "foobar"),
+			},
+		},
+		{
+			name:    "update unique index to existing index",
+			uuid:    "foo",
+			model:   &testModel{Foo: "bar"},
+			wantErr: false,
+			expected: valueToUUIDs{
+				"bar": newUUIDSet("foo", "bar", "foobar"),
+			},
+		},
+		{
+			name:    "update multi index to different index",
+			uuid:    "foobar",
+			model:   &testModel{Foo: "foo"},
+			wantErr: false,
+			expected: valueToUUIDs{
+				"foo": newUUIDSet("foo", "foobar"),
+				"bar": newUUIDSet("bar"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc, err := NewTableCache(dbModel, testData, nil)
+			require.Nil(t, err)
+			rc := tc.Table("Open_vSwitch")
+			require.NotNil(t, rc)
+			err = rc.Update(tt.uuid, tt.model, true)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.Nil(t, err)
+				require.Equal(t, tt.expected, rc.indexes["foo"])
 			}
 		})
 	}
@@ -423,9 +799,207 @@ func TestRowCacheUpdateMultiIndex(t *testing.T) {
 				assert.Nil(t, err)
 				mapperInfo, err := dbModel.NewModelInfo(tt.model)
 				require.Nil(t, err)
-				h, err := valueFromIndex(mapperInfo, newIndex("foo", "bar"))
+				h, err := valueFromIndex(mapperInfo, newColumnKeysFromColumns("foo", "bar"))
 				require.Nil(t, err)
-				assert.Equal(t, tt.uuid, rc.indexes["foo,bar"][h])
+				assert.Len(t, rc.indexes["foo,bar"][h], 1)
+				assert.Equal(t, tt.uuid, rc.indexes["foo,bar"][h].getAny())
+			}
+		})
+	}
+}
+
+func TestRowCacheUpdateMultiClientIndex(t *testing.T) {
+	type testModel struct {
+		UUID string            `ovsdb:"_uuid"`
+		Foo  string            `ovsdb:"foo"`
+		Bar  map[string]string `ovsdb:"bar"`
+		Baz  string            `ovsdb:"baz"`
+	}
+	var schema ovsdb.DatabaseSchema
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	require.Nil(t, err)
+
+	db.SetIndexes(map[string][]model.ClientIndex{
+		"Open_vSwitch": {
+			{
+				Columns: []model.ColumnKey{
+					{
+						Column: "foo",
+					},
+					{
+						Column: "bar",
+						Key:    "bar",
+					},
+				},
+			},
+		},
+	})
+	index := newIndexFromColumnKeys(db.Indexes("Open_vSwitch")[0].Columns...)
+
+	err = json.Unmarshal([]byte(`{
+		"name": "Open_vSwitch",
+		"tables": {
+		  "Open_vSwitch": {
+		    "columns": {
+		      "foo": {
+			    "type": "string"
+			  },
+			  "bar": {
+				"type": {
+					"key": "string",
+					"value": "string",
+					"min": 0, 
+					"max": "unlimited"
+				}
+			  },
+			  "baz": {
+			    "type": "string"
+			  }
+		    }
+		  }
+		}
+	}`), &schema)
+	require.Nil(t, err)
+
+	testData := Data{
+		"Open_vSwitch": map[string]model.Model{
+			"foo":    &testModel{Foo: "foo", Bar: map[string]string{"bar": "foo"}},
+			"bar":    &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+			"foobar": &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+		},
+	}
+	dbModel, errs := model.NewDatabaseModel(schema, db)
+	require.Empty(t, errs)
+
+	type expected struct {
+		index model.Model
+		uuids uuidset
+	}
+
+	tests := []struct {
+		name     string
+		uuid     string
+		model    *testModel
+		wantErr  bool
+		expected []expected
+	}{
+		{
+			name:    "error if row does not exist",
+			uuid:    "baz",
+			model:   &testModel{Foo: "baz", Bar: map[string]string{"bar": "baz"}},
+			wantErr: true,
+		},
+		{
+			name:  "update non-index",
+			uuid:  "foo",
+			model: &testModel{Foo: "foo", Bar: map[string]string{"bar": "foo"}, Baz: "bar"},
+			expected: []expected{
+				{
+					index: &testModel{Foo: "foo", Bar: map[string]string{"bar": "foo"}},
+					uuids: newUUIDSet("foo"),
+				},
+				{
+					index: &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+					uuids: newUUIDSet("bar", "foobar"),
+				},
+			},
+		},
+		{
+			name:    "update one index column",
+			uuid:    "foo",
+			model:   &testModel{Foo: "foo", Bar: map[string]string{"bar": "baz"}},
+			wantErr: false,
+			expected: []expected{
+				{
+					index: &testModel{Foo: "foo", Bar: map[string]string{"bar": "baz"}},
+					uuids: newUUIDSet("foo"),
+				},
+				{
+					index: &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+					uuids: newUUIDSet("bar", "foobar"),
+				},
+			},
+		},
+		{
+			name:    "update other index column",
+			uuid:    "foo",
+			model:   &testModel{Foo: "baz", Bar: map[string]string{"bar": "foo"}},
+			wantErr: false,
+			expected: []expected{
+				{
+					index: &testModel{Foo: "baz", Bar: map[string]string{"bar": "foo"}},
+					uuids: newUUIDSet("foo"),
+				},
+				{
+					index: &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+					uuids: newUUIDSet("bar", "foobar"),
+				},
+			},
+		},
+		{
+			name:    "update both index columns",
+			uuid:    "foo",
+			model:   &testModel{Foo: "baz", Bar: map[string]string{"bar": "baz"}},
+			wantErr: false,
+			expected: []expected{
+				{
+					index: &testModel{Foo: "baz", Bar: map[string]string{"bar": "baz"}},
+					uuids: newUUIDSet("foo"),
+				},
+				{
+					index: &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+					uuids: newUUIDSet("bar", "foobar"),
+				},
+			},
+		},
+		{
+			name:    "update unique index to existing index",
+			uuid:    "foo",
+			model:   &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+			wantErr: false,
+			expected: []expected{
+				{
+					index: &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+					uuids: newUUIDSet("foo", "bar", "foobar"),
+				},
+			},
+		},
+		{
+			name:    "update multi index to different index",
+			uuid:    "foobar",
+			model:   &testModel{Foo: "foo", Bar: map[string]string{"bar": "foo"}},
+			wantErr: false,
+			expected: []expected{
+				{
+					index: &testModel{Foo: "foo", Bar: map[string]string{"bar": "foo"}},
+					uuids: newUUIDSet("foo", "foobar"),
+				},
+				{
+					index: &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+					uuids: newUUIDSet("bar"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc, err := NewTableCache(dbModel, testData, nil)
+			require.Nil(t, err)
+			rc := tc.Table("Open_vSwitch")
+			require.NotNil(t, rc)
+			err = rc.Update(tt.uuid, tt.model, true)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.Nil(t, err)
+				require.Len(t, rc.indexes[index], len(tt.expected))
+				for _, expectedUUID := range tt.expected {
+					mapperInfo, err := dbModel.NewModelInfo(expectedUUID.index)
+					require.Nil(t, err)
+					h, err := valueFromIndex(mapperInfo, db.Indexes("Open_vSwitch")[0].Columns)
+					require.Nil(t, err)
+					require.Equal(t, expectedUUID.uuids, rc.indexes[index][h], expectedUUID.index)
+				}
 			}
 		})
 	}
@@ -491,7 +1065,137 @@ func TestRowCacheDelete(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				require.Nil(t, err)
-				assert.Equal(t, "", rc.indexes["foo"][tt.model.Foo])
+				assert.Nil(t, rc.indexes["foo"][tt.model.Foo])
+			}
+		})
+	}
+}
+
+func TestRowCacheDeleteClientIndex(t *testing.T) {
+	type testModel struct {
+		UUID string            `ovsdb:"_uuid"`
+		Foo  string            `ovsdb:"foo"`
+		Bar  map[string]string `ovsdb:"bar"`
+	}
+	var schema ovsdb.DatabaseSchema
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	require.Nil(t, err)
+
+	db.SetIndexes(map[string][]model.ClientIndex{
+		"Open_vSwitch": {
+			{
+				Columns: []model.ColumnKey{
+					{
+						Column: "foo",
+					},
+					{
+						Column: "bar",
+						Key:    "bar",
+					},
+				},
+			},
+		},
+	})
+	index := newIndexFromColumnKeys(db.Indexes("Open_vSwitch")[0].Columns...)
+
+	err = json.Unmarshal([]byte(`{
+		"name": "Open_vSwitch",
+		"tables": {
+		  "Open_vSwitch": {
+		    "columns": {
+		      "foo": {
+			    "type": "string"
+			  },
+			  "bar": {
+				"type": {
+					"key": "string",
+					"value": "string",
+					"min": 0, 
+					"max": "unlimited"
+				}
+			  }
+		    }
+		  }
+		}
+	}`), &schema)
+	require.Nil(t, err)
+
+	testData := Data{
+		"Open_vSwitch": map[string]model.Model{
+			"foo":    &testModel{Foo: "foo", Bar: map[string]string{"bar": "foo"}},
+			"bar":    &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+			"foobar": &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+		},
+	}
+	dbModel, errs := model.NewDatabaseModel(schema, db)
+	require.Empty(t, errs)
+
+	type expected struct {
+		index model.Model
+		uuids uuidset
+	}
+
+	tests := []struct {
+		name     string
+		uuid     string
+		model    *testModel
+		wantErr  bool
+		expected []expected
+	}{
+		{
+			name:    "error if row does not exist",
+			uuid:    "baz",
+			model:   &testModel{Foo: "baz", Bar: map[string]string{"bar": "baz"}},
+			wantErr: true,
+		},
+		{
+			name:    "delete a row with unique index",
+			uuid:    "foo",
+			model:   &testModel{Foo: "foo", Bar: map[string]string{"bar": "foo"}},
+			wantErr: false,
+			expected: []expected{
+				{
+					index: &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+					uuids: newUUIDSet("bar", "foobar"),
+				},
+			},
+		},
+		{
+			name:    "delete a row with duplicated index",
+			uuid:    "foobar",
+			model:   &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+			wantErr: false,
+			expected: []expected{
+				{
+					index: &testModel{Foo: "foo", Bar: map[string]string{"bar": "foo"}},
+					uuids: newUUIDSet("foo"),
+				},
+				{
+					index: &testModel{Foo: "bar", Bar: map[string]string{"bar": "bar"}},
+					uuids: newUUIDSet("bar"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc, err := NewTableCache(dbModel, testData, nil)
+			require.Nil(t, err)
+			rc := tc.Table("Open_vSwitch")
+			require.NotNil(t, rc)
+			err = rc.Delete(tt.uuid)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.Nil(t, err)
+				require.Len(t, rc.indexes[index], len(tt.expected))
+				for _, expected := range tt.expected {
+					mapperInfo, err := dbModel.NewModelInfo(expected.index)
+					require.Nil(t, err)
+					h, err := valueFromIndex(mapperInfo, db.Indexes("Open_vSwitch")[0].Columns)
+					require.Nil(t, err)
+					require.Equal(t, expected.uuids, rc.indexes[index][h], expected.index)
+				}
 			}
 		})
 	}
@@ -1109,6 +1813,27 @@ func TestIndex(t *testing.T) {
 	}
 	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &indexTestModel{}})
 	assert.Nil(t, err)
+	db.SetIndexes(map[string][]model.ClientIndex{
+		"Open_vSwitch": {
+			{
+				Columns: []model.ColumnKey{
+					{
+						Column: "bar",
+					},
+				},
+			},
+			{
+				Columns: []model.ColumnKey{
+					{
+						Column: "foo",
+					},
+					{
+						Column: "baz",
+					},
+				},
+			},
+		},
+	})
 	var schema ovsdb.DatabaseSchema
 	err = json.Unmarshal([]byte(`
 		 {"name": "Open_vSwitch",
@@ -1135,34 +1860,44 @@ func TestIndex(t *testing.T) {
 	assert.Empty(t, errs)
 	tc, err := NewTableCache(dbModel, nil, nil)
 	assert.Nil(t, err)
+	table := tc.Table("Open_vSwitch")
+
 	obj := &indexTestModel{
 		UUID: "test1",
 		Foo:  "foo",
 		Bar:  "bar",
 		Baz:  42,
 	}
-	table := tc.Table("Open_vSwitch")
-
 	err = table.Create(obj.UUID, obj, true)
 	assert.Nil(t, err)
+
+	obj2 := &indexTestModel{
+		UUID: "test2",
+		Foo:  "foo2",
+		Bar:  "bar",
+		Baz:  78,
+	}
+	err = table.Create(obj2.UUID, obj2, true)
+	assert.Nil(t, err)
+
 	t.Run("Index by single column", func(t *testing.T) {
 		idx, err := table.Index("foo")
 		assert.Nil(t, err)
 		info, err := dbModel.NewModelInfo(obj)
 		assert.Nil(t, err)
-		v, err := valueFromIndex(info, newIndex("foo"))
+		v, err := valueFromIndex(info, newColumnKeysFromColumns("foo"))
 		assert.Nil(t, err)
-		assert.Equal(t, idx[v], obj.UUID)
+		assert.ElementsMatch(t, idx[v], []string{obj.UUID})
 	})
 	t.Run("Index by single column miss", func(t *testing.T) {
 		idx, err := table.Index("foo")
 		assert.Nil(t, err)
-		obj2 := obj
-		obj2.Foo = "wrong"
+		obj3 := *obj
+		obj3.Foo = "wrong"
 		assert.Nil(t, err)
-		info, err := dbModel.NewModelInfo(obj2)
+		info, err := dbModel.NewModelInfo(&obj3)
 		assert.Nil(t, err)
-		v, err := valueFromIndex(info, newIndex("foo"))
+		v, err := valueFromIndex(info, newColumnKeysFromColumns("foo"))
 		assert.Nil(t, err)
 		_, ok := idx[v]
 		assert.False(t, ok)
@@ -1180,25 +1915,39 @@ func TestIndex(t *testing.T) {
 		assert.Nil(t, err)
 		info, err := dbModel.NewModelInfo(obj)
 		assert.Nil(t, err)
-		v, err := valueFromIndex(info, newIndex("bar", "baz"))
+		v, err := valueFromIndex(info, newColumnKeysFromColumns("bar", "baz"))
 		assert.Nil(t, err)
-		assert.Equal(t, idx[v], obj.UUID)
+		assert.ElementsMatch(t, idx[v], []string{obj.UUID})
 	})
 	t.Run("Index by multi-column miss", func(t *testing.T) {
 		idx, err := table.Index("bar", "baz")
 		assert.Nil(t, err)
-		obj2 := obj
-		obj2.Baz++
-		info, err := dbModel.NewModelInfo(obj)
+		obj3 := *obj
+		obj3.Baz++
+		info, err := dbModel.NewModelInfo(&obj3)
 		assert.Nil(t, err)
-		v, err := valueFromIndex(info, newIndex("bar", "baz"))
+		v, err := valueFromIndex(info, newColumnKeysFromColumns("bar", "baz"))
 		assert.Nil(t, err)
 		_, ok := idx[v]
 		assert.False(t, ok)
 	})
-	t.Run("Index type", func(t *testing.T) {
-		idx := newIndex("foo", "bar")
-		assert.Equal(t, idx.columns(), []string{"foo", "bar"})
+	t.Run("Client index by single column", func(t *testing.T) {
+		idx, err := table.Index("bar")
+		assert.Nil(t, err)
+		info, err := dbModel.NewModelInfo(obj)
+		assert.Nil(t, err)
+		v, err := valueFromIndex(info, newColumnKeysFromColumns("bar"))
+		assert.Nil(t, err)
+		assert.ElementsMatch(t, idx[v], []string{obj.UUID, obj2.UUID})
+	})
+	t.Run("Client index by multiple column", func(t *testing.T) {
+		idx, err := table.Index("foo", "baz")
+		assert.Nil(t, err)
+		info, err := dbModel.NewModelInfo(obj)
+		assert.Nil(t, err)
+		v, err := valueFromIndex(info, newColumnKeysFromColumns("foo", "baz"))
+		assert.Nil(t, err)
+		assert.ElementsMatch(t, idx[v], []string{obj.UUID})
 	})
 }
 
@@ -1565,6 +2314,135 @@ func TestTableCacheApplyModifications(t *testing.T) {
 	}
 }
 
+func TestTableCacheRowsByModel(t *testing.T) {
+	type testModel struct {
+		UUID string            `ovsdb:"_uuid"`
+		Foo  string            `ovsdb:"foo"`
+		Bar  string            `ovsdb:"bar"`
+		Baz  map[string]string `ovsdb:"baz"`
+	}
+	var schema ovsdb.DatabaseSchema
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
+	require.NoError(t, err)
+	db.SetIndexes(map[string][]model.ClientIndex{
+		"Open_vSwitch": {
+			{
+				Columns: []model.ColumnKey{
+					{
+						Column: "bar",
+					},
+				},
+			},
+			{
+				Columns: []model.ColumnKey{
+					{
+						Column: "bar",
+					},
+					{
+						Column: "baz",
+						Key:    "baz",
+					},
+				},
+			},
+		},
+	})
+	err = json.Unmarshal([]byte(`{
+		"name": "Open_vSwitch",
+		"tables": {
+		  "Open_vSwitch": {
+			"indexes": [["foo"]],
+			"columns": {	
+			  "foo": {
+				"type": "string"
+			  },
+			  "bar": {
+				"type": "string"
+			  },
+			  "baz": {
+				"type": {
+					"key": "string",
+					"value": "string",
+					"min": 0, 
+					"max": "unlimited"
+				}
+			  }
+			}
+		  }
+		}
+	}`), &schema)
+	require.NoError(t, err)
+
+	testData := Data{
+		"Open_vSwitch": map[string]model.Model{
+			"foo":    &testModel{Foo: "foo", Bar: "foo", Baz: map[string]string{"baz": "foo", "other": "other"}},
+			"bar":    &testModel{Foo: "bar", Bar: "bar", Baz: map[string]string{"baz": "bar", "other": "other"}},
+			"foobar": &testModel{Foo: "foobar", Bar: "bar", Baz: map[string]string{"baz": "foobar", "other": "other"}},
+			"baz":    &testModel{Foo: "baz", Bar: "baz", Baz: map[string]string{"baz": "baz", "other": "other"}},
+			"quux":   &testModel{Foo: "quux", Bar: "quux", Baz: map[string]string{"baz": "quux", "other": "other"}},
+			"quuz":   &testModel{Foo: "quuz", Bar: "quux", Baz: map[string]string{"baz": "quux", "other": "other"}},
+		},
+	}
+	dbModel, errs := model.NewDatabaseModel(schema, db)
+	require.Empty(t, errs)
+
+	tests := []struct {
+		name  string
+		model model.Model
+		rows  map[string]model.Model
+	}{
+		{
+			"by non index, no result",
+			&testModel{Foo: "no", Bar: "no", Baz: map[string]string{"baz": "no"}},
+			nil,
+		},
+		{
+			"by single column client index, single result",
+			&testModel{Bar: "foo"},
+			map[string]model.Model{
+				"foo": testData["Open_vSwitch"]["foo"],
+			},
+		},
+		{
+			"by single column client index, multiple results",
+			&testModel{Bar: "bar"},
+			map[string]model.Model{
+				"bar":    testData["Open_vSwitch"]["bar"],
+				"foobar": testData["Open_vSwitch"]["foobar"],
+			},
+		},
+		{
+			"by multi column client index, single result",
+			&testModel{Bar: "baz", Baz: map[string]string{"baz": "baz"}},
+			map[string]model.Model{
+				"baz": testData["Open_vSwitch"]["baz"],
+			},
+		},
+		{
+			"by client index, multiple results",
+			&testModel{Bar: "quux", Baz: map[string]string{"baz": "quux"}},
+			map[string]model.Model{
+				"quux": testData["Open_vSwitch"]["quux"],
+				"quuz": testData["Open_vSwitch"]["quuz"],
+			},
+		},
+		{
+			"by schema index prioritized over client index",
+			&testModel{Foo: "foo", Bar: "bar", Baz: map[string]string{"baz": "bar"}},
+			map[string]model.Model{
+				"foo": testData["Open_vSwitch"]["foo"],
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc, err := NewTableCache(dbModel, testData, nil)
+			require.NoError(t, err)
+			rows := tc.Table("Open_vSwitch").RowsByModel(tt.model)
+			require.Equal(t, tt.rows, rows)
+		})
+	}
+}
+
 type rowsByConditionTestModel struct {
 	UUID   string            `ovsdb:"_uuid"`
 	Foo    string            `ovsdb:"foo"`
@@ -1580,26 +2458,45 @@ func setupRowsByConditionCache(t require.TestingT) *TableCache {
 	var schema ovsdb.DatabaseSchema
 	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &rowsByConditionTestModel{}})
 	require.NoError(t, err)
+	db.SetIndexes(map[string][]model.ClientIndex{
+		"Open_vSwitch": {
+			{
+				Columns: []model.ColumnKey{
+					{
+						Column: "foobar",
+						Key:    "foobar",
+					},
+				},
+			},
+			{
+				Columns: []model.ColumnKey{
+					{
+						Column: "empty",
+					},
+				},
+			},
+		},
+	})
 	err = json.Unmarshal([]byte(`{
 		"name": "Open_vSwitch",
 		"tables": {
 		  "Open_vSwitch": {
 			"indexes": [["foo"], ["bar"], ["quux", "quuz"]],
-		    "columns": {
-		      "foo": {
-			    "type": "string"
+			"columns": {	
+			  "foo": {
+				"type": "string"
 			  },
 			  "bar": {
 				"type": "string"
 			  },
 			  "baz": {
-				"type": "string"
+			    "type": "string"
 			  },
 			  "quux": {
-				"type": "string"
+			    "type": "string"
 			  },
 			  "quuz": {
-				"type": "string"
+			    "type": "string"
 			  },
 			  "foobar": {
 				"type": {
@@ -1610,14 +2507,13 @@ func setupRowsByConditionCache(t require.TestingT) *TableCache {
 				}
 			  },
 			  "empty": {
-				"type": "string"
+			    "type": "string"
 			  }
-		    }
+			}
 		  }
 		}
 	}`), &schema)
 	require.NoError(t, err)
-
 	dbModel, errs := model.NewDatabaseModel(schema, db)
 	require.Empty(t, errs)
 	tc, err := NewTableCache(dbModel, nil, nil)
@@ -1632,12 +2528,13 @@ func BenchmarkRowsByCondition(b *testing.B) {
 	models := []*rowsByConditionTestModel{}
 	for i := 0; i < numRows; i++ {
 		model := &rowsByConditionTestModel{
-			UUID: fmt.Sprintf("UUID-%d", i),
-			Foo:  fmt.Sprintf("Foo-%d", i),
-			Bar:  fmt.Sprintf("Bar-%d", i),
-			Baz:  fmt.Sprintf("Baz-%d", i),
-			Quux: fmt.Sprintf("Quux-%d", i),
-			Quuz: fmt.Sprintf("Quuz-%d", i),
+			UUID:   fmt.Sprintf("UUID-%d", i),
+			Foo:    fmt.Sprintf("Foo-%d", i),
+			Bar:    fmt.Sprintf("Bar-%d", i),
+			Baz:    fmt.Sprintf("Baz-%d", i),
+			Quux:   fmt.Sprintf("Quux-%d", i),
+			Quuz:   fmt.Sprintf("Quuz-%d", i),
+			FooBar: map[string]string{"foobar": fmt.Sprintf("FooBar-%d", i)},
 		}
 		err := rc.Create(model.UUID, model, true)
 		require.NoError(b, err)
@@ -1663,6 +2560,14 @@ func BenchmarkRowsByCondition(b *testing.B) {
 			prepare: func(i int) []ovsdb.Condition {
 				return []ovsdb.Condition{
 					{Column: "foo", Function: ovsdb.ConditionEqual, Value: models[i].Foo},
+				}
+			},
+		},
+		{
+			name: "by single column client index",
+			prepare: func(i int) []ovsdb.Condition {
+				return []ovsdb.Condition{
+					{Column: "foobar", Function: ovsdb.ConditionIncludes, Value: ovsdb.OvsMap{GoMap: map[interface{}]interface{}{"foobar": models[i].FooBar["foobar"]}}},
 				}
 			},
 		},

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1065,7 +1065,7 @@ func TestTableCachePopulate2BrokenIndexes(t *testing.T) {
 	assert.False(t, ok)
 
 	t.Log("Lookup Original Insert By Index")
-	result := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "bar"})
+	_, result := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "bar"})
 	require.NotNil(t, result)
 }
 
@@ -1243,18 +1243,18 @@ func TestTableCacheRowByModelSingleIndex(t *testing.T) {
 	myFoo, tc := setupRowByModelSingleIndex(t)
 
 	t.Run("get foo by index", func(t *testing.T) {
-		foo := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "foo"})
+		_, foo := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "foo"})
 		assert.NotNil(t, foo)
 		assert.Equal(t, myFoo, foo)
 	})
 
 	t.Run("get non-existent item by index", func(t *testing.T) {
-		baz := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "baz"})
+		_, baz := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "baz"})
 		assert.Nil(t, baz)
 	})
 
 	t.Run("no index data", func(t *testing.T) {
-		foo := tc.Table("Open_vSwitch").RowByModel(&testModel{Bar: "foo"})
+		_, foo := tc.Table("Open_vSwitch").RowByModel(&testModel{Bar: "foo"})
 		assert.Nil(t, foo)
 	})
 }
@@ -1355,19 +1355,19 @@ func TestTableCacheRowByModelTwoIndexes(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("get foo by Foo index", func(t *testing.T) {
-		foo := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "foo"})
+		_, foo := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "foo"})
 		assert.NotNil(t, foo)
 		assert.Equal(t, myFoo, foo)
 	})
 
 	t.Run("get foo by Bar index", func(t *testing.T) {
-		foo := tc.Table("Open_vSwitch").RowByModel(&testModel{Bar: "foo"})
+		_, foo := tc.Table("Open_vSwitch").RowByModel(&testModel{Bar: "foo"})
 		assert.NotNil(t, foo)
 		assert.Equal(t, myFoo, foo)
 	})
 
 	t.Run("get non-existent item by index", func(t *testing.T) {
-		baz := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "baz"})
+		_, baz := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "baz"})
 		assert.Nil(t, baz)
 	})
 
@@ -1405,18 +1405,18 @@ func TestTableCacheRowByModelMultiIndex(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("incomplete index", func(t *testing.T) {
-		foo := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "foo"})
+		_, foo := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "foo"})
 		assert.Nil(t, foo)
 	})
 
 	t.Run("get foo by index", func(t *testing.T) {
-		foo := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "foo", Bar: "foo"})
+		_, foo := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "foo", Bar: "foo"})
 		assert.NotNil(t, foo)
 		assert.Equal(t, myFoo, foo)
 	})
 
 	t.Run("get non-existent item by index", func(t *testing.T) {
-		baz := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "baz", Bar: "baz"})
+		_, baz := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "baz", Bar: "baz"})
 		assert.Nil(t, baz)
 	})
 }

--- a/cache/uuidset.go
+++ b/cache/uuidset.go
@@ -1,0 +1,67 @@
+package cache
+
+type void struct{}
+type uuidset map[string]void
+
+func newUUIDSet(uuids ...string) uuidset {
+	s := uuidset{}
+	for _, uuid := range uuids {
+		s[uuid] = void{}
+	}
+	return s
+}
+
+func (s uuidset) add(uuid string) {
+	s[uuid] = void{}
+}
+
+func (s uuidset) remove(uuid string) {
+	delete(s, uuid)
+}
+
+func (s uuidset) has(uuid string) bool {
+	_, ok := s[uuid]
+	return ok
+}
+
+func (s uuidset) getAny() string {
+	for k := range s {
+		return k
+	}
+	return ""
+}
+
+func (s uuidset) list() []string {
+	uuids := make([]string, 0, len(s))
+	for uuid := range s {
+		uuids = append(uuids, uuid)
+	}
+	return uuids
+}
+
+func (s uuidset) empty() bool {
+	return len(s) == 0
+}
+
+func addUUIDSet(s1, s2 uuidset) uuidset {
+	if len(s2) == 0 {
+		return s1
+	}
+	if s1 == nil {
+		s1 = uuidset{}
+	}
+	for uuid := range s2 {
+		s1.add(uuid)
+	}
+	return s1
+}
+
+func substractUUIDSet(s1, s2 uuidset) uuidset {
+	if len(s1) == 0 || len(s2) == 0 {
+		return s1
+	}
+	for uuid := range s2 {
+		s1.remove(uuid)
+	}
+	return s1
+}

--- a/cache/uuidset.go
+++ b/cache/uuidset.go
@@ -65,3 +65,25 @@ func substractUUIDSet(s1, s2 uuidset) uuidset {
 	}
 	return s1
 }
+
+func intersectUUIDSets(s1, s2 uuidset) uuidset {
+	if len(s1) == 0 || len(s2) == 0 {
+		return nil
+	}
+	var big uuidset
+	var small uuidset
+	if len(s1) > len(s2) {
+		big = s1
+		small = s2
+	} else {
+		big = s2
+		small = s1
+	}
+	f := uuidset{}
+	for uuid := range small {
+		if big.has(uuid) {
+			f.add(uuid)
+		}
+	}
+	return f
+}

--- a/client/api.go
+++ b/client/api.go
@@ -29,7 +29,7 @@ type API interface {
 	// Create a ConditionalAPI from a Model's index data or a list of Conditions
 	// where operations apply to elements that match any of the conditions
 	// If no condition is given, it will match the values provided in model.Model according
-	// to the database index.
+	// to the indexes.
 	Where(model.Model, ...model.Condition) ConditionalAPI
 
 	// Create a ConditionalAPI from a Model's index data or a list of Conditions
@@ -170,12 +170,12 @@ func (a api) List(ctx context.Context, result interface{}) error {
 
 // Where returns a conditionalAPI based on a Condition list
 func (a api) Where(model model.Model, cond ...model.Condition) ConditionalAPI {
-	return newConditionalAPI(a.cache, a.conditionFromModel(false, model, cond...), a.logger)
+	return newConditionalAPI(a.cache, a.conditionFromModel(false, false, model, cond...), a.logger)
 }
 
 // Where returns a conditionalAPI based on a Condition list
 func (a api) WhereAll(model model.Model, cond ...model.Condition) ConditionalAPI {
-	return newConditionalAPI(a.cache, a.conditionFromModel(true, model, cond...), a.logger)
+	return newConditionalAPI(a.cache, a.conditionFromModel(true, false, model, cond...), a.logger)
 }
 
 // Where returns a conditionalAPI based a Predicate
@@ -199,7 +199,7 @@ func (a api) conditionFromFunc(predicate interface{}) Conditional {
 }
 
 // FromModel returns a Condition from a model and a list of fields
-func (a api) conditionFromModel(any bool, model model.Model, cond ...model.Condition) Conditional {
+func (a api) conditionFromModel(any bool, cache bool, model model.Model, cond ...model.Condition) Conditional {
 	var conditional Conditional
 	var err error
 
@@ -213,7 +213,6 @@ func (a api) conditionFromModel(any bool, model model.Model, cond ...model.Condi
 		if err != nil {
 			conditional = newErrorConditional(err)
 		}
-
 	} else {
 		conditional, err = newExplicitConditional(tableName, a.cache, any, model, cond...)
 		if err != nil {

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -306,8 +306,6 @@ func TestAPIListFields(t *testing.T) {
 	}
 	tcache := apiTestCache(t, testData)
 
-	testObj := testLogicalSwitchPort{}
-
 	test := []struct {
 		name    string
 		fields  []interface{}
@@ -316,9 +314,10 @@ func TestAPIListFields(t *testing.T) {
 		err     bool
 	}{
 		{
-			name:    "empty object must match everything",
+			name:    "empty object and no explicit conditions must fail",
+			prepare: func(t *testLogicalSwitchPort) {},
 			content: lspcacheList,
-			err:     false,
+			err:     true,
 		},
 		{
 			name: "List unique by UUID",
@@ -342,7 +341,8 @@ func TestAPIListFields(t *testing.T) {
 		t.Run(fmt.Sprintf("ApiListFields: %s", tt.name), func(t *testing.T) {
 			var result []testLogicalSwitchPort
 			// Clean object
-			testObj = testLogicalSwitchPort{}
+			testObj := testLogicalSwitchPort{}
+			tt.prepare(&testObj)
 			api := newAPI(tcache, &discardLogger)
 			err := api.Where(&testObj).List(context.Background(), &result)
 			if tt.err {

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -450,7 +450,7 @@ func TestConditionFromModel(t *testing.T) {
 		t.Run(fmt.Sprintf("conditionFromModel: %s", tt.name), func(t *testing.T) {
 			cache := apiTestCache(t, nil)
 			apiIface := newAPI(cache, &discardLogger)
-			condition := apiIface.(api).conditionFromModel(false, tt.model, tt.conds...)
+			condition := apiIface.(api).conditionFromModel(false, false, tt.model, tt.conds...)
 			if tt.err {
 				assert.IsType(t, &errorConditional{}, condition)
 			} else {

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -311,13 +311,11 @@ func TestAPIListFields(t *testing.T) {
 		fields  []interface{}
 		prepare func(*testLogicalSwitchPort)
 		content []model.Model
-		err     bool
 	}{
 		{
-			name:    "empty object and no explicit conditions must fail",
+			name:    "No match",
 			prepare: func(t *testLogicalSwitchPort) {},
-			content: lspcacheList,
-			err:     true,
+			content: []model.Model{},
 		},
 		{
 			name: "List unique by UUID",
@@ -325,7 +323,6 @@ func TestAPIListFields(t *testing.T) {
 				t.UUID = aUUID0
 			},
 			content: []model.Model{lspcache[aUUID0]},
-			err:     false,
 		},
 		{
 			name: "List unique by Index",
@@ -333,25 +330,19 @@ func TestAPIListFields(t *testing.T) {
 				t.Name = "lsp2"
 			},
 			content: []model.Model{lspcache[aUUID2]},
-			err:     false,
 		},
 	}
 
 	for _, tt := range test {
 		t.Run(fmt.Sprintf("ApiListFields: %s", tt.name), func(t *testing.T) {
-			var result []testLogicalSwitchPort
+			var result []*testLogicalSwitchPort
 			// Clean object
 			testObj := testLogicalSwitchPort{}
 			tt.prepare(&testObj)
 			api := newAPI(tcache, &discardLogger)
 			err := api.Where(&testObj).List(context.Background(), &result)
-			if tt.err {
-				assert.NotNil(t, err)
-			} else {
-				assert.Nil(t, err)
-				assert.ElementsMatchf(t, tt.content, tt.content, "Content should match")
-			}
-
+			assert.Nil(t, err)
+			assert.ElementsMatchf(t, tt.content, result, "Content should match")
 		})
 	}
 

--- a/client/condition.go
+++ b/client/condition.go
@@ -134,7 +134,12 @@ func (c *explicitConditional) Matches() (map[string]model.Model, error) {
 
 // Generate returns conditions based on the provided Condition list
 func (c *explicitConditional) Generate() ([][]ovsdb.Condition, error) {
-	return c.anyConditions, nil
+	models, _ := c.Matches()
+	if len(models) == 0 {
+		// no cache hits, return conditions we were given
+		return c.anyConditions, nil
+	}
+	return generateConditionsFromModels(c.cache.DatabaseModel(), models)
 }
 
 // newExplicitConditional creates a new explicitConditional

--- a/client/condition.go
+++ b/client/condition.go
@@ -85,7 +85,12 @@ func (c *equalityConditional) Matches() (map[string]model.Model, error) {
 // based on the UUID of the found model. Otherwise, the conditions will be based
 // on the index.
 func (c *equalityConditional) Generate() ([][]ovsdb.Condition, error) {
-	return generateConditionsFromModels(c.cache.DatabaseModel(), map[string]model.Model{"": c.model})
+	models, _ := c.Matches()
+	if len(models) == 0 {
+		// no cache hits, generate condition from model we were given
+		return generateConditionsFromModels(c.cache.DatabaseModel(), map[string]model.Model{"": c.model})
+	}
+	return generateConditionsFromModels(c.cache.DatabaseModel(), models)
 }
 
 // NewEqualityCondition creates a new equalityConditional

--- a/client/condition.go
+++ b/client/condition.go
@@ -158,7 +158,7 @@ func (c *predicateConditional) Generate() ([][]ovsdb.Condition, error) {
 	if tableCache == nil {
 		return nil, ErrNotFound
 	}
-	for _, row := range tableCache.Rows() {
+	for _, row := range tableCache.RowsShallow() {
 		match, err := c.Matches(row)
 		if err != nil {
 			return nil, err

--- a/client/condition.go
+++ b/client/condition.go
@@ -77,11 +77,7 @@ func (c *equalityConditional) Matches() (map[string]model.Model, error) {
 	if tableCache == nil {
 		return nil, ErrNotFound
 	}
-	u, m := tableCache.RowByModel(c.model)
-	if m == nil {
-		return nil, nil
-	}
-	return map[string]model.Model{u: m} , nil
+	return tableCache.RowsByModel(c.model), nil
 }
 
 // Generate conditions based on the equality of the first available index. If

--- a/client/condition.go
+++ b/client/condition.go
@@ -16,118 +16,141 @@ type Conditional interface {
 	// Generate returns a list of lists of conditions to be used in Operations
 	// Each element in the (outer) list corresponds to an operation
 	Generate() ([][]ovsdb.Condition, error)
-	// matches returns true if a model matches the condition
-	Matches(m model.Model) (bool, error)
+	// Returns the models that match the conditions
+	Matches() (map[string]model.Model, error)
 	// returns the table that this condition is associated with
 	Table() string
 }
 
-// equalityConditional uses the information available in a model to generate conditions
-// The conditions are based on the equality of the first available index.
-// The priority of indexes is: uuid, {schema index}
-type equalityConditional struct {
-	dbModel   model.DatabaseModel
-	tableName string
-	info      *mapper.Info
-	singleOp  bool
+func generateConditionsFromModels(dbModel model.DatabaseModel, models map[string]model.Model) ([][]ovsdb.Condition, error) {
+	anyConditions := make([][]ovsdb.Condition, 0, len(models))
+	for _, model := range models {
+		info, err := dbModel.NewModelInfo(model)
+		if err != nil {
+			return nil, err
+		}
+		allConditions, err := dbModel.Mapper.NewEqualityCondition(info)
+		if err != nil {
+			return nil, err
+		}
+		anyConditions = append(anyConditions, allConditions)
+	}
+	return anyConditions, nil
 }
 
-func (c *equalityConditional) Matches(m model.Model) (bool, error) {
-	info, err := c.dbModel.NewModelInfo(m)
-	if err != nil {
-		return false, err
+func generateOvsdbConditionsFromModelConditions(dbModel model.DatabaseModel, info *mapper.Info, conditions []model.Condition, singleOp bool) ([][]ovsdb.Condition, error) {
+	anyConditions := [][]ovsdb.Condition{}
+	if singleOp {
+		anyConditions = append(anyConditions, []ovsdb.Condition{})
 	}
-	return c.dbModel.Mapper.EqualFields(c.info, info)
+	for _, condition := range conditions {
+		ovsdbCond, err := dbModel.Mapper.NewCondition(info, condition.Field, condition.Function, condition.Value)
+		if err != nil {
+			return nil, err
+		}
+		allConditions := []ovsdb.Condition{*ovsdbCond}
+		if singleOp {
+			anyConditions[0] = append(anyConditions[0], allConditions...)
+		} else {
+			anyConditions = append(anyConditions, allConditions)
+		}
+	}
+	return anyConditions, nil
+}
+
+// equalityConditional uses the indexes available in a provided model to find a
+// matching model in the database.
+type equalityConditional struct {
+	tableName string
+	model     model.Model
+	cache     *cache.TableCache
 }
 
 func (c *equalityConditional) Table() string {
 	return c.tableName
 }
 
-// Generate returns a condition based on the model and the field pointers
-func (c *equalityConditional) Generate() ([][]ovsdb.Condition, error) {
-	var result [][]ovsdb.Condition
+// Returns the models that match the indexes available through the provided
+// model.
+func (c *equalityConditional) Matches() (map[string]model.Model, error) {
+	tableCache := c.cache.Table(c.tableName)
+	if tableCache == nil {
+		return nil, ErrNotFound
+	}
+	u, m := tableCache.RowByModel(c.model)
+	if m == nil {
+		return nil, nil
+	}
+	return map[string]model.Model{u: m} , nil
+}
 
-	conds, err := c.dbModel.Mapper.NewEqualityCondition(c.info)
-	if err != nil {
-		return nil, err
-	}
-	if c.singleOp {
-		result = append(result, conds)
-	} else {
-		for _, c := range conds {
-			result = append(result, []ovsdb.Condition{c})
-		}
-	}
-	return result, nil
+// Generate conditions based on the equality of the first available index. If
+// the index can be matched against a model in the cache, the condition will be
+// based on the UUID of the found model. Otherwise, the conditions will be based
+// on the index.
+func (c *equalityConditional) Generate() ([][]ovsdb.Condition, error) {
+	return generateConditionsFromModels(c.cache.DatabaseModel(), map[string]model.Model{"": c.model})
 }
 
 // NewEqualityCondition creates a new equalityConditional
-func newEqualityConditional(dbModel model.DatabaseModel, table string, all bool, model model.Model, fields ...interface{}) (Conditional, error) {
-	info, err := dbModel.NewModelInfo(model)
-	if err != nil {
-		return nil, err
-	}
+func newEqualityConditional(table string, cache *cache.TableCache, model model.Model) (Conditional, error) {
 	return &equalityConditional{
-		dbModel:   dbModel,
 		tableName: table,
-		info:      info,
-		singleOp:  all,
+		model:     model,
+		cache:     cache,
 	}, nil
 }
 
 // explicitConditional generates conditions based on the provided Condition list
 type explicitConditional struct {
-	dbModel    model.DatabaseModel
-	tableName  string
-	info       *mapper.Info
-	conditions []model.Condition
-	singleOp   bool
-}
-
-func (c *explicitConditional) Matches(m model.Model) (bool, error) {
-	return false, fmt.Errorf("cannot perform cache comparisons using explicit conditions")
+	tableName     string
+	anyConditions [][]ovsdb.Condition
+	cache         *cache.TableCache
 }
 
 func (c *explicitConditional) Table() string {
 	return c.tableName
 }
 
-// Generate returns a condition based on the model and the field pointers
-func (c *explicitConditional) Generate() ([][]ovsdb.Condition, error) {
-	var result [][]ovsdb.Condition
-	var conds []ovsdb.Condition
-
-	for _, cond := range c.conditions {
-		ovsdbCond, err := c.dbModel.Mapper.NewCondition(c.info, cond.Field, cond.Function, cond.Value)
+// Returns the models that match the conditions
+func (c *explicitConditional) Matches() (map[string]model.Model, error) {
+	tableCache := c.cache.Table(c.tableName)
+	if tableCache == nil {
+		return nil, ErrNotFound
+	}
+	found := map[string]model.Model{}
+	for _, allConditions := range c.anyConditions {
+		models, err := tableCache.RowsByCondition(allConditions)
 		if err != nil {
 			return nil, err
 		}
-		if c.singleOp {
-			conds = append(conds, *ovsdbCond)
-		} else {
-			result = append(result, []ovsdb.Condition{*ovsdbCond})
+		for uuid, model := range models {
+			found[uuid] = model
 		}
-
 	}
-	if c.singleOp {
-		result = append(result, conds)
-	}
-	return result, nil
+	return found, nil
 }
 
-// newIndexCondition creates a new equalityConditional
-func newExplicitConditional(dbModel model.DatabaseModel, table string, all bool, model model.Model, cond ...model.Condition) (Conditional, error) {
+// Generate returns conditions based on the provided Condition list
+func (c *explicitConditional) Generate() ([][]ovsdb.Condition, error) {
+	return c.anyConditions, nil
+}
+
+// newExplicitConditional creates a new explicitConditional
+func newExplicitConditional(table string, cache *cache.TableCache, all bool, model model.Model, cond ...model.Condition) (Conditional, error) {
+	dbModel := cache.DatabaseModel()
 	info, err := dbModel.NewModelInfo(model)
 	if err != nil {
 		return nil, err
 	}
+	anyConditions, err := generateOvsdbConditionsFromModelConditions(dbModel, info, cond, all)
+	if err != nil {
+		return nil, err
+	}
 	return &explicitConditional{
-		dbModel:    dbModel,
-		tableName:  table,
-		info:       info,
-		conditions: cond,
-		singleOp:   all,
+		tableName:     table,
+		anyConditions: anyConditions,
+		cache:         cache,
 	}, nil
 }
 
@@ -141,9 +164,22 @@ type predicateConditional struct {
 
 // matches returns the result of the execution of the predicate
 // Type verifications are not performed
-func (c *predicateConditional) Matches(model model.Model) (bool, error) {
-	ret := reflect.ValueOf(c.predicate).Call([]reflect.Value{reflect.ValueOf(model)})
-	return ret[0].Bool(), nil
+// Returns the models that match the conditions
+func (c *predicateConditional) Matches() (map[string]model.Model, error) {
+	tableCache := c.cache.Table(c.tableName)
+	if tableCache == nil {
+		return nil, ErrNotFound
+	}
+	found := map[string]model.Model{}
+	// run the predicate on a shallow copy of the models for speed and only
+	// clone the matches
+	for u, m := range tableCache.RowsShallow() {
+		ret := reflect.ValueOf(c.predicate).Call([]reflect.Value{reflect.ValueOf(m)})
+		if ret[0].Bool() {
+			found[u] = model.Clone(m)
+		}
+	}
+	return found, nil
 }
 
 func (c *predicateConditional) Table() string {
@@ -153,29 +189,8 @@ func (c *predicateConditional) Table() string {
 // generate returns a list of conditions that match, by _uuid equality, all the objects that
 // match the predicate
 func (c *predicateConditional) Generate() ([][]ovsdb.Condition, error) {
-	allConditions := make([][]ovsdb.Condition, 0)
-	tableCache := c.cache.Table(c.tableName)
-	if tableCache == nil {
-		return nil, ErrNotFound
-	}
-	for _, row := range tableCache.RowsShallow() {
-		match, err := c.Matches(row)
-		if err != nil {
-			return nil, err
-		}
-		if match {
-			info, err := c.cache.DatabaseModel().NewModelInfo(row)
-			if err != nil {
-				return nil, err
-			}
-			elemCond, err := c.cache.Mapper().NewEqualityCondition(info)
-			if err != nil {
-				return nil, err
-			}
-			allConditions = append(allConditions, elemCond)
-		}
-	}
-	return allConditions, nil
+	models, _ := c.Matches()
+	return generateConditionsFromModels(c.cache.DatabaseModel(), models)
 }
 
 // newPredicateConditional creates a new predicateConditional
@@ -193,8 +208,8 @@ type errorConditional struct {
 	err error
 }
 
-func (e *errorConditional) Matches(model.Model) (bool, error) {
-	return false, e.err
+func (e *errorConditional) Matches() (map[string]model.Model, error) {
+	return nil, e.err
 }
 
 func (e *errorConditional) Table() string {

--- a/client/condition_test.go
+++ b/client/condition_test.go
@@ -66,16 +66,27 @@ func TestEqualityConditional(t *testing.T) {
 			matches: map[string]model.Model{aUUID0: lspcacheList[0]},
 		},
 		{
-			name:  "by index",
+			name:  "by index with cache",
 			model: &testLogicalSwitchPort{Name: "lsp1"},
+			condition: [][]ovsdb.Condition{
+				{
+					{
+						Column:   "_uuid",
+						Function: ovsdb.ConditionEqual,
+						Value:    ovsdb.UUID{GoUUID: aUUID1},
+					}}},
+			matches: map[string]model.Model{aUUID1: lspcacheList[1]},
+		},
+		{
+			name:  "by index with no cache",
+			model: &testLogicalSwitchPort{Name: "foo"},
 			condition: [][]ovsdb.Condition{
 				{
 					{
 						Column:   "name",
 						Function: ovsdb.ConditionEqual,
-						Value:    "lsp1",
+						Value:    "foo",
 					}}},
-			matches: map[string]model.Model{aUUID1: lspcacheList[1]},
 		},
 		{
 			name:  "by non index",

--- a/client/doc.go
+++ b/client/doc.go
@@ -74,10 +74,6 @@ generate an appropriate condition. Therefore the following two statements are eq
 		Value: "myUUID"},
 	    })
 
-When indexes are used, the generated conditions will be based on the UUIDs of the matching models found
-in the cache. If no matches are found in the cache, the generated conditions will be based on the
-fields themselves.
-
 Where() accepts multiple Condition instances (through variadic arguments).
 If provided, the client will generate multiple operations each matching one condition.
 For example, the following operation will delete all the Logical Switches named "foo" OR "bar":
@@ -95,8 +91,11 @@ For example, the following operation will delete all the Logical Switches named 
 
 To create a Condition that matches all of the conditions simultaneously (i.e: AND semantics), use WhereAll().
 
-Where() and WhereAll() inject conditions into operations that will be evaluated by the server.
-However, to perform searches on the local cache, a more flexible mechanism is available: WhereCache()
+Where() or WhereAll() evaluate the provided index values or explicit conditions against the cache and generate
+conditions based on the UUIDs of matching models. If no matches are found in the cache, the generated conditions
+will be based on the index or condition fields themselves.
+
+A more flexible mechanism to search the cache is available: WhereCache()
 
 WhereCache() accepts a function that takes any Model as argument and returns a boolean.
 It is used to search the cache so commonly used with List() function. For example:

--- a/client/doc.go
+++ b/client/doc.go
@@ -61,9 +61,8 @@ Conditions must refer to fields of the provided Model (via pointer to fields). E
 		Value: []string{"portUUID"},
 	    })
 
-If no client.Condition is provided, the client will use the first non-null field that corresponds
-to a database index to generate an appropriate condition. Therefore the following
-two statements are equivalent:
+If no client.Condition is provided, the client will use any of fields that correspond to indexes to
+generate an appropriate condition. Therefore the following two statements are equivalent:
 
 	ls = &MyLogicalSwitch {UUID:"myUUID"}
 
@@ -111,7 +110,7 @@ same condition using Where() or WhereAll() which will be more efficient.
 
 Get
 
-Get() operation is a simple operation capable of retrieving one Model based on some of its indexes. E.g:
+Get() operation is a simple operation capable of retrieving one Model based on some of its schema indexes. E.g:
 
 	ls := &LogicalSwitch{UUID:"myUUID"}
 	err := ovs.Get(ls)

--- a/client/doc.go
+++ b/client/doc.go
@@ -61,8 +61,8 @@ Conditions must refer to fields of the provided Model (via pointer to fields). E
 		Value: []string{"portUUID"},
 	    })
 
-If no client.Condition is provided, the client will create a default Condition based on the Model's data.
-The first non-null field that corresponds to a database index will be used. Therefore the following
+If no client.Condition is provided, the client will use the first non-null field that corresponds
+to a database index to generate an appropriate condition. Therefore the following
 two statements are equivalent:
 
 	ls = &MyLogicalSwitch {UUID:"myUUID"}

--- a/client/doc.go
+++ b/client/doc.go
@@ -74,6 +74,10 @@ generate an appropriate condition. Therefore the following two statements are eq
 		Value: "myUUID"},
 	    })
 
+When indexes are used, the generated conditions will be based on the UUIDs of the matching models found
+in the cache. If no matches are found in the cache, the generated conditions will be based on the
+fields themselves.
+
 Where() accepts multiple Condition instances (through variadic arguments).
 If provided, the client will generate multiple operations each matching one condition.
 For example, the following operation will delete all the Logical Switches named "foo" OR "bar":

--- a/model/client.go
+++ b/model/client.go
@@ -8,10 +8,22 @@ import (
 	"github.com/ovn-org/libovsdb/ovsdb"
 )
 
+// ColumnKey addresses a column and optionally a key within a column
+type ColumnKey struct {
+	Column string
+	Key    interface{}
+}
+
+// ClientIndex defines a client index by a set of columns
+type ClientIndex struct {
+	Columns []ColumnKey
+}
+
 // ClientDBModel contains the client information needed to build a DatabaseModel
 type ClientDBModel struct {
-	name  string
-	types map[string]reflect.Type
+	name    string
+	types   map[string]reflect.Type
+	indexes map[string][]ClientIndex
 }
 
 // NewModel returns a new instance of a model from a specific string
@@ -29,6 +41,28 @@ func (db ClientDBModel) Name() string {
 	return db.name
 }
 
+// Indexes returns the client indexes for a model
+func (db ClientDBModel) Indexes(table string) []ClientIndex {
+	if len(db.indexes) == 0 {
+		return nil
+	}
+	if _, ok := db.indexes[table]; ok {
+		return copyIndexes(db.indexes)[table]
+	}
+	return nil
+}
+
+// SetIndexes sets the client indexes. Client indexes are optional, similar to
+// schema indexes and are only tracked in the specific client instances that are
+// provided with this client model. A client index may point to multiple models
+// as uniqueness is not enforced. They are defined per table and multiple
+// indexes can be defined for a table. Each index consists of a set of columns.
+// If the column is a map, specific keys of that map can be addressed for the
+// index.
+func (db *ClientDBModel) SetIndexes(indexes map[string][]ClientIndex) {
+	db.indexes = copyIndexes(indexes)
+}
+
 // Validate validates the DatabaseModel against the input schema
 // Returns all the errors detected
 func (db ClientDBModel) validate(schema ovsdb.DatabaseSchema) []error {
@@ -38,6 +72,7 @@ func (db ClientDBModel) validate(schema ovsdb.DatabaseSchema) []error {
 			db.name, schema.Name))
 	}
 
+	infos := make(map[string]*mapper.Info, len(db.types))
 	for tableName := range db.types {
 		tableSchema := schema.Table(tableName)
 		if tableSchema == nil {
@@ -49,8 +84,41 @@ func (db ClientDBModel) validate(schema ovsdb.DatabaseSchema) []error {
 			errors = append(errors, err)
 			continue
 		}
-		if _, err := mapper.NewInfo(tableName, tableSchema, model); err != nil {
+		info, err := mapper.NewInfo(tableName, tableSchema, model)
+		if err != nil {
 			errors = append(errors, err)
+			continue
+		}
+		infos[tableName] = info
+	}
+
+	for tableName, indexSets := range db.indexes {
+		info, ok := infos[tableName]
+		if !ok {
+			errors = append(errors, fmt.Errorf("database model contains a client index for table %s that does not exist in schema", tableName))
+			continue
+		}
+		for _, indexSet := range indexSets {
+			for _, indexColumn := range indexSet.Columns {
+				f, err := info.FieldByColumn(indexColumn.Column)
+				if err != nil {
+					errors = append(
+						errors,
+						fmt.Errorf("database model contains a client index for column %s that does not exist in table %s",
+							indexColumn.Column,
+							tableName))
+					continue
+				}
+				if indexColumn.Key != nil && reflect.ValueOf(f).Kind() != reflect.Map {
+					errors = append(
+						errors,
+						fmt.Errorf("database model contains a client index for key %s in column %s of table %s that is not a map",
+							indexColumn.Key,
+							indexColumn.Column,
+							tableName))
+					continue
+				}
+			}
 		}
 	}
 	return errors
@@ -82,4 +150,22 @@ func NewClientDBModel(name string, models map[string]Model) (ClientDBModel, erro
 		types: types,
 		name:  name,
 	}, nil
+}
+
+func copyIndexes(src map[string][]ClientIndex) map[string][]ClientIndex {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string][]ClientIndex, len(src))
+	for table, indexSets := range src {
+		dst[table] = make([]ClientIndex, 0, len(indexSets))
+		for _, indexSet := range indexSets {
+			indexSetCopy := ClientIndex{
+				Columns: make([]ColumnKey, len(indexSet.Columns)),
+			}
+			copy(indexSetCopy.Columns, indexSet.Columns)
+			dst[table] = append(dst[table], indexSetCopy)
+		}
+	}
+	return dst
 }


### PR DESCRIPTION
A user may specify additional indexes at runtime through the client DB
model at client initialization. Indexes are specified in sets per table.
Each set consists of columns and optionally a key within the column that
can be addressed if the column type is a map.

The main use case is performance. Running a predicate on all the rows of
a table can be costly. Introducing new indexes in the schema is not backwards
compatible or might not align with the general concept of the schema but those
additional indexes might be useful for specific uses of that schema that 
would otherwise rely on running less performant predicates frequently.

For example, with OVN-K, checking whether ~40 LBs are present in the cache
by a predicate that matches by name on a table that contains ~200K rows took 
around 3 seconds. While surely there is different ways to optimize a predicate, 
for OVN-K which gives & frequently addresses LBs by unique names would 
make sense to have them indexed, something that is not possible to do with 
the schema without breaking backward compatibility.

This can be enhanced in the future with more use cases. For example, supporting
primary and secondary client indexes where primary client indexes could be 
checked for duplicates against a transaction before sending it to the server.

This is implemented in the cache tracking client indexes as if they were
schema indexes. Indexes map to a set of uuids instead of a single uuid
where the set will consist of a single uuid for schema index but might
consist of multiple uuids for client indexes. A new `RowsByModel` method
queries the cache considering schema and client indexes. `RowsByCondition`
also makes use of the new client indexes naturally. The legacy
`RowByModel` method considers only schema indexes. Schema indexes have
priority over client indexes in general.

API wise, client indexes are leveraged through the conditional
APIs from `Where(...)` and `WhereAll(...)`.

So where you would have before something like
```
// slow predicate run on all the LB table rows...
WhereCache(func (lb *LoadBalancer) bool {
    return lb.ExternalIds["myIdKey"] == "myIdValue"
}).List(ctx, &results)
```

Now you can have
```
dbModel, err := nbdb.FullDatabaseModel()
db.SetIndexes(map[string][]model.ClientIndex{
  "Load_Balancer": {{Columns: []model.ColumnKey{Column: "external_ids", Key: "myIdKey"}}}
})

// connect and everything....

lb := &LoadBalancer{
    ExternalIds: map[string]string{"myIdKey": "myIdValue"},
}
// quick indexed result
Where(lb).List(ctx, &results)
```

Other changes in this context:

* Cherry-picked @dave-tucker's [api: Allow use of Where for client-side ops](https://github.com/ovn-org/libovsdb/commit/b54c97c4b95409f779814be465a21f252082554a) 
  so that client indexes can be leveraged through the `Where.List` and `WhereAll.List` 
  conditional APIs. 
* As improvements to the above, run the predicates on shallow copies of model, 
  remove the unnecessary clone and return cache matches directly instead of 
  in-directing through RowsByCondition.
* Fixed an issue with RowsByCondition that was implementing an `Or` between the 
  conditions instead of an `And`. also improved performance.
* Instead of translating model conditions to ovsdb conditions and
  sending those to the server, perform a query on the cache through
  `RowsByModel` or `RowsByCondition` and generate uuid based conditions
  off those results. Fallback to the original conditionals if no cache hits are obtained.

  This is similar to what was already being done for the predicate conditional, this PR
  does the same for the equality and explicit conditionals.

  This has two benefits:

  * OVSDB server does not index schema indexes, it only ensures uniqueness
    but operations based on those indexes are not necessarily fast. By
    querying the cache for the uuids we improve the performance of index
    based operations. Users will no longer be required to do a `Get` before any 
    server side op to ensure this is optimized through the uuid.
  * The conditionals APIs can fully benefit of client indexes for both cache and 
    server side ops.
  
**RFCs**

* The `ClientDBModel`API could be better but I did not want to complicate it 
  unnecessarily. Feedback welcome.
* With this change we rely more on the cache. But the cache doesn't seem to
  be aware at all of monitored vs non-monitored columns and will happily index
  zero values from non-monitored columns. I am not worried in excess about it
  in the context of this PR as this is an issue already present, but perhaps we
  ought to do something about it.
