### PR TITLE
Fix register metrics once

### DIFF
--- a/client/metrics.go
+++ b/client/metrics.go
@@ -13,9 +13,8 @@ type metrics struct {
 	numTableUpdates *prometheus.CounterVec
 	numDisconnects  prometheus.Counter
 	numMonitors     prometheus.Gauge
+	registerOnce    sync.Once
 }
-
-var regMetricsOnce sync.Once
 
 func (m *metrics) init(modelName string, namespace, subsystem string) {
 	// labels that are the same across all metrics
@@ -70,7 +69,7 @@ func (m *metrics) init(modelName string, namespace, subsystem string) {
 }
 
 func (m *metrics) register(r prometheus.Registerer) {
-	regMetricsOnce.Do(func() {
+	m.registerOnce.Do(func() {
 		r.MustRegister(
 			m.numUpdates,
 			m.numTableUpdates,


### PR DESCRIPTION
A package scope instance of sync.Once doesn't allow
new instances of type metrics which have different
ConstLabels to be exposed.

Previous patch did not consider that if a metric
contains different ConstLabels, then they must be registered
or they will not be exposed.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>