### PR TITLE
Improve integer precision to uint64 as ovs does.

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -18,7 +18,7 @@ type testModel struct {
 	UUID  string   `ovsdb:"_uuid"`
 	Foo   string   `ovsdb:"foo"`
 	Bar   string   `ovsdb:"bar"`
-	Baz   int      `ovsdb:"baz"`
+	Baz   uint64   `ovsdb:"baz"`
 	Array []string `ovsdb:"array"`
 }
 

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -17,10 +17,10 @@ import (
 )
 
 var (
-	trueVal  = true
-	falseVal = false
-	one      = 1
-	six      = 6
+	trueVal         = true
+	falseVal        = false
+	one      uint64 = 1
+	six      uint64 = 6
 )
 
 var discardLogger = logr.Discard()
@@ -1136,9 +1136,9 @@ func TestAPIUpdate(t *testing.T) {
 	tcache := apiTestCache(t, testData)
 
 	testObj := testLogicalSwitchPort{}
-	testRow := ovsdb.Row(map[string]interface{}{"type": "somethingElse", "tag": testOvsSet(t, []int{6})})
-	tagRow := ovsdb.Row(map[string]interface{}{"tag": testOvsSet(t, []int{6})})
-	var nilInt *int
+	testRow := ovsdb.Row(map[string]interface{}{"type": "somethingElse", "tag": testOvsSet(t, []uint64{6})})
+	tagRow := ovsdb.Row(map[string]interface{}{"tag": testOvsSet(t, []uint64{6})})
+	var nilInt *uint64
 	testNilRow := ovsdb.Row(map[string]interface{}{"type": "somethingElse", "tag": testOvsSet(t, nilInt)})
 	typeRow := ovsdb.Row(map[string]interface{}{"type": "somethingElse"})
 	fields := []interface{}{&testObj.Tag, &testObj.Type}

--- a/client/api_test_model.go
+++ b/client/api_test_model.go
@@ -128,7 +128,7 @@ func (*testLogicalSwitch) Table() string {
 	return "Logical_Switch"
 }
 
-//LogicalSwitchPort struct defines an object in Logical_Switch_Port table
+// LogicalSwitchPort struct defines an object in Logical_Switch_Port table
 type testLogicalSwitchPort struct {
 	UUID             string            `ovsdb:"_uuid"`
 	Up               *bool             `ovsdb:"up"`
@@ -140,8 +140,8 @@ type testLogicalSwitchPort struct {
 	Enabled          *bool             `ovsdb:"enabled"`
 	Addresses        []string          `ovsdb:"addresses"`
 	Dhcpv6Options    *string           `ovsdb:"dhcpv6_options"`
-	TagRequest       *int              `ovsdb:"tag_request"`
-	Tag              *int              `ovsdb:"tag"`
+	TagRequest       *uint64           `ovsdb:"tag_request"`
+	Tag              *uint64           `ovsdb:"tag"`
 	PortSecurity     []string          `ovsdb:"port_security"`
 	ExternalIds      map[string]string `ovsdb:"external_ids"`
 	Type             string            `ovsdb:"type"`

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -57,8 +57,8 @@ type Bridge struct {
 	DatapathVersion     string            `ovsdb:"datapath_version"`
 	ExternalIDs         map[string]string `ovsdb:"external_ids"`
 	FailMode            *BridgeFailMode   `ovsdb:"fail_mode"`
-	FloodVLANs          [4096]int         `ovsdb:"flood_vlans"`
-	FlowTables          map[int]string    `ovsdb:"flow_tables"`
+	FloodVLANs          [4096]uint64      `ovsdb:"flood_vlans"`
+	FlowTables          map[uint64]string `ovsdb:"flow_tables"`
 	IPFIX               *string           `ovsdb:"ipfix"`
 	McastSnoopingEnable bool              `ovsdb:"mcast_snooping_enable"`
 	Mirrors             []string          `ovsdb:"mirrors"`
@@ -78,7 +78,7 @@ type Bridge struct {
 type OpenvSwitch struct {
 	UUID            string            `ovsdb:"_uuid"`
 	Bridges         []string          `ovsdb:"bridges"`
-	CurCfg          int               `ovsdb:"cur_cfg"`
+	CurCfg          uint64            `ovsdb:"cur_cfg"`
 	DatapathTypes   []string          `ovsdb:"datapath_types"`
 	Datapaths       map[string]string `ovsdb:"datapaths"`
 	DbVersion       *string           `ovsdb:"db_version"`
@@ -87,7 +87,7 @@ type OpenvSwitch struct {
 	ExternalIDs     map[string]string `ovsdb:"external_ids"`
 	IfaceTypes      []string          `ovsdb:"iface_types"`
 	ManagerOptions  []string          `ovsdb:"manager_options"`
-	NextCfg         int               `ovsdb:"next_cfg"`
+	NextCfg         uint64            `ovsdb:"next_cfg"`
 	OtherConfig     map[string]string `ovsdb:"other_config"`
 	OVSVersion      *string           `ovsdb:"ovs_version"`
 	SSL             *string           `ovsdb:"ssl"`

--- a/mapper/info_test.go
+++ b/mapper/info_test.go
@@ -76,7 +76,7 @@ func TestNewMapperInfo(t *testing.T) {
 func TestMapperInfoSet(t *testing.T) {
 	type obj struct {
 		Ostring string            `ovsdb:"aString"`
-		Oint    int               `ovsdb:"aInteger"`
+		Oint    uint64            `ovsdb:"aInteger"`
 		Oset    []string          `ovsdb:"aSet"`
 		Omap    map[string]string `ovsdb:"aMap"`
 	}
@@ -162,7 +162,7 @@ func TestMapperInfoSet(t *testing.T) {
 func TestMapperInfoColByPtr(t *testing.T) {
 	type obj struct {
 		ostring string            `ovsdb:"aString"`
-		oint    int               `ovsdb:"aInteger"`
+		oint    uint64            `ovsdb:"aInteger"`
 		oset    []string          `ovsdb:"aSet"`
 		omap    map[string]string `ovsdb:"aMap"`
 	}

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -26,7 +26,7 @@ var (
 		aUUID3,
 	}
 
-	aIntSet = []int{
+	aIntSet = []uint64{
 		3,
 		2,
 		42,
@@ -191,7 +191,7 @@ func TestMapperGetData(t *testing.T) {
 		ASingleSet          *string           `ovsdb:"aSingleSet"`
 		AUUIDSet            []string          `ovsdb:"aUUIDSet"`
 		AUUID               string            `ovsdb:"aUUID"`
-		AIntSet             []int             `ovsdb:"aIntSet"`
+		AIntSet             []uint64          `ovsdb:"aIntSet"`
 		AFloat              float64           `ovsdb:"aFloat"`
 		AFloatSet           [10]float64       `ovsdb:"aFloatSet"`
 		YetAnotherStringSet []string          `ovsdb:"aEmptySet"`
@@ -293,11 +293,11 @@ func TestMapperNewRow(t *testing.T) {
 	}, {
 		name: "aIntSet",
 		objInput: &struct {
-			MyIntSet []int `ovsdb:"aIntSet"`
+			MyIntSet []uint64 `ovsdb:"aIntSet"`
 		}{
-			MyIntSet: []int{0, 42},
+			MyIntSet: []uint64{0, 42},
 		},
-		expectedRow: ovsdb.Row(map[string]interface{}{"aIntSet": testOvsSet(t, []int{0, 42})}),
+		expectedRow: ovsdb.Row(map[string]interface{}{"aIntSet": testOvsSet(t, []uint64{0, 42})}),
 	}, {
 		name: "aFloat",
 		objInput: &struct {
@@ -663,8 +663,8 @@ func TestMapperEqualIndexes(t *testing.T) {
 		Config map[string]string `ovsdb:"config"`
 		Comp1  string            `ovsdb:"composed_1"`
 		Comp2  string            `ovsdb:"composed_2"`
-		Int1   int               `ovsdb:"int1"`
-		Int2   int               `ovsdb:"int2"`
+		Int1   uint64            `ovsdb:"int1"`
+		Int2   uint64            `ovsdb:"int2"`
 	}
 
 	var schema ovsdb.DatabaseSchema
@@ -930,8 +930,8 @@ func TestMapperMutation(t *testing.T) {
 		String    string            `ovsdb:"string"`
 		Set       []string          `ovsdb:"set"`
 		Map       map[string]string `ovsdb:"map"`
-		Int       int               `ovsdb:"int"`
-		UnMutable int               `ovsdb:"unmutable"`
+		Int       uint64            `ovsdb:"int"`
+		UnMutable uint64            `ovsdb:"unmutable"`
 	}
 
 	var schema ovsdb.DatabaseSchema
@@ -962,8 +962,8 @@ func TestMapperMutation(t *testing.T) {
 			column:   "int",
 			obj:      testType{},
 			mutator:  ovsdb.MutateOperationAdd,
-			value:    1,
-			expected: ovsdb.NewMutation("int", ovsdb.MutateOperationAdd, 1),
+			value:    uint64(1),
+			expected: ovsdb.NewMutation("int", ovsdb.MutateOperationAdd, uint64(1)),
 			err:      false,
 		},
 		{
@@ -971,8 +971,8 @@ func TestMapperMutation(t *testing.T) {
 			column:   "int",
 			obj:      testType{},
 			mutator:  ovsdb.MutateOperationModulo,
-			value:    2,
-			expected: ovsdb.NewMutation("int", ovsdb.MutateOperationModulo, 2),
+			value:    uint64(2),
+			expected: ovsdb.NewMutation("int", ovsdb.MutateOperationModulo, uint64(2)),
 			err:      false,
 		},
 		{
@@ -980,7 +980,7 @@ func TestMapperMutation(t *testing.T) {
 			column:  "unmutable",
 			obj:     testType{},
 			mutator: ovsdb.MutateOperationSubtract,
-			value:   2,
+			value:   uint64(2),
 			err:     true,
 		},
 		{
@@ -1111,8 +1111,8 @@ func TestNewMonitorRequest(t *testing.T) {
 		Config map[string]string `ovsdb:"config"`
 		Comp1  string            `ovsdb:"composed_1"`
 		Comp2  string            `ovsdb:"composed_2"`
-		Int1   int               `ovsdb:"int1"`
-		Int2   int               `ovsdb:"int2"`
+		Int1   uint64            `ovsdb:"int1"`
+		Int2   uint64            `ovsdb:"int2"`
 	}
 	var schema ovsdb.DatabaseSchema
 	err := json.Unmarshal(testSchema, &schema)

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -91,7 +91,7 @@ func TestValidate(t *testing.T) {
 		"TestTable": &struct {
 			aUUID   string            `ovsdb:"_uuid"`
 			aString string            `ovsdb:"aString"`
-			aInt    int               `ovsdb:"aInt"`
+			aInt    uint64            `ovsdb:"aInt"`
 			aFloat  float64           `ovsdb:"aFloat"`
 			aSet    []string          `ovsdb:"aSet"`
 			aMap    map[string]string `ovsdb:"aMap"`

--- a/modelgen/table.go
+++ b/modelgen/table.go
@@ -171,11 +171,11 @@ var _ model.ComparableModel = &{{ $structName }}{}
 // (see GetTableTemplateData). In addition, the following functions can be used
 // within the template:
 //
-//    - `PrintVal`: prints a field value
-//    - `FieldName`: prints the name of a field based on its column
-//    - `FieldType`: prints the field type based on its column and schema
-//    - `FieldTypeWithEnums`: same as FieldType but with enum type expansion
-//    - `OvsdbTag`: prints the ovsdb tag
+//   - `PrintVal`: prints a field value
+//   - `FieldName`: prints the name of a field based on its column
+//   - `FieldType`: prints the field type based on its column and schema
+//   - `FieldTypeWithEnums`: same as FieldType but with enum type expansion
+//   - `OvsdbTag`: prints the ovsdb tag
 func NewTableTemplate() *template.Template {
 	return template.Must(template.New("").Funcs(
 		template.FuncMap{
@@ -396,7 +396,7 @@ func FieldEnum(tableName, columnName string, column *ovsdb.ColumnSchema) *Enum {
 func AtomicType(atype string) string {
 	switch atype {
 	case ovsdb.TypeInteger:
-		return "int"
+		return "uint64"
 	case ovsdb.TypeReal:
 		return "float64"
 	case ovsdb.TypeBoolean:
@@ -485,7 +485,7 @@ func expandInitilaisms(s string) string {
 
 func printVal(v interface{}, t string) string {
 	switch t {
-	case "int":
+	case "uint64":
 		return fmt.Sprintf(`%d`, v)
 	case "float64":
 		return fmt.Sprintf(`%f`, v)

--- a/modelgen/table_test.go
+++ b/modelgen/table_test.go
@@ -74,7 +74,7 @@ type AtomicTable struct {
 	UUID      string               ` + "`" + `ovsdb:"_uuid"` + "`" + `
 	EventType AtomicTableEventType ` + "`" + `ovsdb:"event_type"` + "`" + `
 	Float     float64              ` + "`" + `ovsdb:"float"` + "`" + `
-	Int       int                  ` + "`" + `ovsdb:"int"` + "`" + `
+	Int       uint64               ` + "`" + `ovsdb:"int"` + "`" + `
 	Protocol  *AtomicTableProtocol ` + "`" + `ovsdb:"protocol"` + "`" + `
 	Str       string               ` + "`" + `ovsdb:"str"` + "`" + `
 }
@@ -95,7 +95,7 @@ type AtomicTable struct {
 	UUID      string  ` + "`" + `ovsdb:"_uuid"` + "`" + `
 	EventType string  ` + "`" + `ovsdb:"event_type"` + "`" + `
 	Float     float64 ` + "`" + `ovsdb:"float"` + "`" + `
-	Int       int     ` + "`" + `ovsdb:"int"` + "`" + `
+	Int       uint64  ` + "`" + `ovsdb:"int"` + "`" + `
 	Protocol  *string ` + "`" + `ovsdb:"protocol"` + "`" + `
 	Str       string  ` + "`" + `ovsdb:"str"` + "`" + `
 }
@@ -134,14 +134,14 @@ type AtomicTable struct {
 	UUID      string               ` + "`" + `ovsdb:"_uuid"` + "`" + `
 	EventType AtomicTableEventType ` + "`" + `ovsdb:"event_type"` + "`" + `
 	Float     float64              ` + "`" + `ovsdb:"float"` + "`" + `
-	Int       int                  ` + "`" + `ovsdb:"int"` + "`" + `
+	Int       uint64               ` + "`" + `ovsdb:"int"` + "`" + `
 	Protocol  *AtomicTableProtocol ` + "`" + `ovsdb:"protocol"` + "`" + `
 	Str       string               ` + "`" + `ovsdb:"str"` + "`" + `
 
 	OtherUUID      string
 	OtherEventType string
 	OtherFloat     float64
-	OtherInt       int
+	OtherInt       uint64
 	OtherProtocol  *string
 	OtherStr       string
 }
@@ -176,7 +176,7 @@ type AtomicTable struct {
 	UUID      string               ` + "`" + `ovsdb:"_uuid"` + "`" + `
 	EventType AtomicTableEventType ` + "`" + `ovsdb:"event_type"` + "`" + `
 	Float     float64              ` + "`" + `ovsdb:"float"` + "`" + `
-	Int       int                  ` + "`" + `ovsdb:"int"` + "`" + `
+	Int       uint64               ` + "`" + `ovsdb:"int"` + "`" + `
 	Protocol  *AtomicTableProtocol ` + "`" + `ovsdb:"protocol"` + "`" + `
 	Str       string               ` + "`" + `ovsdb:"str"` + "`" + `
 }
@@ -308,14 +308,14 @@ type AtomicTable struct {
 	UUID      string               ` + "`" + `ovsdb:"_uuid"` + "`" + `
 	EventType AtomicTableEventType ` + "`" + `ovsdb:"event_type"` + "`" + `
 	Float     float64              ` + "`" + `ovsdb:"float"` + "`" + `
-	Int       int                  ` + "`" + `ovsdb:"int"` + "`" + `
+	Int       uint64               ` + "`" + `ovsdb:"int"` + "`" + `
 	Protocol  *AtomicTableProtocol ` + "`" + `ovsdb:"protocol"` + "`" + `
 	Str       string               ` + "`" + `ovsdb:"str"` + "`" + `
 
 	OtherUUID      string
 	OtherEventType string
 	OtherFloat     float64
-	OtherInt       int
+	OtherInt       uint64
 	OtherProtocol  *string
 	OtherStr       string
 }
@@ -418,7 +418,7 @@ type AtomicTable struct {
 	UUID      string  ` + "`" + `ovsdb:"_uuid"` + "`" + `
 	EventType string  ` + "`" + `ovsdb:"event_type"` + "`" + `
 	Float     float64 ` + "`" + `ovsdb:"float"` + "`" + `
-	Int       int     ` + "`" + `ovsdb:"int"` + "`" + `
+	Int       uint64  ` + "`" + `ovsdb:"int"` + "`" + `
 	Protocol  *string ` + "`" + `ovsdb:"protocol"` + "`" + `
 	Str       string  ` + "`" + `ovsdb:"str"` + "`" + `
 }
@@ -515,7 +515,7 @@ type AtomicTable struct {
 	UUID      string               ` + "`" + `ovsdb:"_uuid"` + "`" + `
 	EventType AtomicTableEventType ` + "`" + `ovsdb:"event_type"` + "`" + `
 	Float     float64              ` + "`" + `ovsdb:"float"` + "`" + `
-	Int       int                  ` + "`" + `ovsdb:"int"` + "`" + `
+	Int       uint64               ` + "`" + `ovsdb:"int"` + "`" + `
 	Protocol  *AtomicTableProtocol ` + "`" + `ovsdb:"protocol"` + "`" + `
 	Str       string               ` + "`" + `ovsdb:"str"` + "`" + `
 }
@@ -620,7 +620,7 @@ func TestAtomicType(t *testing.T) {
 		in   string
 		out  string
 	}{
-		{"IntegerToInt", ovsdb.TypeInteger, "int"},
+		{"IntegerToInt", ovsdb.TypeInteger, "uint64"},
 		{"RealToFloat", ovsdb.TypeReal, "float64"},
 		{"BooleanToBool", ovsdb.TypeBoolean, "bool"},
 		{"StringToString", ovsdb.TypeString, "string"},
@@ -764,8 +764,8 @@ func buildTestBridge() *vswitchd.Bridge {
 		DatapathVersion:     *buildRandStr(),
 		ExternalIDs:         map[string]string{*buildRandStr(): *buildRandStr(), *buildRandStr(): *buildRandStr()},
 		FailMode:            &vswitchd.BridgeFailModeSecure,
-		FloodVLANs:          [4096]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-		FlowTables:          map[int]string{1: *buildRandStr(), 2: *buildRandStr()},
+		FloodVLANs:          [4096]uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		FlowTables:          map[uint64]string{1: *buildRandStr(), 2: *buildRandStr()},
 		IPFIX:               buildRandStr(),
 		McastSnoopingEnable: false,
 		Mirrors:             []string{*buildRandStr(), *buildRandStr()},
@@ -784,7 +784,7 @@ func buildTestBridge() *vswitchd.Bridge {
 
 func buildTestInterface() *vswitchd.Interface {
 	aBool := false
-	aInt := 0
+	aInt := uint64(0)
 	return &vswitchd.Interface{
 		UUID:                      *buildRandStr(),
 		AdminState:                buildRandStr(),
@@ -795,7 +795,7 @@ func buildTestInterface() *vswitchd.Interface {
 		CFMFlapCount:              &aInt,
 		CFMHealth:                 &aInt,
 		CFMMpid:                   &aInt,
-		CFMRemoteMpids:            []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		CFMRemoteMpids:            []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 		CFMRemoteOpstate:          buildRandStr(),
 		Duplex:                    buildRandStr(),
 		Error:                     buildRandStr(),
@@ -819,7 +819,7 @@ func buildTestInterface() *vswitchd.Interface {
 		OfportRequest:             &aInt,
 		Options:                   map[string]string{*buildRandStr(): *buildRandStr(), *buildRandStr(): *buildRandStr()},
 		OtherConfig:               map[string]string{*buildRandStr(): *buildRandStr(), *buildRandStr(): *buildRandStr()},
-		Statistics:                map[string]int{*buildRandStr(): 0, *buildRandStr(): 1},
+		Statistics:                map[string]uint64{*buildRandStr(): 0, *buildRandStr(): 1},
 		Status:                    map[string]string{*buildRandStr(): *buildRandStr(), *buildRandStr(): *buildRandStr()},
 		Type:                      *buildRandStr(),
 	}

--- a/ovsdb/bindings.go
+++ b/ovsdb/bindings.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	intType  = reflect.TypeOf(0)
+	intType  = reflect.TypeOf(uint64(0))
 	realType = reflect.TypeOf(0.0)
 	boolType = reflect.TypeOf(true)
 	strType  = reflect.TypeOf("")
@@ -52,8 +52,8 @@ func NativeTypeFromAtomic(basicType string) reflect.Type {
 	}
 }
 
-//NativeType returns the reflect.Type that can hold the value of a column
-//OVS Type to Native Type convertions:
+// NativeType returns the reflect.Type that can hold the value of a column
+// OVS Type to Native Type convertions:
 // OVS sets -> go slices, arrays or a go native type depending on the key
 // OVS uuid -> go strings
 // OVS map  -> go map
@@ -99,7 +99,7 @@ func OvsToNativeAtomic(basicType string, ovsElem interface{}) (interface{}, erro
 		return ovsElem, nil
 	case TypeInteger:
 		naType := NativeTypeFromAtomic(basicType)
-		// Default decoding of numbers is float64, convert them to int
+		// Default decoding of numbers is float64, convert them to uint64
 		if !reflect.TypeOf(ovsElem).ConvertibleTo(naType) {
 			return nil, NewErrWrongType("OvsToNativeAtomic", fmt.Sprintf("Convertible to %s", naType), ovsElem)
 		}

--- a/ovsdb/bindings_test.go
+++ b/ovsdb/bindings_test.go
@@ -29,14 +29,15 @@ var (
 		aUUID3,
 	}
 
-	aIntSet = []int{
+	aIntSet = []uint64{
 		3,
 		2,
 		42,
 	}
 	aFloat = 42.00
 
-	aInt = 42
+	aInt    uint64 = 42
+	aBitInt uint64 = 18446744073709551615
 
 	aFloatSet = []float64{
 		3.0,
@@ -75,7 +76,7 @@ func TestOvsToNativeAndNativeToOvs(t *testing.T) {
 	is, _ := NewOvsSet(aIntSet)
 	fs, _ := NewOvsSet(aFloatSet)
 
-	sis, _ := NewOvsSet([]int{aInt})
+	sis, _ := NewOvsSet([]uint64{aInt})
 	sfs, _ := NewOvsSet([]float64{aFloat})
 
 	es, _ := NewOvsSet(aEmptySet)
@@ -125,6 +126,13 @@ func TestOvsToNativeAndNativeToOvs(t *testing.T) {
 			input:  aInt,
 			native: aInt,
 			ovs:    aInt,
+		},
+		{
+			name:   "Big Integers",
+			schema: []byte(`{"type":"integer"}`),
+			input:  aBitInt,
+			native: aBitInt,
+			ovs:    aBitInt,
 		},
 		{
 			name:   "Integer set with float ovs type ",
@@ -236,7 +244,7 @@ func TestOvsToNativeAndNativeToOvs(t *testing.T) {
 				}
 			}`),
 			input:  sis,
-			native: []int{aInt},
+			native: []uint64{aInt},
 			ovs:    sis,
 		},
 		{
@@ -252,7 +260,7 @@ func TestOvsToNativeAndNativeToOvs(t *testing.T) {
 				}
 			}`),
 			input:  sfs,
-			native: []int{aInt},
+			native: []uint64{aInt},
 			ovs:    sis,
 		},
 
@@ -844,21 +852,21 @@ func TestMutationValidation(t *testing.T) {
 			name:     "integer",
 			column:   []byte(`{"type":"integer"}`),
 			mutators: []Mutator{MutateOperationAdd, MutateOperationAdd, MutateOperationSubtract, MutateOperationMultiply, MutateOperationDivide, MutateOperationModulo},
-			value:    4,
+			value:    uint64(4),
 			valid:    true,
 		},
 		{
 			name:     "unmutable",
 			column:   []byte(`{"type":"integer", "mutable": false}`),
 			mutators: []Mutator{MutateOperationAdd, MutateOperationAdd, MutateOperationSubtract, MutateOperationMultiply, MutateOperationDivide, MutateOperationModulo},
-			value:    4,
+			value:    uint64(4),
 			valid:    false,
 		},
 		{
 			name:     "integer wrong mutator",
 			column:   []byte(`{"type":"integer"}`),
 			mutators: []Mutator{"some", "wrong", "mutator"},
-			value:    4,
+			value:    uint64(4),
 			valid:    false,
 		},
 		{
@@ -892,7 +900,7 @@ func TestMutationValidation(t *testing.T) {
 				   }
 				 }`),
 			mutators: []Mutator{MutateOperationAdd, MutateOperationAdd, MutateOperationSubtract, MutateOperationMultiply, MutateOperationDivide, MutateOperationModulo},
-			value:    4,
+			value:    uint64(4),
 			valid:    true,
 		},
 		{
@@ -970,7 +978,7 @@ func TestMutationValidation(t *testing.T) {
 				   }
 				 }`),
 			mutators: []Mutator{MutateOperationInsert, MutateOperationDelete},
-			value:    []int{45, 11},
+			value:    []uint64{uint64(45), uint64(11)},
 			valid:    true,
 		},
 		{
@@ -1075,7 +1083,7 @@ func TestConditionValidation(t *testing.T) {
 			name:      "numeric",
 			column:    []byte(`{"type":"integer"}`),
 			functions: []ConditionFunction{ConditionGreaterThanOrEqual, ConditionGreaterThan, ConditionLessThan, ConditionLessThanOrEqual, ConditionEqual, ConditionIncludes, ConditionNotEqual, ConditionExcludes},
-			value:     1000,
+			value:     uint64(1000),
 			valid:     true,
 		},
 		{

--- a/ovsdb/serverdb/database.go
+++ b/ovsdb/serverdb/database.go
@@ -20,7 +20,7 @@ type Database struct {
 	UUID      string        `ovsdb:"_uuid"`
 	Cid       *string       `ovsdb:"cid"`
 	Connected bool          `ovsdb:"connected"`
-	Index     *int          `ovsdb:"index"`
+	Index     *uint64       `ovsdb:"index"`
 	Leader    bool          `ovsdb:"leader"`
 	Model     DatabaseModel `ovsdb:"model"`
 	Name      string        `ovsdb:"name"`
@@ -46,7 +46,7 @@ func equalDatabaseCid(a, b *string) bool {
 	return *a == *b
 }
 
-func copyDatabaseIndex(a *int) *int {
+func copyDatabaseIndex(a *uint64) *uint64 {
 	if a == nil {
 		return nil
 	}
@@ -54,7 +54,7 @@ func copyDatabaseIndex(a *int) *int {
 	return &b
 }
 
-func equalDatabaseIndex(a, b *int) bool {
+func equalDatabaseIndex(a, b *uint64) bool {
 	if (a == nil) != (b == nil) {
 		return false
 	}

--- a/test/ovs/ovs_integration_test.go
+++ b/test/ovs/ovs_integration_test.go
@@ -144,7 +144,7 @@ type bridgeType struct {
 type ovsType struct {
 	UUID            string            `ovsdb:"_uuid"`
 	Bridges         []string          `ovsdb:"bridges"`
-	CurCfg          int               `ovsdb:"cur_cfg"`
+	CurCfg          uint64            `ovsdb:"cur_cfg"`
 	DatapathTypes   []string          `ovsdb:"datapath_types"`
 	Datapaths       map[string]string `ovsdb:"datapaths"`
 	DbVersion       *string           `ovsdb:"db_version"`
@@ -153,7 +153,7 @@ type ovsType struct {
 	ExternalIDs     map[string]string `ovsdb:"external_ids"`
 	IfaceTypes      []string          `ovsdb:"iface_types"`
 	ManagerOptions  []string          `ovsdb:"manager_options"`
-	NextCfg         int               `ovsdb:"next_cfg"`
+	NextCfg         uint64            `ovsdb:"next_cfg"`
 	OtherConfig     map[string]string `ovsdb:"other_config"`
 	OVSVersion      *string           `ovsdb:"ovs_version"`
 	SSL             *string           `ovsdb:"ssl"`
@@ -170,8 +170,8 @@ type ipfixType struct {
 
 // queueType is the simplified ORM model of the Queue table
 type queueType struct {
-	UUID string `ovsdb:"_uuid"`
-	DSCP *int   `ovsdb:"dscp"`
+	UUID string  `ovsdb:"_uuid"`
+	DSCP *uint64 `ovsdb:"dscp"`
 }
 
 var defDB, _ = model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
@@ -807,7 +807,7 @@ func (suite *OVSIntegrationSuite) TestWait() {
 	assert.Error(suite.T(), err)
 }
 
-func (suite *OVSIntegrationSuite) createQueue(queueName string, dscp int) (string, error) {
+func (suite *OVSIntegrationSuite) createQueue(queueName string, dscp uint64) (string, error) {
 	q := queueType{
 		DSCP: &dscp,
 	}


### PR DESCRIPTION
We want to generate interface metrics from interface statistics and found that integer precision in libovsdb and ovs does not match.

https://www.openvswitch.org/support/dist-docs/ovs-vswitchd.conf.db.5.html
>>
       Statistics:
         Statistics: Successful transmit and receive counters:
            statistics : rx_packets  optional integer
            statistics : rx_bytes    optional integer
            statistics : tx_packets  optional integer
            statistics : tx_bytes    optional integer
         Statistics: Receive errors:
            statistics : rx_dropped  optional integer
            statistics : rx_frame_err
                                     optional integer
            statistics : rx_over_err optional integer
            statistics : rx_crc_err  optional integer
            statistics : rx_errors   optional integer
         Statistics: Transmit errors:
            statistics : tx_dropped  optional integer
            statistics : collisions  optional integer
            statistics : tx_errors   optional integer

https://github.com/openvswitch/ovs/blob/d29491eeb4a6e2128430eeac9a08327d8e7d8ed6/lib/netdev-linux.c#L201-L227
```
struct rtnl_link_stats64 {
    uint64_t rx_packets;
    uint64_t tx_packets;
    uint64_t rx_bytes;
    uint64_t tx_bytes;
    uint64_t rx_errors;
    uint64_t tx_errors;
    uint64_t rx_dropped;
    uint64_t tx_dropped;
    uint64_t multicast;
    uint64_t collisions;

    uint64_t rx_length_errors;
    uint64_t rx_over_errors;
    uint64_t rx_crc_errors;
    uint64_t rx_frame_errors;
    uint64_t rx_fifo_errors;
    uint64_t rx_missed_errors;

    uint64_t tx_aborted_errors;
    uint64_t tx_carrier_errors;
    uint64_t tx_fifo_errors;
    uint64_t tx_heartbeat_errors;
    uint64_t tx_window_errors;

    uint64_t rx_compressed;
    uint64_t tx_compressed;
};
```

Case
```
=== RUN   TestOvsToNativeAndNativeToOvs/Big_Integers
    bindings_test.go:447: 
        	Error Trace:	libovsdb/ovsdb/bindings_test.go:447
        	Error:      	Not equal: 
        	            	expected: uint64(0xffffffffffffffff)
        	            	actual  : int(-1)
        	Test:       	TestOvsToNativeAndNativeToOvs/Big_Integers
        	Messages:   	fail to convert ovs2native. input: 18446744073709551615(uint64). expected 18446744073709551615(uint64). got -1 (int)
    --- FAIL: TestOvsToNativeAndNativeToOvs/Big_Integers (0.00s)


Expected :uint64(0xffffffffffffffff)
Actual   :int(-1)
```