### PR TITLE
Fixes creating ovs sets for types with nil pointers

### DIFF
--- a/ovsdb/encoding_test.go
+++ b/ovsdb/encoding_test.go
@@ -59,6 +59,8 @@ func TestMap(t *testing.T) {
 }
 
 func TestSet(t *testing.T) {
+	var x *int
+	var y *string
 	tests := []struct {
 		name     string
 		input    interface{}
@@ -148,6 +150,16 @@ func TestSet(t *testing.T) {
 			"valid uuid set multiple elements",
 			[]UUID{validUUID0, validUUID1},
 			fmt.Sprintf(`["set",[["uuid","%v"],["uuid","%v"]]]`, validUUIDStr0, validUUIDStr1),
+		},
+		{
+			name:     "nil pointer of valid *int type",
+			input:    x,
+			expected: `["set",[]]`,
+		},
+		{
+			name:     "nil pointer of valid *string type",
+			input:    y,
+			expected: `["set",[]]`,
 		},
 	}
 	for _, tt := range tests {

--- a/ovsdb/set.go
+++ b/ovsdb/set.go
@@ -19,13 +19,18 @@ type OvsSet struct {
 
 // NewOvsSet creates a new OVSDB style set from a Go interface (object)
 func NewOvsSet(obj interface{}) (OvsSet, error) {
+	ovsSet := make([]interface{}, 0)
 	var v reflect.Value
 	if reflect.TypeOf(obj).Kind() == reflect.Ptr {
 		v = reflect.ValueOf(obj).Elem()
+		if v.Kind() == reflect.Invalid {
+			// must be a nil pointer, so just return an empty set
+			return OvsSet{ovsSet}, nil
+		}
 	} else {
 		v = reflect.ValueOf(obj)
 	}
-	ovsSet := make([]interface{}, 0)
+
 	switch v.Kind() {
 	case reflect.Slice, reflect.Array:
 		for i := 0; i < v.Len(); i++ {


### PR DESCRIPTION
NewOvsSet tries to get the concrete value of a pointer and then check
its type. This wont work for nil pointers that are still holding valid
types themselves. If we get a nil pointer we can simply return an empty
set.

Fixes #310

Signed-off-by: Tim Rozet <trozet@redhat.com>