### PR TITLE
separate timeout values for connect and monitor

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -21,7 +21,8 @@ type options struct {
 	tlsConfig             *tls.Config
 	reconnect             bool
 	leaderOnly            bool
-	timeout               time.Duration
+	connectTimeout        time.Duration
+	monitorTimeout        time.Duration
 	backoff               backoff.BackOff
 	logger                *logr.Logger
 	registry              prometheus.Registerer
@@ -100,11 +101,21 @@ func WithLeaderOnly(leaderOnly bool) Option {
 // algorithm to use. Using WithReconnect implies that
 // requested transactions will block until the client has fully reconnected,
 // rather than immediately returning an error if there is no connection.
-func WithReconnect(timeout time.Duration, backoff backoff.BackOff) Option {
+func WithReconnect(connectTimeout time.Duration, backoff backoff.BackOff) Option {
 	return func(o *options) error {
 		o.reconnect = true
-		o.timeout = timeout
+		o.connectTimeout = connectTimeout
 		o.backoff = backoff
+		return nil
+	}
+}
+
+// WithMonitorTimeout sets the timeout for DB monitoring. If this
+// is not set, connectTimeout will be used for both tcp connect
+// and db monitoring during reconnect.
+func WithMonitorTimeout(monitorTimeout time.Duration) Option {
+	return func(o *options) error {
+		o.monitorTimeout = monitorTimeout
 		return nil
 	}
 }

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -112,7 +112,12 @@ func TestWithReconnect(t *testing.T) {
 	fn := WithReconnect(timeout, &backoff.ZeroBackOff{})
 	err := fn(opts)
 	require.NoError(t, err)
-	assert.Equal(t, timeout, opts.timeout)
+	assert.Equal(t, timeout, opts.connectTimeout)
 	assert.Equal(t, true, opts.reconnect)
 	assert.Equal(t, &backoff.ZeroBackOff{}, opts.backoff)
+	monitorTimeout := 5 * time.Second
+	fn = WithMonitorTimeout(monitorTimeout)
+	err = fn(opts)
+	require.NoError(t, err)
+	assert.Equal(t, monitorTimeout, opts.monitorTimeout)
 }


### PR DESCRIPTION
`tryEndpoint` and `monitor` in reconnect code use the same timeout context,
client may get timeout error during reconnect if the db size is too big.
This change allows client to specify `connectTimeout` and `monitorTimeout`
respectively to avoid such issue.

Signed-off-by: Xiaobin Qu <xqu@nvidia.com>