### PR TITLE
cache: remove one Clone() from Populate2 modify operation

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -278,21 +278,21 @@ func (r *RowCache) Create(uuid string, m model.Model, checkIndexes bool) error {
 	return nil
 }
 
-// Update updates the content in the cache
-func (r *RowCache) Update(uuid string, m model.Model, checkIndexes bool) error {
+// Update updates the content in the cache and returns the original (pre-update) model
+func (r *RowCache) Update(uuid string, m model.Model, checkIndexes bool) (model.Model, error) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 	if _, ok := r.cache[uuid]; !ok {
-		return NewErrCacheInconsistent(fmt.Sprintf("cannot update row %s as it does not exist in the cache", uuid))
+		return nil, NewErrCacheInconsistent(fmt.Sprintf("cannot update row %s as it does not exist in the cache", uuid))
 	}
 	oldRow := model.Clone(r.cache[uuid])
 	oldInfo, err := r.dbModel.NewModelInfo(oldRow)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	newInfo, err := r.dbModel.NewModelInfo(m)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	newIndexes := r.newIndexes()
 	var errs []error
@@ -301,11 +301,11 @@ func (r *RowCache) Update(uuid string, m model.Model, checkIndexes bool) error {
 		var err error
 		oldVal, err := valueFromIndex(oldInfo, indexSpec.columns)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		newVal, err := valueFromIndex(newInfo, indexSpec.columns)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		// if old and new values are the same, don't worry
@@ -336,7 +336,7 @@ func (r *RowCache) Update(uuid string, m model.Model, checkIndexes bool) error {
 		}
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("%+v", errs)
+		return nil, fmt.Errorf("%+v", errs)
 	}
 	// write indexes
 	for k1, v1 := range newIndexes {
@@ -349,7 +349,7 @@ func (r *RowCache) Update(uuid string, m model.Model, checkIndexes bool) error {
 		}
 	}
 	r.cache[uuid] = model.Clone(m)
-	return nil
+	return oldRow, nil
 }
 
 func (r *RowCache) IndexExists(row model.Model) error {
@@ -929,10 +929,10 @@ func (t *TableCache) Populate(tableUpdates ovsdb.TableUpdates) error {
 				}
 				if existing := tCache.Row(uuid); existing != nil {
 					if !model.Equal(newModel, existing) {
-						logger.V(5).Info("updating row", "old:", fmt.Sprintf("%+v", existing), "new", fmt.Sprintf("%+v", newModel))
-						if err := tCache.Update(uuid, newModel, false); err != nil {
+						if _, err := tCache.Update(uuid, newModel, false); err != nil {
 							return err
 						}
+						logger.V(5).Info("updated row", "old:", fmt.Sprintf("%+v", existing), "new", fmt.Sprintf("%+v", newModel))
 						t.eventProcessor.AddEvent(updateEvent, table, existing, newModel)
 					}
 					// no diff
@@ -996,20 +996,20 @@ func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) error {
 				}
 				t.eventProcessor.AddEvent(addEvent, table, nil, m)
 			case row.Modify != nil:
-				existing := tCache.Row(uuid)
-				if existing == nil {
+				modified := tCache.Row(uuid)
+				if modified == nil {
 					return NewErrCacheInconsistent(fmt.Sprintf("row with uuid %s does not exist", uuid))
 				}
-				modified := model.Clone(existing)
-				err := t.ApplyModifications(table, modified, *row.Modify)
+				changed, err := t.ApplyModifications(table, modified, *row.Modify)
 				if err != nil {
 					return fmt.Errorf("unable to apply row modifications: %w", err)
 				}
-				if !model.Equal(modified, existing) {
-					logger.V(5).Info("updating row", "old", fmt.Sprintf("%+v", existing), "new", fmt.Sprintf("%+v", modified))
-					if err := tCache.Update(uuid, modified, false); err != nil {
+				if changed {
+					existing, err := tCache.Update(uuid, modified, false)
+					if err != nil {
 						return err
 					}
+					logger.V(5).Info("updated row", "old", fmt.Sprintf("%+v", existing), "new", fmt.Sprintf("%+v", modified))
 					t.eventProcessor.AddEvent(updateEvent, table, existing, modified)
 				}
 			case row.Delete != nil:
@@ -1226,24 +1226,26 @@ func (t *TableCache) CreateModel(tableName string, row *ovsdb.Row, uuid string) 
 	return model, nil
 }
 
-// ApplyModifications applies the contents of a RowUpdate2.Modify to a model
+// ApplyModifications applies the contents of a RowUpdate2.Modify to a model.
+// It returns true if any changes were actually applied.
 // nolint: gocyclo
-func (t *TableCache) ApplyModifications(tableName string, base model.Model, update ovsdb.Row) error {
+func (t *TableCache) ApplyModifications(tableName string, base model.Model, update ovsdb.Row) (bool, error) {
 	if !t.dbModel.Valid() {
-		return fmt.Errorf("database model not valid")
+		return false, fmt.Errorf("database model not valid")
 	}
 	table := t.dbModel.Schema.Table(tableName)
 	if table == nil {
-		return fmt.Errorf("table %s not found", tableName)
+		return false, fmt.Errorf("table %s not found", tableName)
 	}
 	schema := t.dbModel.Schema.Table(tableName)
 	if schema == nil {
-		return fmt.Errorf("no schema for table %s", tableName)
+		return false, fmt.Errorf("no schema for table %s", tableName)
 	}
 	info, err := t.dbModel.NewModelInfo(base)
 	if err != nil {
-		return err
+		return false, err
 	}
+	modified := false
 	for k, v := range update {
 		if k == "_uuid" {
 			continue
@@ -1251,7 +1253,7 @@ func (t *TableCache) ApplyModifications(tableName string, base model.Model, upda
 
 		current, err := info.FieldByColumn(k)
 		if err != nil {
-			return err
+			return modified, err
 		}
 
 		var value interface{}
@@ -1262,19 +1264,20 @@ func (t *TableCache) ApplyModifications(tableName string, base model.Model, upda
 			value, err = ovsdb.OvsToNativeSlice(schema.Column(k).TypeObj.Key.Type, v)
 		}
 		if err != nil {
-			return err
+			return modified, err
 		}
 		nv := reflect.ValueOf(value)
 
 		switch reflect.ValueOf(current).Kind() {
 		case reflect.Slice, reflect.Array:
 			// The difference between two sets are all elements that only belong to one of the sets.
-			// Iterate new values
+			// If a value in the update set exists in the set, it will be removed from the base set.
+			// If a value in the update set does not exist in the set, it will be added to the base set.
 			for i := 0; i < nv.Len(); i++ {
 				// search for match in base values
 				baseValue, err := info.FieldByColumn(k)
 				if err != nil {
-					return err
+					return modified, err
 				}
 				bv := reflect.ValueOf(baseValue)
 				var found bool
@@ -1285,8 +1288,9 @@ func (t *TableCache) ApplyModifications(tableName string, base model.Model, upda
 						newValue := reflect.AppendSlice(bv.Slice(0, j), bv.Slice(j+1, bv.Len()))
 						err = info.SetField(k, newValue.Interface())
 						if err != nil {
-							return err
+							return modified, err
 						}
+						modified = true
 						break
 					}
 				}
@@ -1294,35 +1298,39 @@ func (t *TableCache) ApplyModifications(tableName string, base model.Model, upda
 					newValue := reflect.Append(bv, nv.Index(i))
 					err = info.SetField(k, newValue.Interface())
 					if err != nil {
-						return err
+						return modified, err
 					}
+					modified = true
 				}
 			}
 		case reflect.Ptr:
 			// if NativeToOVS was successful, then simply assign
-			if nv.Type() == reflect.ValueOf(current).Type() {
+			bv := reflect.ValueOf(current)
+			if (nv.Type() == bv.Type()) && !reflect.DeepEqual(nv.Interface(), bv.Interface()) {
 				err = info.SetField(k, nv.Interface())
 				if err != nil {
-					return err
+					return modified, err
 				}
+				modified = true
 				break
 			}
 			// With a pointer type, an update value could be a set with 2 elements [old, new]
 			if nv.Len() != 2 {
-				return fmt.Errorf("expected a slice with 2 elements for update: %+v", update)
+				return modified, fmt.Errorf("expected a slice with 2 elements for update: %+v", update)
 			}
 			// the new value is the value in the slice which isn't equal to the existing string
 			for i := 0; i < nv.Len(); i++ {
 				baseValue, err := info.FieldByColumn(k)
 				if err != nil {
-					return err
+					return modified, err
 				}
 				bv := reflect.ValueOf(baseValue)
-				if nv.Index(i) != bv {
+				if !reflect.DeepEqual(nv.Index(i).Addr().Interface(), bv.Interface()) {
 					err = info.SetField(k, nv.Index(i).Addr().Interface())
 					if err != nil {
-						return err
+						return modified, err
 					}
+					modified = true
 				}
 			}
 		case reflect.Map:
@@ -1333,9 +1341,8 @@ func (t *TableCache) ApplyModifications(tableName string, base model.Model, upda
 
 			baseValue, err := info.FieldByColumn(k)
 			if err != nil {
-				return err
+				return modified, err
 			}
-
 			bv := reflect.ValueOf(baseValue)
 			if bv.IsNil() {
 				bv = reflect.MakeMap(nv.Type())
@@ -1350,12 +1357,15 @@ func (t *TableCache) ApplyModifications(tableName string, base model.Model, upda
 				// key does not exist, add it
 				if !existingValue.IsValid() {
 					bv.SetMapIndex(mk, mv)
+					modified = true
 				} else if reflect.DeepEqual(mv.Interface(), existingValue.Interface()) {
 					// delete it
 					bv.SetMapIndex(mk, reflect.Value{})
+					modified = true
 				} else {
 					// set new value
 					bv.SetMapIndex(mk, mv)
+					modified = true
 				}
 			}
 			if len(bv.MapKeys()) == 0 {
@@ -1363,18 +1373,22 @@ func (t *TableCache) ApplyModifications(tableName string, base model.Model, upda
 			}
 			err = info.SetField(k, bv.Interface())
 			if err != nil {
-				return err
+				return modified, err
 			}
 
 		default:
 			// For columns with single value, the difference is the value of the new column.
-			err = info.SetField(k, value)
-			if err != nil {
-				return err
+			bv := reflect.ValueOf(current)
+			if !reflect.DeepEqual(nv.Interface(), bv.Interface()) {
+				err = info.SetField(k, value)
+				if err != nil {
+					return modified, err
+				}
+				modified = true
 			}
 		}
 	}
-	return nil
+	return modified, nil
 }
 
 func valueFromIndex(info *mapper.Info, columnKeys []model.ColumnKey) (interface{}, error) {

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -18,6 +18,36 @@ type testModel struct {
 	UUID string `ovsdb:"_uuid"`
 	Foo  string `ovsdb:"foo"`
 	Bar  string `ovsdb:"bar"`
+	Baz  int `ovsdb:"baz"`
+}
+
+const testSchemaFmt string = `{
+  "name": "Open_vSwitch",
+  "tables": {
+    "Open_vSwitch": {
+`
+
+const testSchemaFmt2 string = `
+      "columns": {
+        "foo": {
+          "type": "string"
+        },
+        "bar": {
+          "type": "string"
+        },
+        "baz": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}`
+
+func getTestSchema(indexes string) []byte {
+	if len(indexes) > 0 {
+		return []byte(testSchemaFmt + fmt.Sprintf(`"indexes": [%s],`, indexes) + testSchemaFmt2)
+	}
+	return []byte(testSchemaFmt + testSchemaFmt2)
 }
 
 func TestRowCache_Row(t *testing.T) {
@@ -85,23 +115,7 @@ func TestRowCacheCreate(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
 	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	require.Nil(t, err)
-	err = json.Unmarshal([]byte(`
-		 {"name": "Open_vSwitch",
-		  "tables": {
-		    "Open_vSwitch": {
-			  "indexes": [["foo"]],
-		      "columns": {
-		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
-		      }
-		    }
-		 }
-	     }
-	`), &schema)
+	err = json.Unmarshal(getTestSchema(`["foo"]`), &schema)
 	require.Nil(t, err)
 	testData := Data{
 		"Open_vSwitch": map[string]model.Model{"bar": &testModel{Foo: "bar"}},
@@ -186,21 +200,7 @@ func TestRowCacheCreateClientIndex(t *testing.T) {
 		},
 	})
 	require.Nil(t, err)
-	err = json.Unmarshal([]byte(`{
-		"name": "Open_vSwitch",
-		"tables": {
-		  "Open_vSwitch": {
-		    "columns": {
-		      "foo": {
-			    "type": "string"
-			  },
-			  "bar": {
-			    "type": "string"
-			  }
-		    }
-		  }
-		}
-	}`), &schema)
+	err = json.Unmarshal(getTestSchema(""), &schema)
 	require.Nil(t, err)
 	testData := Data{
 		"Open_vSwitch": map[string]model.Model{"bar": &testModel{Foo: "bar"}},
@@ -263,23 +263,7 @@ func TestRowCacheCreateMultiIndex(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
 	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	require.Nil(t, err)
-	err = json.Unmarshal([]byte(`
-		 {"name": "Open_vSwitch",
-		  "tables": {
-		    "Open_vSwitch": {
-			  "indexes": [["foo", "bar"]],
-		      "columns": {
-		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
-		      }
-		    }
-		 }
-	     }
-	`), &schema)
+	err = json.Unmarshal(getTestSchema(`["foo", "bar"]`), &schema)
 	require.Nil(t, err)
 	index := newIndexFromColumns("foo", "bar")
 	testData := Data{
@@ -533,23 +517,7 @@ func TestRowCacheUpdate(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
 	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	require.Nil(t, err)
-	err = json.Unmarshal([]byte(`
-		 {"name": "Open_vSwitch",
-		  "tables": {
-		    "Open_vSwitch": {
-			  "indexes": [["foo"]],
-		      "columns": {
-		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
-		      }
-		    }
-		 }
-	     }
-	`), &schema)
+	err = json.Unmarshal(getTestSchema(`["foo"]`), &schema)
 	require.Nil(t, err)
 	testData := Data{
 		"Open_vSwitch": map[string]model.Model{
@@ -629,21 +597,7 @@ func TestRowCacheUpdateClientIndex(t *testing.T) {
 			},
 		},
 	})
-	err = json.Unmarshal([]byte(`{
-		"name": "Open_vSwitch",
-		"tables": {
-		  "Open_vSwitch": {
-		    "columns": {
-		      "foo": {
-			    "type": "string"
-			  },
-			  "bar": {
-			    "type": "string"
-			  }
-		    }
-		  }
-		}
-	}`), &schema)
+	err = json.Unmarshal(getTestSchema(""), &schema)
 	require.Nil(t, err)
 	testData := Data{
 		"Open_vSwitch": map[string]model.Model{
@@ -729,23 +683,7 @@ func TestRowCacheUpdateMultiIndex(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
 	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	require.Nil(t, err)
-	err = json.Unmarshal([]byte(`
-		 {"name": "Open_vSwitch",
-		  "tables": {
-		    "Open_vSwitch": {
-			  "indexes": [["foo", "bar"]],
-		      "columns": {
-		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
-		      }
-		    }
-		 }
-	     }
-	`), &schema)
+	err = json.Unmarshal(getTestSchema(`["foo", "bar"]`), &schema)
 	require.Nil(t, err)
 	index := newIndexFromColumns("foo", "bar")
 	testData := Data{
@@ -1011,23 +949,7 @@ func TestRowCacheDelete(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
 	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	require.Nil(t, err)
-	err = json.Unmarshal([]byte(`
-		 {"name": "Open_vSwitch",
-		  "tables": {
-		    "Open_vSwitch": {
-			  "indexes": [["foo"]],
-		      "columns": {
-		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
-		      }
-		    }
-		 }
-	     }
-	`), &schema)
+	err = json.Unmarshal(getTestSchema(`["foo"]`), &schema)
 	require.Nil(t, err)
 	testData := Data{
 		"Open_vSwitch": map[string]model.Model{
@@ -1340,23 +1262,7 @@ func TestTableCacheTable(t *testing.T) {
 	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	assert.Nil(t, err)
 	var schema ovsdb.DatabaseSchema
-	err = json.Unmarshal([]byte(`
-		 {"name": "Open_vSwitch",
-		  "tables": {
-		    "Open_vSwitch": {
-			  "indexes": [["foo"]],
-		      "columns": {
-		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
-		      }
-		    }
-		 }
-	     }
-	`), &schema)
+	err = json.Unmarshal(getTestSchema(`["foo"]`), &schema)
 	assert.Nil(t, err)
 	dbModel, errs := model.NewDatabaseModel(schema, db)
 	require.Empty(t, errs)
@@ -1407,8 +1313,11 @@ func TestTableCacheTables(t *testing.T) {
 			  "type": "string"
 			},
 			"bar": {
-				"type": "string"
-			  }
+			  "type": "string"
+			},
+			"baz": {
+			  "type": "integer"
+			}
 		      }
 		    },
 		    "test2": {
@@ -1417,8 +1326,11 @@ func TestTableCacheTables(t *testing.T) {
 			  "type": "string"
 			},
 			"bar": {
-				"type": "string"
-			  }
+			  "type": "string"
+			},
+			"baz": {
+			  "type": "integer"
+			}
 		      }
 		    },
 		    "test3": {
@@ -1427,8 +1339,11 @@ func TestTableCacheTables(t *testing.T) {
 			  "type": "string"
 			},
 			"bar": {
-				"type": "string"
-			  }
+			  "type": "string"
+			},
+			"baz": {
+			  "type": "integer"
+			}
 		      }
 		    }
 		 }
@@ -1473,23 +1388,7 @@ func TestTableCache_populate(t *testing.T) {
 	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	assert.Nil(t, err)
 	var schema ovsdb.DatabaseSchema
-	err = json.Unmarshal([]byte(`
-		 {"name": "Open_vSwitch",
-		  "tables": {
-		    "Open_vSwitch": {
-			  "indexes": [["foo"]],
-		      "columns": {
-		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
-		      }
-		    }
-		 }
-	     }
-	`), &schema)
+	err = json.Unmarshal(getTestSchema(`["foo"]`), &schema)
 	assert.Nil(t, err)
 	dbModel, errs := model.NewDatabaseModel(schema, db)
 	require.Empty(t, errs)
@@ -1543,23 +1442,7 @@ func TestTableCachePopulate(t *testing.T) {
 	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	assert.Nil(t, err)
 	var schema ovsdb.DatabaseSchema
-	err = json.Unmarshal([]byte(`
-		 {"name": "Open_vSwitch",
-		  "tables": {
-		    "Open_vSwitch": {
-			  "indexes": [["foo"]],
-		      "columns": {
-		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
-		      }
-		    }
-		 }
-	     }
-	`), &schema)
+	err = json.Unmarshal(getTestSchema(`["foo"]`), &schema)
 	assert.Nil(t, err)
 	dbModel, errs := model.NewDatabaseModel(schema, db)
 	require.Empty(t, errs)
@@ -1612,23 +1495,7 @@ func TestTableCachePopulate2(t *testing.T) {
 	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	assert.Nil(t, err)
 	var schema ovsdb.DatabaseSchema
-	err = json.Unmarshal([]byte(`
-		 {"name": "Open_vSwitch",
-		  "tables": {
-		    "Open_vSwitch": {
-			  "indexes": [["foo"]],
-		      "columns": {
-		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
-		      }
-		    }
-		 }
-	     }
-	`), &schema)
+	err = json.Unmarshal(getTestSchema(`["foo"]`), &schema)
 	assert.Nil(t, err)
 	dbModel, errs := model.NewDatabaseModel(schema, db)
 	require.Empty(t, errs)
@@ -1702,23 +1569,7 @@ func TestTableCachePopulate2BrokenIndexes(t *testing.T) {
 	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	assert.Nil(t, err)
 	var schema ovsdb.DatabaseSchema
-	err = json.Unmarshal([]byte(`
-		 {"name": "Open_vSwitch",
-		  "tables": {
-		    "Open_vSwitch": {
-			  "indexes": [["foo"]],
-		      "columns": {
-		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
-		      }
-		    }
-		 }
-	     }
-	`), &schema)
+	err = json.Unmarshal(getTestSchema(`["foo"]`), &schema)
 	assert.Nil(t, err)
 	dbModel, errs := model.NewDatabaseModel(schema, db)
 	require.Empty(t, errs)
@@ -1807,13 +1658,7 @@ func TestEventProcessor_AddEvent(t *testing.T) {
 }
 
 func TestIndex(t *testing.T) {
-	type indexTestModel struct {
-		UUID string `ovsdb:"_uuid"`
-		Foo  string `ovsdb:"foo"`
-		Bar  string `ovsdb:"bar"`
-		Baz  int    `ovsdb:"baz"`
-	}
-	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &indexTestModel{}})
+	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	assert.Nil(t, err)
 	db.SetIndexes(map[string][]model.ClientIndex{
 		"Open_vSwitch": {
@@ -1837,26 +1682,7 @@ func TestIndex(t *testing.T) {
 		},
 	})
 	var schema ovsdb.DatabaseSchema
-	err = json.Unmarshal([]byte(`
-		 {"name": "Open_vSwitch",
-		  "tables": {
-		    "Open_vSwitch": {
-			  "indexes": [["foo"], ["bar","baz"]],
-		      "columns": {
-		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			},
-			"baz": {
-				"type": "integer"
-			}
-		      }
-		    }
-		 }
-	     }
-	`), &schema)
+	err = json.Unmarshal(getTestSchema(`["foo"], ["bar","baz"]`), &schema)
 	assert.Nil(t, err)
 	dbModel, errs := model.NewDatabaseModel(schema, db)
 	assert.Empty(t, errs)
@@ -1864,7 +1690,7 @@ func TestIndex(t *testing.T) {
 	assert.Nil(t, err)
 	table := tc.Table("Open_vSwitch")
 
-	obj := &indexTestModel{
+	obj := &testModel{
 		UUID: "test1",
 		Foo:  "foo",
 		Bar:  "bar",
@@ -1873,7 +1699,7 @@ func TestIndex(t *testing.T) {
 	err = table.Create(obj.UUID, obj, true)
 	assert.Nil(t, err)
 
-	obj2 := &indexTestModel{
+	obj2 := &testModel{
 		UUID: "test2",
 		Foo:  "foo2",
 		Bar:  "bar",
@@ -1957,23 +1783,7 @@ func setupRowByModelSingleIndex(t require.TestingT) (*testModel, *TableCache) {
 	var schema ovsdb.DatabaseSchema
 	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	require.Nil(t, err)
-	err = json.Unmarshal([]byte(`
-		 {"name": "Open_vSwitch",
-		  "tables": {
-		    "Open_vSwitch": {
-			  "indexes": [["foo"]],
-		      "columns": {
-		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-			  "type": "string"
-			}
-		      }
-		    }
-		 }
-	     }
-	`), &schema)
+	err = json.Unmarshal(getTestSchema(`["foo"]`), &schema)
 	require.NoError(t, err)
 	myFoo := &testModel{Foo: "foo", Bar: "foo"}
 	testData := Data{
@@ -2075,23 +1885,7 @@ func TestTableCacheRowByModelTwoIndexes(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
 	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	require.Nil(t, err)
-	err = json.Unmarshal([]byte(`
-		 {"name": "Open_vSwitch",
-		  "tables": {
-		    "Open_vSwitch": {
-			  "indexes": [["foo"], ["bar"]],
-		      "columns": {
-		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
-		      }
-		    }
-		 }
-	     }
-	`), &schema)
+	err = json.Unmarshal(getTestSchema(`["foo"], ["bar"]`), &schema)
 	require.NoError(t, err)
 	myFoo := &testModel{Foo: "foo", Bar: "foo"}
 	testData := Data{
@@ -2128,23 +1922,7 @@ func TestTableCacheRowByModelMultiIndex(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
 	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})
 	require.Nil(t, err)
-	err = json.Unmarshal([]byte(`
-		 {"name": "Open_vSwitch",
-		  "tables": {
-		    "Open_vSwitch": {
-			  "indexes": [["foo", "bar"]],
-		      "columns": {
-		        "foo": {
-			  "type": "string"
-			},
-			"bar": {
-				"type": "string"
-			  }
-		      }
-		    }
-		 }
-	     }
-	`), &schema)
+	err = json.Unmarshal(getTestSchema(`["foo", "bar"]`), &schema)
 	require.NoError(t, err)
 	myFoo := &testModel{Foo: "foo", Bar: "foo"}
 	testData := Data{


### PR DESCRIPTION
tCache.Row() clones the model to get 'existing'. The another explicit
Clone() is done to get 'modified' which is passed to ApplyModifications()
and updated with the ovsdb row update. If 'modified' and 'existing'
are different, then 'modified' is passed to Update() which does two more
clones. First for the original row to (presumably?) nothing in the old
row changes underneath Update() while it's processing the update.
Finally Update() clones 'modified' and assigns that as the new row
in the cache.

So, we clone the cache row into 'existing', clone that into 'modified',
update 'modified', clone 'modified' again to update the cache, and then
throw it away. Ideally we could assign 'modified' to the cache instead of
clone it again, but we have to pass it to the event handlers and we have
to ensure it won't be changed underneath the event handler after we've
released the row cache lock.

Since Populate2() owns 'modified' (at least until it hands it off to
the event handler) we can change a few things around and get rid of the
first clone from 'existing' to 'modified'. 'existing'-s only purpose
was to enable the model.Equal() comparison to know if we should actually
update the cache, but since ApplyModifications() makes the changes it
knows when 'modified' is changed. Use that instead of model.Equal().

Lastly, the event handler also used 'existing' but since we're
replacing the original model in the row cache with 'modified' we can
return the original model for the event handler in place of 'existing'
since 'existing' was (previous to this patch) cloned from the original
model anyway.

All this avoids a Clone() in a hotpath. Testcases and benchmarks added.

```
Before (cpu: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz)
---
BenchmarkPopulate2UpdateArray-8   	      37	  27568442 ns/op
BenchmarkPopulate2UpdateArray-8   	      38	  27635436 ns/op
BenchmarkPopulate2UpdateArray-8   	      40	  27003451 ns/op

BenchmarkPopulate2UpdateArray-8   	      37	  29406288 ns/op
BenchmarkPopulate2UpdateArray-8   	      37	  27819324 ns/op
BenchmarkPopulate2UpdateArray-8   	      43	  27707464 ns/op

BenchmarkPopulate2UpdateArray-8   	      36	  29182002 ns/op
BenchmarkPopulate2UpdateArray-8   	      37	  28766003 ns/op
BenchmarkPopulate2UpdateArray-8   	      39	  27447263 ns/op

BenchmarkPopulate2UpdateArray-8   	      34	  30350489 ns/op
BenchmarkPopulate2UpdateArray-8   	      42	  27639410 ns/op
BenchmarkPopulate2UpdateArray-8   	      39	  27781289 ns/op

After (cpu: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz)
---
BenchmarkPopulate2UpdateArray-8   	      40	  25367097 ns/op
BenchmarkPopulate2UpdateArray-8   	      49	  25201249 ns/op
BenchmarkPopulate2UpdateArray-8   	      45	  24333118 ns/op

BenchmarkPopulate2UpdateArray-8   	      46	  24455417 ns/op
BenchmarkPopulate2UpdateArray-8   	      46	  25009966 ns/op
BenchmarkPopulate2UpdateArray-8   	      42	  24985884 ns/op

BenchmarkPopulate2UpdateArray-8   	      39	  26141899 ns/op
BenchmarkPopulate2UpdateArray-8   	      44	  25563094 ns/op
BenchmarkPopulate2UpdateArray-8   	      43	  25235681 ns/op

BenchmarkPopulate2UpdateArray-8   	      39	  26473300 ns/op
BenchmarkPopulate2UpdateArray-8   	      44	  25417718 ns/op
BenchmarkPopulate2UpdateArray-8   	      42	  25356652 ns/op
```