### PR TITLE
On row modification ignore unknown columns

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/gob"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -1284,7 +1285,12 @@ func (t *TableCache) ApplyModifications(tableName string, base model.Model, upda
 		}
 
 		current, err := info.FieldByColumn(k)
-		if err != nil {
+		var colNotFoundErr *mapper.ErrColumnNotFound
+		if errors.As(err, &colNotFoundErr) {
+			// Ignore missing columns
+			t.logger.V(2).Info("OVSDB row modification received with missing column", "name", k)
+			continue
+		} else if err != nil {
 			return modified, err
 		}
 

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -2264,6 +2264,14 @@ func TestTableCacheApplyModifications(t *testing.T) {
 			false,
 			false,
 		},
+		{
+			"add to set with other columns that do not exist in client schema",
+			ovsdb.Row{"foo": "bar", "set": aFooSet, "does": "notExist"},
+			&testDBModel{Set: []string{}},
+			&testDBModel{Set: []string{"foo"}},
+			true,
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
We see in OCP: E0808 19:02:21.541427      1 cache.go:889] cache "msg"="during libovsdb cache populate2" "error"="unable to apply row modifications: column: port_security not found in table: Port_Binding" "database"="OVN_Southbound"

According to OVN team, when a row modification comes for an unknown
column, that column is simply ignored. This commit leverages the same
behavior and logs an error so that users know there is a schema
mismatch.

Signed-off-by: Tim Rozet <trozet@redhat.com>