### PR TITLE
Make table name a const above generated model

### DIFF
--- a/modelgen/table.go
+++ b/modelgen/table.go
@@ -171,11 +171,11 @@ var _ model.ComparableModel = &{{ $structName }}{}
 // (see GetTableTemplateData). In addition, the following functions can be used
 // within the template:
 //
-//    - `PrintVal`: prints a field value
-//    - `FieldName`: prints the name of a field based on its column
-//    - `FieldType`: prints the field type based on its column and schema
-//    - `FieldTypeWithEnums`: same as FieldType but with enum type expansion
-//    - `OvsdbTag`: prints the ovsdb tag
+//   - `PrintVal`: prints a field value
+//   - `FieldName`: prints the name of a field based on its column
+//   - `FieldType`: prints the field type based on its column and schema
+//   - `FieldTypeWithEnums`: same as FieldType but with enum type expansion
+//   - `OvsdbTag`: prints the ovsdb tag
 func NewTableTemplate() *template.Template {
 	return template.Must(template.New("").Funcs(
 		template.FuncMap{
@@ -194,6 +194,9 @@ func NewTableTemplate() *template.Template {
 {{ define "preStructDefinitions" }}{{ end }}
 {{- define "structComment" }}
 // {{ index . "StructName" }} defines an object in {{ index . "TableName" }} table
+{{- end }}
+{{- define "showTableName" }}
+const {{ index . "StructName" }}Table = "{{ index . "TableName" }}"
 {{- end }}
 {{ define "extraTags" }}{{ end }}
 {{ define "extraFields" }}{{ end }}
@@ -224,6 +227,7 @@ package {{ index . "PackageName" }}
 {{ template "extendedGenImports" . }}
 {{ template "extraImports" . }}
 {{ template "preStructDefinitions" . }}
+{{ template "showTableName" . }}
 {{ template "enums" . }}
 {{ template "structComment" . }}
 type {{ index . "StructName" }} struct {

--- a/modelgen/table_test.go
+++ b/modelgen/table_test.go
@@ -57,6 +57,8 @@ func TestNewTableTemplate(t *testing.T) {
 
 package test
 
+const AtomicTableTable = "atomicTable"
+
 type (
 	AtomicTableEventType = string
 	AtomicTableProtocol  = string
@@ -90,6 +92,8 @@ type AtomicTable struct {
 
 package test
 
+const AtomicTableTable = "atomicTable"
+
 // AtomicTable defines an object in atomicTable table
 type AtomicTable struct {
 	UUID      string  ` + "`" + `ovsdb:"_uuid"` + "`" + `
@@ -116,6 +120,8 @@ type AtomicTable struct {
 // DO NOT EDIT.
 
 package test
+
+const AtomicTableTable = "atomicTable"
 
 type (
 	AtomicTableEventType = string
@@ -158,6 +164,8 @@ type AtomicTable struct {
 package test
 
 import "github.com/ovn-org/libovsdb/model"
+
+const AtomicTableTable = "atomicTable"
 
 type (
 	AtomicTableEventType = string
@@ -291,6 +299,8 @@ import "github.com/ovn-org/libovsdb/model"
 
 import "fmt"
 
+const AtomicTableTable = "atomicTable"
+
 type (
 	AtomicTableEventType = string
 	AtomicTableProtocol  = string
@@ -413,6 +423,8 @@ package test
 
 import "github.com/ovn-org/libovsdb/model"
 
+const AtomicTableTable = "atomicTable"
+
 // AtomicTable defines an object in atomicTable table
 type AtomicTable struct {
 	UUID      string  ` + "`" + `ovsdb:"_uuid"` + "`" + `
@@ -497,6 +509,8 @@ func {{ index . "TestName" }} () string {
 // DO NOT EDIT.
 
 package test
+
+const AtomicTableTable = "atomicTable"
 
 type (
 	AtomicTableEventType = string

--- a/ovsdb/serverdb/database.go
+++ b/ovsdb/serverdb/database.go
@@ -5,6 +5,8 @@ package serverdb
 
 import "github.com/ovn-org/libovsdb/model"
 
+const DatabaseTable = "Database"
+
 type (
 	DatabaseModel = string
 )


### PR DESCRIPTION
We need a table name when EventHandlerFuncs callback, it's better to provide a const variable.

https://github.com/ovn-org/libovsdb/blob/main/cache/cache.go#L764-L776
```
// EventHandler can handle events when the contents of the cache changes
type EventHandler interface {
	OnAdd(table string, model model.Model)
	OnUpdate(table string, old model.Model, new model.Model)
	OnDelete(table string, model model.Model)
}

// EventHandlerFuncs is a wrapper for the EventHandler interface
// It allows a caller to only implement the functions they need
type EventHandlerFuncs struct {
	AddFunc    func(table string, model model.Model)
	UpdateFunc func(table string, old model.Model, new model.Model)
	DeleteFunc func(table string, model model.Model)
}
```