### PR TITLE
cache: optimize ApplyModifications() set iteration

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1281,8 +1281,9 @@ func (t *TableCache) ApplyModifications(tableName string, base model.Model, upda
 				}
 				bv := reflect.ValueOf(baseValue)
 				var found bool
+				newVal := nv.Index(i).Interface()
 				for j := 0; j < bv.Len(); j++ {
-					if bv.Index(j).Interface() == nv.Index(i).Interface() {
+					if bv.Index(j).Interface() == newVal {
 						// found a match, delete from slice
 						found = true
 						newValue := reflect.AppendSlice(bv.Slice(0, j), bv.Slice(j+1, bv.Len()))


### PR DESCRIPTION
Lift the new value access out of the hot loop and save
a bunch of time iterating over large sets.

```
Before
---
BenchmarkTableCacheApplyModificationsSet-8   	     268	   4664892 ns/op
BenchmarkTableCacheApplyModificationsSet-8   	     266	   4501507 ns/op
BenchmarkTableCacheApplyModificationsSet-8   	     229	   4500050 ns/op

BenchmarkTableCacheApplyModificationsSet-8   	     268	   4466431 ns/op
BenchmarkTableCacheApplyModificationsSet-8   	     271	   4645624 ns/op
BenchmarkTableCacheApplyModificationsSet-8   	     276	   4416883 ns/op

After
---
BenchmarkTableCacheApplyModificationsSet-8   	     520	   2280201 ns/op
BenchmarkTableCacheApplyModificationsSet-8   	     480	   2581277 ns/op
BenchmarkTableCacheApplyModificationsSet-8   	     469	   2371769 ns/op

BenchmarkTableCacheApplyModificationsSet-8   	     494	   2492495 ns/op
BenchmarkTableCacheApplyModificationsSet-8   	     522	   2666051 ns/op
BenchmarkTableCacheApplyModificationsSet-8   	     489	   2602648 ns/op
```