### PR TITLE
cache: stop always evaluating debug logging arguments in hotpaths

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -920,8 +920,8 @@ func (t *TableCache) Populate(tableUpdates ovsdb.TableUpdates) error {
 		}
 		tCache := t.cache[table]
 		for uuid, row := range updates {
-			logger := t.logger.WithValues("uuid", uuid, "table", table)
-			logger.V(5).Info("processing update")
+			dbgLogger := t.logger.WithValues("uuid", uuid, "table", table).V(5)
+			dbgLogger.Info("processing update")
 			if row.New != nil {
 				newModel, err := t.CreateModel(table, row.New, uuid)
 				if err != nil {
@@ -932,13 +932,17 @@ func (t *TableCache) Populate(tableUpdates ovsdb.TableUpdates) error {
 						if _, err := tCache.Update(uuid, newModel, false); err != nil {
 							return err
 						}
-						logger.V(5).Info("updated row", "old:", fmt.Sprintf("%+v", existing), "new", fmt.Sprintf("%+v", newModel))
+						if dbgLogger.Enabled() {
+							dbgLogger.Info("updated row", "old:", fmt.Sprintf("%+v", existing), "new", fmt.Sprintf("%+v", newModel))
+						}
 						t.eventProcessor.AddEvent(updateEvent, table, existing, newModel)
 					}
 					// no diff
 					continue
 				}
-				logger.V(5).Info("creating row", "model", fmt.Sprintf("%+v", newModel))
+				if dbgLogger.Enabled() {
+					dbgLogger.Info("creating row", "model", fmt.Sprintf("%+v", newModel))
+				}
 				if err := tCache.Create(uuid, newModel, false); err != nil {
 					return err
 				}
@@ -949,7 +953,9 @@ func (t *TableCache) Populate(tableUpdates ovsdb.TableUpdates) error {
 				if err != nil {
 					return err
 				}
-				logger.V(5).Info("deleting row", "model", fmt.Sprintf("%+v", oldModel))
+				if dbgLogger.Enabled() {
+					dbgLogger.Info("deleting row", "model", fmt.Sprintf("%+v", oldModel))
+				}
 				if err := tCache.Delete(uuid); err != nil {
 					return err
 				}
@@ -972,15 +978,17 @@ func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) error {
 		}
 		tCache := t.cache[table]
 		for uuid, row := range updates {
-			logger := t.logger.WithValues("uuid", uuid, "table", table)
-			logger.V(5).Info("processing update")
+			dbgLogger := t.logger.WithValues("uuid", uuid, "table", table).V(5)
+			dbgLogger.Info("processing update")
 			switch {
 			case row.Initial != nil:
 				m, err := t.CreateModel(table, row.Initial, uuid)
 				if err != nil {
 					return err
 				}
-				logger.V(5).Info("creating row", "model", fmt.Sprintf("%+v", m))
+				if dbgLogger.Enabled() {
+					dbgLogger.Info("creating row", "model", fmt.Sprintf("%+v", m))
+				}
 				if err := tCache.Create(uuid, m, false); err != nil {
 					return err
 				}
@@ -990,7 +998,9 @@ func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) error {
 				if err != nil {
 					return err
 				}
-				logger.V(5).Info("inserting row", "model", fmt.Sprintf("%+v", m))
+				if dbgLogger.Enabled() {
+					dbgLogger.Info("inserting row", "model", fmt.Sprintf("%+v", m))
+				}
 				if err := tCache.Create(uuid, m, false); err != nil {
 					return err
 				}
@@ -1009,7 +1019,9 @@ func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) error {
 					if err != nil {
 						return err
 					}
-					logger.V(5).Info("updated row", "old", fmt.Sprintf("%+v", existing), "new", fmt.Sprintf("%+v", modified))
+					if dbgLogger.Enabled() {
+						dbgLogger.Info("updated row", "old", fmt.Sprintf("%+v", existing), "new", fmt.Sprintf("%+v", modified))
+					}
 					t.eventProcessor.AddEvent(updateEvent, table, existing, modified)
 				}
 			case row.Delete != nil:
@@ -1021,7 +1033,9 @@ func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) error {
 				if m == nil {
 					return NewErrCacheInconsistent(fmt.Sprintf("row with uuid %s does not exist", uuid))
 				}
-				logger.V(5).Info("deleting row", "model", fmt.Sprintf("%+v", m))
+				if dbgLogger.Enabled() {
+					dbgLogger.Info("deleting row", "model", fmt.Sprintf("%+v", m))
+				}
 				if err := tCache.Delete(uuid); err != nil {
 					return err
 				}


### PR DESCRIPTION
Arguments to log functions still get evaluated by Go even though
the Log() function will never be called due to the V(5).

So stop burning a ton of time constructing debug logging strings
that will never get printed anywhere, unless we've actually
got debug logging enabled.

```
Before
---
BenchmarkPopulate2UpdateArray-8   	      43	  25525739 ns/op
BenchmarkPopulate2UpdateArray-8   	      42	  24999238 ns/op
BenchmarkPopulate2UpdateArray-8   	      46	  24176152 ns/op

BenchmarkPopulate2UpdateArray-8   	      43	  26409268 ns/op
BenchmarkPopulate2UpdateArray-8   	      46	  24408124 ns/op
BenchmarkPopulate2UpdateArray-8   	      43	  25397653 ns/op

BenchmarkPopulate2UpdateArray-8   	      43	  25063454 ns/op
BenchmarkPopulate2UpdateArray-8   	      44	  24937264 ns/op
BenchmarkPopulate2UpdateArray-8   	      46	  24411459 ns/op

After
---
BenchmarkPopulate2UpdateArray-8   	      51	  22622261 ns/op
BenchmarkPopulate2UpdateArray-8   	      54	  21740579 ns/op
BenchmarkPopulate2UpdateArray-8   	      51	  22653041 ns/op

BenchmarkPopulate2UpdateArray-8   	      50	  21653251 ns/op
BenchmarkPopulate2UpdateArray-8   	      54	  22234639 ns/op
BenchmarkPopulate2UpdateArray-8   	      52	  22120362 ns/op

BenchmarkPopulate2UpdateArray-8   	      54	  22482835 ns/op
BenchmarkPopulate2UpdateArray-8   	      52	  21854665 ns/op
BenchmarkPopulate2UpdateArray-8   	      48	  22153154 ns/op
```