### PR TITLE
Fix NativeToOVS assignment for pointer values in cache

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -957,7 +957,10 @@ func (t *TableCache) ApplyModifications(tableName string, base model.Model, upda
 			// if NativeToOVS was successful, then simply assign
 			if nv.Type() == reflect.ValueOf(current).Type() {
 				err = info.SetField(k, nv.Interface())
-				return err
+				if err != nil {
+					return err
+				}
+				break
 			}
 			// With a pointer type, an update value could be a set with 2 elements [old, new]
 			if nv.Len() != 2 {

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1428,6 +1428,7 @@ func TestTableCacheApplyModifications(t *testing.T) {
 		Map   map[string]string `ovsdb:"map"`
 		Map2  map[string]string `ovsdb:"map2"`
 		Ptr   *string           `ovsdb:"ptr"`
+		Ptr2  *string           `ovsdb:"ptr2"`
 	}
 	aEmptySet, _ := ovsdb.NewOvsSet([]string{})
 	aFooSet, _ := ovsdb.NewOvsSet([]string{"foo"})
@@ -1507,21 +1508,21 @@ func TestTableCacheApplyModifications(t *testing.T) {
 		},
 		{
 			"set optional value",
-			ovsdb.Row{"ptr": aWallaceSet},
-			&testDBModel{Ptr: nil},
-			&testDBModel{Ptr: &wallace},
+			ovsdb.Row{"ptr": aWallaceSet, "ptr2": aWallaceSet},
+			&testDBModel{Ptr: nil, Ptr2: nil},
+			&testDBModel{Ptr: &wallace, Ptr2: &wallace},
 		},
 		{
 			"replace optional value",
-			ovsdb.Row{"ptr": aWallaceGromitSet},
-			&testDBModel{Ptr: &wallace},
-			&testDBModel{Ptr: &gromit},
+			ovsdb.Row{"ptr": aWallaceGromitSet, "ptr2": aWallaceGromitSet},
+			&testDBModel{Ptr: &wallace, Ptr2: &wallace},
+			&testDBModel{Ptr: &gromit, Ptr2: &gromit},
 		},
 		{
 			"delete optional value",
-			ovsdb.Row{"ptr": aEmptySet},
-			&testDBModel{Ptr: &wallace},
-			&testDBModel{Ptr: nil},
+			ovsdb.Row{"ptr": aEmptySet, "ptr2": aEmptySet},
+			&testDBModel{Ptr: &wallace, Ptr2: &wallace},
+			&testDBModel{Ptr: nil, Ptr2: nil},
 		},
 	}
 	for _, tt := range tests {
@@ -1540,7 +1541,8 @@ func TestTableCacheApplyModifications(t *testing.T) {
 					  "set": { "type": { "key": { "type": "string" }, "min": 0,	"max": "unlimited" } },
 					  "map": { "type": { "key": "string", "max": "unlimited", "min": 0, "value": "string" } },
 					  "map2": { "type": { "key": "string", "max": "unlimited", "min": 0, "value": "string" } },
-					  "ptr": { "type": { "key": { "type": "string" }, "min": 0,	"max": 1 } }
+					  "ptr":  { "type": { "key": { "type": "string" }, "min": 0,	"max": 1 } },
+					  "ptr2": { "type": { "key": { "type": "string" }, "min": 0,	"max": 1 } }
 					}
 				  }
 				}


### PR DESCRIPTION
If NativeToOVS was successful, then simply assign the value and break
out of the switch statement, but continue with the loop. Prior to this
change, only a single pointer value was assigned, and then regardless of
success or failure, ApplyModifications returned with the error code,
even if it was nil. That skipped other valid Modifications if several of
them assigned a NativeToOvs pointer value.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>