### PR TITLE
client: add WhereAny() and let Where() take multiple models

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,19 @@ Once the client object is created, a generic API can be used to interact with th
 
 Others, have to be called on a `ConditionalAPI` (`Update`, `Delete`, `Mutate`). There are three ways to create a `ConditionalAPI`:
 
-**Where()**: `Where()` can be used to create a `ConditionalAPI` using a list of Condition objects. Each condition object specifies a field using a pointer
+**Where()**: `Where()` can be used to create a `ConditionalAPI` based on the index information that the provided Model contains. Example:
+
+      ls := &LogicalSwitch{UUID: "foo"}
+      ops, _ := ovs.Where(ls).Delete()
+
+It will check the field corresponding to the `_uuid` column as well as all the other schema-defined or client-defined indexes in that order of priority.
+The first available index will be used to generate a condition.
+
+**WhereAny()**: `WhereAny()` can be used to create a `ConditionalAPI` using a list of Condition objects. Each condition object specifies a field using a pointer
 to a Model's field, a `ovsdb.ConditionFunction` and a value. The type of the value depends on the type of the field being mutated. Example:
 
       ls := &LogicalSwitch{}
-      ops, _ := ovs.Where(ls, client.Condition{
+      ops, _ := ovs.WhereAny(ls, client.Condition{
           Field: &ls.Config,
           Function: ovsdb.ConditionIncludes,
           Value: map[string]string{"foo": "bar"},
@@ -61,13 +69,8 @@ to a Model's field, a `ovsdb.ConditionFunction` and a value. The type of the val
 
 The resulting `ConditionalAPI` will create one operation per condition, so all the rows that match *any* of the specified conditions will be affected.
 
-If no conditions are provided, `Where()` will create a `ConditionalAPI` based on the index information that the provided Model contains.
-It will check the field corresponding to the `_uuid` column as well as all the other schema-defined or client-defined indexes in that order of priority.
-The first available index will be used to generate a condition.
-
-**WhereAll()**: `WhereAll()` behaves like `Where()` but with *AND* semantics. The resulting `ConditionalAPI` will put all the
+**WhereAll()**: `WhereAll()` behaves like `WhereAny()` but with *AND* semantics. The resulting `ConditionalAPI` will put all the
 conditions into a single operation. Therefore the operation will affect the rows that satisfy *all* the conditions.
-
 
 **WhereCache()**: `WhereCache()` uses a function callback to filter on the local cache. It's primary use is to perform cache operations such as
 `List()`. However, it can also be used to create server-side operations (such as `Delete()`, `Update()` or `Delete()`). If used this way, it will

--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ Once the client object is created, a generic API can be used to interact with th
 
 Others, have to be called on a `ConditionalAPI` (`Update`, `Delete`, `Mutate`). There are three ways to create a `ConditionalAPI`:
 
-**Where()**: `Where()` can be used to create a `ConditionalAPI` based on the index information that the provided Model contains. Example:
+**Where()**: `Where()` can be used to create a `ConditionalAPI` based on the index information that the provided Models contain. Example:
 
       ls := &LogicalSwitch{UUID: "foo"}
-      ops, _ := ovs.Where(ls).Delete()
+      ls2 := &LogicalSwitch{UUID: "foo2"}
+      ops, _ := ovs.Where(ls, ls2).Delete()
 
 It will check the field corresponding to the `_uuid` column as well as all the other schema-defined or client-defined indexes in that order of priority.
 The first available index will be used to generate a condition.

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1659,7 +1659,8 @@ func TestTableCachePopulate2BrokenIndexes(t *testing.T) {
 	assert.False(t, ok)
 
 	t.Log("Lookup Original Insert By Index")
-	_, result := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "bar"})
+	_, result, err := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "bar"})
+	require.NoError(t, err)
 	require.NotNil(t, result)
 }
 
@@ -1841,19 +1842,31 @@ func TestTableCacheRowByModelSingleIndex(t *testing.T) {
 	myFoo, tc := setupRowByModelSingleIndex(t)
 
 	t.Run("get foo by index", func(t *testing.T) {
-		_, foo := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "foo"})
+		_, foo, err := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "foo"})
+		assert.NoError(t, err)
 		assert.NotNil(t, foo)
 		assert.Equal(t, myFoo, foo)
 	})
 
 	t.Run("get non-existent item by index", func(t *testing.T) {
-		_, baz := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "baz"})
+		_, baz, err := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "baz"})
+		assert.NoError(t, err)
 		assert.Nil(t, baz)
 	})
 
 	t.Run("no index data", func(t *testing.T) {
-		_, foo := tc.Table("Open_vSwitch").RowByModel(&testModel{Bar: "foo"})
+		_, foo, err := tc.Table("Open_vSwitch").RowByModel(&testModel{Bar: "foo"})
+		assert.NoError(t, err)
 		assert.Nil(t, foo)
+	})
+
+	t.Run("wrong model type", func(t *testing.T) {
+		type badModel struct {
+			UUID string `ovsdb:"_uuid"`
+			Baz  string `ovsdb:"baz"`
+		}
+		_, _, err := tc.Table("Open_vSwitch").RowByModel(&badModel{Baz: "baz"})
+		assert.Error(t, err)
 	})
 }
 
@@ -2040,19 +2053,22 @@ func TestTableCacheRowByModelTwoIndexes(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("get foo by Foo index", func(t *testing.T) {
-		_, foo := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "foo"})
+		_, foo, err := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "foo"})
+		assert.NoError(t, err)
 		assert.NotNil(t, foo)
 		assert.Equal(t, myFoo, foo)
 	})
 
 	t.Run("get foo by Bar index", func(t *testing.T) {
-		_, foo := tc.Table("Open_vSwitch").RowByModel(&testModel{Bar: "foo"})
+		_, foo, err := tc.Table("Open_vSwitch").RowByModel(&testModel{Bar: "foo"})
+		assert.NoError(t, err)
 		assert.NotNil(t, foo)
 		assert.Equal(t, myFoo, foo)
 	})
 
 	t.Run("get non-existent item by index", func(t *testing.T) {
-		_, baz := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "baz"})
+		_, baz, err := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "baz"})
+		assert.NoError(t, err)
 		assert.Nil(t, baz)
 	})
 
@@ -2074,18 +2090,21 @@ func TestTableCacheRowByModelMultiIndex(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("incomplete index", func(t *testing.T) {
-		_, foo := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "foo"})
+		_, foo, err := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "foo"})
+		assert.NoError(t, err)
 		assert.Nil(t, foo)
 	})
 
 	t.Run("get foo by index", func(t *testing.T) {
-		_, foo := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "foo", Bar: "foo"})
+		_, foo, err := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "foo", Bar: "foo"})
+		assert.NoError(t, err)
 		assert.NotNil(t, foo)
 		assert.Equal(t, myFoo, foo)
 	})
 
 	t.Run("get non-existent item by index", func(t *testing.T) {
-		_, baz := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "baz", Bar: "baz"})
+		_, baz, err := tc.Table("Open_vSwitch").RowByModel(&testModel{Foo: "baz", Bar: "baz"})
+		assert.NoError(t, err)
 		assert.Nil(t, baz)
 	})
 }
@@ -2413,7 +2432,8 @@ func TestTableCacheRowsByModel(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tc, err := NewTableCache(dbModel, testData, nil)
 			require.NoError(t, err)
-			rows := tc.Table("Open_vSwitch").RowsByModel(tt.model)
+			rows, err := tc.Table("Open_vSwitch").RowsByModel(tt.model)
+			require.NoError(t, err)
 			require.Equal(t, tt.rows, rows)
 		})
 	}

--- a/client/api.go
+++ b/client/api.go
@@ -170,12 +170,12 @@ func (a api) List(ctx context.Context, result interface{}) error {
 
 // Where returns a conditionalAPI based on a Condition list
 func (a api) Where(model model.Model, cond ...model.Condition) ConditionalAPI {
-	return newConditionalAPI(a.cache, a.conditionFromModel(false, false, model, cond...), a.logger)
+	return newConditionalAPI(a.cache, a.conditionFromModel(false, model, cond...), a.logger)
 }
 
 // Where returns a conditionalAPI based on a Condition list
 func (a api) WhereAll(model model.Model, cond ...model.Condition) ConditionalAPI {
-	return newConditionalAPI(a.cache, a.conditionFromModel(true, false, model, cond...), a.logger)
+	return newConditionalAPI(a.cache, a.conditionFromModel(true, model, cond...), a.logger)
 }
 
 // Where returns a conditionalAPI based a Predicate
@@ -199,7 +199,7 @@ func (a api) conditionFromFunc(predicate interface{}) Conditional {
 }
 
 // FromModel returns a Condition from a model and a list of fields
-func (a api) conditionFromModel(any bool, cache bool, model model.Model, cond ...model.Condition) Conditional {
+func (a api) conditionFromModel(any bool, model model.Model, cond ...model.Condition) Conditional {
 	var conditional Conditional
 	var err error
 

--- a/client/api.go
+++ b/client/api.go
@@ -259,8 +259,10 @@ func (a api) Get(ctx context.Context, m model.Model) error {
 		return ErrNotFound
 	}
 
-	_, found := tableCache.RowByModel(m)
-	if found == nil {
+	_, found, err := tableCache.RowByModel(m)
+	if err != nil {
+		return err
+	} else if found == nil {
 		return ErrNotFound
 	}
 

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -173,6 +173,13 @@ func TestAPIListSimple(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Len(t, result, len(lscacheList))
 	})
+
+	t.Run("ApiList: fails if conditional is an error", func(t *testing.T) {
+		result := []testLogicalSwitch{}
+		api := newConditionalAPI(tcache, newErrorConditional(fmt.Errorf("error")), &discardLogger)
+		err := api.List(context.Background(), &result)
+		assert.NotNil(t, err)
+	})
 }
 
 func TestAPIListPredicate(t *testing.T) {
@@ -1074,6 +1081,13 @@ func TestAPIMutate(t *testing.T) {
 			},
 			err: true,
 		},
+		{
+			name: "fails if conditional is an error",
+			condition: func(a API) ConditionalAPI {
+				return newConditionalAPI(nil, newErrorConditional(fmt.Errorf("error")), &discardLogger)
+			},
+			err: true,
+		},
 	}
 	for _, tt := range test {
 		t.Run(fmt.Sprintf("ApiMutate: %s", tt.name), func(t *testing.T) {
@@ -1432,6 +1446,15 @@ func TestAPIUpdate(t *testing.T) {
 			},
 			err: true,
 		},
+		{
+			name: "fails if conditional is an error",
+			condition: func(a API) ConditionalAPI {
+				return newConditionalAPI(tcache, newErrorConditional(fmt.Errorf("error")), &discardLogger)
+			},
+			prepare: func(t *testLogicalSwitchPort) {
+			},
+			err: true,
+		},
 	}
 	for _, tt := range test {
 		t.Run(fmt.Sprintf("ApiUpdate: %s", tt.name), func(t *testing.T) {
@@ -1648,6 +1671,13 @@ func TestAPIDelete(t *testing.T) {
 					&testLogicalSwitchPort{UUID: aUUID1},
 					&testLogicalSwitch{UUID: aUUID2},
 				)
+			},
+			err: true,
+		},
+		{
+			name: "fails if conditional is an error",
+			condition: func(a API) ConditionalAPI {
+				return newConditionalAPI(nil, newErrorConditional(fmt.Errorf("error")), &discardLogger)
 			},
 			err: true,
 		},
@@ -1958,6 +1988,16 @@ func TestAPIWait(t *testing.T) {
 			},
 			result: []ovsdb.Operation{},
 			err:    false,
+		},
+		{
+			name: "fails if conditional is an error",
+			condition: func(a API) ConditionalAPI {
+				return newConditionalAPI(nil, newErrorConditional(fmt.Errorf("error")), &discardLogger)
+			},
+			prepare: func() (model.Model, []interface{}) {
+				return nil, nil
+			},
+			err: true,
 		},
 	}
 

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -532,7 +532,7 @@ func TestConditionFromModel(t *testing.T) {
 		t.Run(fmt.Sprintf("conditionFromModel: %s", tt.name), func(t *testing.T) {
 			cache := apiTestCache(t, nil)
 			apiIface := newAPI(cache, &discardLogger)
-			condition := apiIface.(api).conditionFromModel(false, false, tt.model, tt.conds...)
+			condition := apiIface.(api).conditionFromModel(false, tt.model, tt.conds...)
 			if tt.err {
 				assert.IsType(t, &errorConditional{}, condition)
 			} else {

--- a/client/client.go
+++ b/client/client.go
@@ -1313,8 +1313,8 @@ func (o *ovsdbClient) List(ctx context.Context, result interface{}) error {
 }
 
 // Where implements the API interface's Where function
-func (o *ovsdbClient) Where(m model.Model) ConditionalAPI {
-	return o.primaryDB().api.Where(m)
+func (o *ovsdbClient) Where(models ...model.Model) ConditionalAPI {
+	return o.primaryDB().api.Where(models...)
 }
 
 // WhereAny implements the API interface's WhereAny function

--- a/client/client.go
+++ b/client/client.go
@@ -1312,9 +1312,14 @@ func (o *ovsdbClient) List(ctx context.Context, result interface{}) error {
 	return primaryDB.api.List(ctx, result)
 }
 
-//Where implements the API interface's Where function
-func (o *ovsdbClient) Where(m model.Model, conditions ...model.Condition) ConditionalAPI {
-	return o.primaryDB().api.Where(m, conditions...)
+// Where implements the API interface's Where function
+func (o *ovsdbClient) Where(m model.Model) ConditionalAPI {
+	return o.primaryDB().api.Where(m)
+}
+
+// WhereAny implements the API interface's WhereAny function
+func (o *ovsdbClient) WhereAny(m model.Model, conditions ...model.Condition) ConditionalAPI {
+	return o.primaryDB().api.WhereAny(m, conditions...)
 }
 
 //WhereAll implements the API interface's WhereAll function

--- a/client/condition.go
+++ b/client/condition.go
@@ -62,7 +62,7 @@ func generateOvsdbConditionsFromModelConditions(dbModel model.DatabaseModel, inf
 // matching model in the database.
 type equalityConditional struct {
 	tableName string
-	model     model.Model
+	models    []model.Model
 	cache     *cache.TableCache
 }
 
@@ -77,7 +77,7 @@ func (c *equalityConditional) Matches() (map[string]model.Model, error) {
 	if tableCache == nil {
 		return nil, ErrNotFound
 	}
-	return tableCache.RowsByModel(c.model)
+	return tableCache.RowsByModels(c.models)
 }
 
 // Generate conditions based on the equality of the first available index. If
@@ -85,19 +85,28 @@ func (c *equalityConditional) Matches() (map[string]model.Model, error) {
 // based on the UUID of the found model. Otherwise, the conditions will be based
 // on the index.
 func (c *equalityConditional) Generate() ([][]ovsdb.Condition, error) {
-	models, _ := c.Matches()
+	models, err := c.Matches()
+	if err != nil && err != ErrNotFound {
+		return nil, err
+	}
 	if len(models) == 0 {
-		// no cache hits, generate condition from model we were given
-		return generateConditionsFromModels(c.cache.DatabaseModel(), map[string]model.Model{"": c.model})
+		// no cache hits, generate condition from models we were given
+		modelMap := make(map[string]model.Model, len(c.models))
+		for i, m := range c.models {
+			// generateConditionsFromModels() ignores the map keys
+			// so just use the range index
+			modelMap[fmt.Sprintf("%d", i)] = m
+		}
+		return generateConditionsFromModels(c.cache.DatabaseModel(), modelMap)
 	}
 	return generateConditionsFromModels(c.cache.DatabaseModel(), models)
 }
 
 // NewEqualityCondition creates a new equalityConditional
-func newEqualityConditional(table string, cache *cache.TableCache, model model.Model) (Conditional, error) {
+func newEqualityConditional(table string, cache *cache.TableCache, models []model.Model) (Conditional, error) {
 	return &equalityConditional{
 		tableName: table,
-		model:     model,
+		models:    models,
 		cache:     cache,
 	}, nil
 }
@@ -134,7 +143,10 @@ func (c *explicitConditional) Matches() (map[string]model.Model, error) {
 
 // Generate returns conditions based on the provided Condition list
 func (c *explicitConditional) Generate() ([][]ovsdb.Condition, error) {
-	models, _ := c.Matches()
+	models, err := c.Matches()
+	if err != nil && err != ErrNotFound {
+		return nil, err
+	}
 	if len(models) == 0 {
 		// no cache hits, return conditions we were given
 		return c.anyConditions, nil
@@ -195,7 +207,10 @@ func (c *predicateConditional) Table() string {
 // generate returns a list of conditions that match, by _uuid equality, all the objects that
 // match the predicate
 func (c *predicateConditional) Generate() ([][]ovsdb.Condition, error) {
-	models, _ := c.Matches()
+	models, err := c.Matches()
+	if err != nil {
+		return nil, err
+	}
 	return generateConditionsFromModels(c.cache.DatabaseModel(), models)
 }
 

--- a/client/condition.go
+++ b/client/condition.go
@@ -143,13 +143,13 @@ func (c *explicitConditional) Generate() ([][]ovsdb.Condition, error) {
 }
 
 // newExplicitConditional creates a new explicitConditional
-func newExplicitConditional(table string, cache *cache.TableCache, all bool, model model.Model, cond ...model.Condition) (Conditional, error) {
+func newExplicitConditional(table string, cache *cache.TableCache, matchAll bool, model model.Model, cond ...model.Condition) (Conditional, error) {
 	dbModel := cache.DatabaseModel()
 	info, err := dbModel.NewModelInfo(model)
 	if err != nil {
 		return nil, err
 	}
-	anyConditions, err := generateOvsdbConditionsFromModelConditions(dbModel, info, cond, all)
+	anyConditions, err := generateOvsdbConditionsFromModelConditions(dbModel, info, cond, matchAll)
 	if err != nil {
 		return nil, err
 	}

--- a/client/condition.go
+++ b/client/condition.go
@@ -77,7 +77,7 @@ func (c *equalityConditional) Matches() (map[string]model.Model, error) {
 	if tableCache == nil {
 		return nil, ErrNotFound
 	}
-	return tableCache.RowsByModel(c.model), nil
+	return tableCache.RowsByModel(c.model)
 }
 
 // Generate conditions based on the equality of the first available index. If

--- a/test/ovs/ovs_integration_test.go
+++ b/test/ovs/ovs_integration_test.go
@@ -763,7 +763,7 @@ func (suite *OVSIntegrationSuite) TestWait() {
 		},
 	}
 	timeout := 0
-	ops, err := suite.client.Where(bridgeRow, conditions...).Wait(
+	ops, err := suite.client.WhereAny(bridgeRow, conditions...).Wait(
 		ovsdb.WaitConditionNotEqual, &timeout, bridgeRow, &bridgeRow.Name)
 	require.NoError(suite.T(), err)
 	reply, err := suite.client.Transact(context.Background(), ops...)
@@ -788,7 +788,7 @@ func (suite *OVSIntegrationSuite) TestWait() {
 		},
 	}
 	timeout = 2 * 1000 // 2 seconds (in milliseconds)
-	ops, err = suite.client.Where(bridgeRow, conditions...).Wait(
+	ops, err = suite.client.WhereAny(bridgeRow, conditions...).Wait(
 		ovsdb.WaitConditionEqual, &timeout, bridgeRow, &bridgeRow.BridgeFailMode)
 	require.NoError(suite.T(), err)
 	reply, err = suite.client.Transact(context.Background(), ops...)
@@ -798,7 +798,7 @@ func (suite *OVSIntegrationSuite) TestWait() {
 
 	// Use wait to get a txn error due to until condition that is not happening
 	timeout = 222 // milliseconds
-	ops, err = suite.client.Where(bridgeRow, conditions...).Wait(
+	ops, err = suite.client.WhereAny(bridgeRow, conditions...).Wait(
 		ovsdb.WaitConditionNotEqual, &timeout, bridgeRow, &bridgeRow.BridgeFailMode)
 	require.NoError(suite.T(), err)
 	reply, err = suite.client.Transact(context.Background(), ops...)


### PR DESCRIPTION
There are cases where we'd like to take a list of models and return a list of results without grabbing the row cache lock for every single item. Batch them up into a Where() condition that can then be List()-ed right after, which is about 2x faster than Get()-ing each item individually.

Before:
```
BenchmarkAPIListMultiple/multiple_results_one_at_a_time_with_Get-8         	     212	   5534355 ns/op
BenchmarkAPIListMultiple/multiple_results_one_at_a_time_with_Get-8         	     212	   5640041 ns/op
BenchmarkAPIListMultiple/multiple_results_one_at_a_time_with_Get-8         	     206	   5680483 ns/op
```
After:
```
BenchmarkAPIListMultiple/multiple_results_in_a_batch_with_WhereAny-8       	     420	   2795212 ns/op
BenchmarkAPIListMultiple/multiple_results_in_a_batch_with_WhereAny-8       	     412	   2895229 ns/op
BenchmarkAPIListMultiple/multiple_results_in_a_batch_with_WhereAny-8       	     412	   2864806 ns/op
```

This PR also adds a WhereAny() call that acts like WhereAll() except with OR semantics, which is equivalent to the previous Where() call including conditions. Thus we now have:

1. Where()  - accepts one or more models and matches on indexes and model data
2. WhereAny() - takes a model and one or more conditions, matching each condition with logical OR
3. WhereAll()  - takes a model and one or more conditions, matching all conditions with a logical AND


@jcaamano @flavio-fernandes @trozet @tssurya