### PR TITLE
server: index uniqueness is a deferred constraint

### DIFF
--- a/cache/uuidset.go
+++ b/cache/uuidset.go
@@ -24,6 +24,18 @@ func (s uuidset) has(uuid string) bool {
 	return ok
 }
 
+func (s uuidset) equals(o uuidset) bool {
+	if len(s) != len(o) {
+		return false
+	}
+	for uuid := range s {
+		if !o.has(uuid) {
+			return false
+		}
+	}
+	return true
+}
+
 func (s uuidset) getAny() string {
 	for k := range s {
 		return k

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cenkalti/rpc2"
 	"github.com/google/uuid"
 	"github.com/ovn-org/libovsdb/cache"
+	db "github.com/ovn-org/libovsdb/database"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/ovn-org/libovsdb/ovsdb/serverdb"
@@ -870,7 +871,7 @@ func newOVSDBServer(t *testing.T, dbModel model.ClientDBModel, schema ovsdb.Data
 	require.NoError(t, err)
 	serverSchema := serverdb.Schema()
 
-	db := server.NewInMemoryDatabase(map[string]model.ClientDBModel{
+	db := db.NewInMemoryDatabase(map[string]model.ClientDBModel{
 		schema.Name:       dbModel,
 		serverSchema.Name: serverDBModel,
 	})

--- a/database/database.go
+++ b/database/database.go
@@ -1,4 +1,4 @@
-package server
+package database
 
 import (
 	"fmt"

--- a/database/errors.go
+++ b/database/errors.go
@@ -1,4 +1,4 @@
-package server
+package database
 
 import (
 	"fmt"

--- a/database/mutate.go
+++ b/database/mutate.go
@@ -1,4 +1,4 @@
-package server
+package database
 
 import (
 	"reflect"

--- a/database/mutate_test.go
+++ b/database/mutate_test.go
@@ -1,4 +1,4 @@
-package server
+package database
 
 import (
 	"testing"

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -74,7 +74,6 @@ func TestWaitOpEquals(t *testing.T) {
 	timeout := 0
 	// Attempt to wait for row with name foo to appear
 	gotResult := transaction.Wait(
-		"Open_vSwitch",
 		"Bridge",
 		&timeout,
 		[]ovsdb.Condition{ovsdb.NewCondition("name", ovsdb.ConditionEqual, "foo")},
@@ -87,7 +86,6 @@ func TestWaitOpEquals(t *testing.T) {
 
 	// Attempt to wait for 2 rows, where one does not exist
 	gotResult = transaction.Wait(
-		"Open_vSwitch",
 		"Bridge",
 		&timeout,
 		[]ovsdb.Condition{ovsdb.NewCondition("name", ovsdb.ConditionEqual, "foo")},
@@ -106,7 +104,6 @@ func TestWaitOpEquals(t *testing.T) {
 	require.Nil(t, err)
 	// Attempt to wait for a row, with multiple columns specified
 	gotResult = transaction.Wait(
-		"Open_vSwitch",
 		"Bridge",
 		&timeout,
 		[]ovsdb.Condition{ovsdb.NewCondition("name", ovsdb.ConditionEqual, "foo")},
@@ -119,7 +116,6 @@ func TestWaitOpEquals(t *testing.T) {
 
 	// Attempt to wait for a row, with multiple columns, but not specified in row filtering
 	gotResult = transaction.Wait(
-		"Open_vSwitch",
 		"Bridge",
 		&timeout,
 		[]ovsdb.Condition{ovsdb.NewCondition("name", ovsdb.ConditionEqual, "foo")},
@@ -133,7 +129,6 @@ func TestWaitOpEquals(t *testing.T) {
 	// Attempt to get something with a non-zero timeout that will fail
 	timeout = 400
 	gotResult = transaction.Wait(
-		"Open_vSwitch",
 		"Bridge",
 		&timeout,
 		[]ovsdb.Condition{ovsdb.NewCondition("name", ovsdb.ConditionEqual, "foo")},
@@ -204,7 +199,6 @@ func TestWaitOpNotEquals(t *testing.T) {
 	timeout := 0
 	// Attempt a wait where no entry with name blah should exist
 	gotResult := transaction.Wait(
-		"Open_vSwitch",
 		"Bridge",
 		&timeout,
 		[]ovsdb.Condition{ovsdb.NewCondition("name", ovsdb.ConditionEqual, "foo")},
@@ -217,7 +211,6 @@ func TestWaitOpNotEquals(t *testing.T) {
 
 	// Attempt another wait with multiple rows specified, one that would match, and one that doesn't
 	gotResult = transaction.Wait(
-		"Open_vSwitch",
 		"Bridge",
 		&timeout,
 		[]ovsdb.Condition{ovsdb.NewCondition("name", ovsdb.ConditionEqual, "foo")},
@@ -237,7 +230,6 @@ func TestWaitOpNotEquals(t *testing.T) {
 	require.Nil(t, err)
 	// Attempt to wait for a row, with multiple columns specified and one is not a match
 	gotResult = transaction.Wait(
-		"Open_vSwitch",
 		"Bridge",
 		&timeout,
 		[]ovsdb.Condition{ovsdb.NewCondition("name", ovsdb.ConditionEqual, "foo")},
@@ -252,7 +244,6 @@ func TestWaitOpNotEquals(t *testing.T) {
 	start := time.Now()
 	timeout = 200
 	gotResult = transaction.Wait(
-		"Open_vSwitch",
 		"Bridge",
 		&timeout,
 		[]ovsdb.Condition{ovsdb.NewCondition("name", ovsdb.ConditionEqual, "foo")},
@@ -325,7 +316,6 @@ func TestMutateOp(t *testing.T) {
 
 	gotResult, gotUpdate := transaction.Mutate(
 		"Open_vSwitch",
-		"Open_vSwitch",
 		[]ovsdb.Condition{
 			ovsdb.NewCondition("_uuid", ovsdb.ConditionEqual, ovsdb.UUID{GoUUID: ovsUUID}),
 		},
@@ -363,7 +353,6 @@ func TestMutateOp(t *testing.T) {
 	keyValueDelete, err := ovsdb.NewOvsMap(map[string]string{"baz": "quux"})
 	assert.Nil(t, err)
 	gotResult, gotUpdate = transaction.Mutate(
-		"Open_vSwitch",
 		"Bridge",
 		[]ovsdb.Condition{
 			ovsdb.NewCondition("_uuid", ovsdb.ConditionEqual, ovsdb.UUID{GoUUID: bridgeUUID}),
@@ -672,7 +661,6 @@ func TestOvsdbServerUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res, updates := transaction.Update(
-				"Open_vSwitch",
 				"Bridge",
 				[]ovsdb.Condition{{
 					Column: "_uuid", Function: ovsdb.ConditionEqual, Value: ovsdb.UUID{GoUUID: bridgeUUID},
@@ -761,7 +749,7 @@ func TestMultipleOps(t *testing.T) {
 	}
 	ops = append(ops, op2)
 
-	results, updates := transaction.Transact("Open_vSwitch", ops)
+	results, updates := transaction.Transact(ops)
 	require.Len(t, results, len(ops))
 	for _, result := range results {
 		assert.Equal(t, "", result.Error)

--- a/example/ovsdb-server/main.go
+++ b/example/ovsdb-server/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/libovsdb/database"
 	"github.com/ovn-org/libovsdb/example/vswitchd"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
@@ -57,7 +58,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	ovsDB := server.NewInMemoryDatabase(map[string]model.ClientDBModel{
+	ovsDB := database.NewInMemoryDatabase(map[string]model.ClientDBModel{
 		schema.Name: clientDBModel,
 	})
 

--- a/server/server.go
+++ b/server/server.go
@@ -164,7 +164,7 @@ func (o *OvsdbServer) GetSchema(client *rpc2.Client, args []interface{}, reply *
 }
 
 // Transact issues a new database transaction and returns the results
-func (o *OvsdbServer) Transact(client *rpc2.Client, args []json.RawMessage, reply *[]ovsdb.OperationResult) error {
+func (o *OvsdbServer) Transact(client *rpc2.Client, args []json.RawMessage, reply *[]*ovsdb.OperationResult) error {
 	// While allowing other rpc handlers to run in parallel, this ovsdb server expects transactions
 	// to be serialized. The following mutex ensures that.
 	// Ref: https://github.com/cenkalti/rpc2/blob/c1acbc6ec984b7ae6830b6a36b62f008d5aefc4c/client.go#L187
@@ -178,9 +178,6 @@ func (o *OvsdbServer) Transact(client *rpc2.Client, args []json.RawMessage, repl
 	err := json.Unmarshal(args[0], &db)
 	if err != nil {
 		return fmt.Errorf("database %v is not a string", args[0])
-	}
-	if !o.db.Exists(db) {
-		return fmt.Errorf("db does not exist")
 	}
 	var ops []ovsdb.Operation
 	namedUUID := make(map[string]ovsdb.UUID)
@@ -224,7 +221,7 @@ func (o *OvsdbServer) Transact(client *rpc2.Client, args []json.RawMessage, repl
 	return o.db.Commit(db, transactionID, updates)
 }
 
-func (o *OvsdbServer) transact(name string, operations []ovsdb.Operation) ([]ovsdb.OperationResult, ovsdb.TableUpdates2) {
+func (o *OvsdbServer) transact(name string, operations []ovsdb.Operation) ([]*ovsdb.OperationResult, ovsdb.TableUpdates2) {
 	o.modelsMutex.Lock()
 	dbModel := o.models[name]
 	o.modelsMutex.Unlock()

--- a/server/server.go
+++ b/server/server.go
@@ -210,9 +210,9 @@ func (o *OvsdbServer) Transact(client *rpc2.Client, args []json.RawMessage, repl
 	}
 	response, updates := o.transact(db, ops)
 	*reply = response
-	for i, operResult := range response {
+	for _, operResult := range response {
 		if operResult.Error != "" {
-			o.logger.Error(errors.New("failed to process operation"), "Skipping transaction DB commit due to error", "operations", ops, "failed operation", ops[i], "operation error", operResult.Error)
+			o.logger.Error(errors.New("failed to process operation"), "Skipping transaction DB commit due to error", "operations", ops, "results", response, "operation error", operResult.Error)
 			return nil
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -229,7 +229,7 @@ func (o *OvsdbServer) transact(name string, operations []ovsdb.Operation) ([]ovs
 	dbModel := o.models[name]
 	o.modelsMutex.Unlock()
 	transaction := database.NewTransaction(dbModel, name, o.db, &o.logger)
-	return transaction.Transact(name, operations)
+	return transaction.Transact(operations)
 }
 
 func deepCopy(a ovsdb.TableUpdates) (ovsdb.TableUpdates, error) {

--- a/server/server_integration_test.go
+++ b/server/server_integration_test.go
@@ -258,9 +258,9 @@ func TestClientServerInsertDuplicate(t *testing.T) {
 	reply, err = ovs.Transact(context.Background(), ops...)
 	require.Nil(t, err)
 	opErrs, err := ovsdb.CheckOperationResults(reply, ops)
+	require.Nil(t, opErrs)
 	require.Error(t, err)
-	require.Error(t, opErrs[0])
-	require.IsTypef(t, &ovsdb.ConstraintViolation{}, opErrs[0], opErrs[0].Error())
+	require.IsTypef(t, &ovsdb.ConstraintViolation{}, err, err.Error())
 }
 
 func TestClientServerInsertAndUpdate(t *testing.T) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,10 +5,13 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/ovn-org/libovsdb/database"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	. "github.com/ovn-org/libovsdb/test"
 )
 
 func TestExpandNamedUUID(t *testing.T) {
@@ -67,16 +70,16 @@ func TestExpandNamedUUID(t *testing.T) {
 
 func TestOvsdbServerMonitor(t *testing.T) {
 	defDB, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{
-		"Open_vSwitch": &ovsType{},
-		"Bridge":       &bridgeType{}})
+		"Open_vSwitch": &OvsType{},
+		"Bridge":       &BridgeType{}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	schema, err := getSchema()
+	schema, err := GetSchema()
 	if err != nil {
 		t.Fatal(err)
 	}
-	ovsDB := NewInMemoryDatabase(map[string]model.ClientDBModel{"Open_vSwitch": defDB})
+	ovsDB := database.NewInMemoryDatabase(map[string]model.ClientDBModel{"Open_vSwitch": defDB})
 	dbModel, errs := model.NewDatabaseModel(schema, defDB)
 	require.Empty(t, errs)
 	o, err := NewOvsdbServer(ovsDB, dbModel)
@@ -98,7 +101,7 @@ func TestOvsdbServerMonitor(t *testing.T) {
 	bazUUID := uuid.NewString()
 	quuxUUID := uuid.NewString()
 
-	transaction := o.NewTransaction(dbModel, "Open_vSwitch", o.db)
+	transaction := database.NewTransaction(dbModel, "Open_vSwitch", o.db, &o.logger)
 
 	_, updates := transaction.Insert("Bridge", fooUUID, ovsdb.Row{"name": "foo"})
 	_, update2 := transaction.Insert("Bridge", barUUID, ovsdb.Row{"name": "bar"})

--- a/test/test_data.go
+++ b/test/test_data.go
@@ -85,6 +85,46 @@ const schema = `
                     "name"
                 ]
             ]
+        },
+        "Flow_Sample_Collector_Set": {
+            "columns": {
+                "id": {
+                    "type": {
+                        "key": {
+                            "type": "integer",
+                            "minInteger": 0,
+                            "maxInteger": 4294967295
+                        },
+                        "min": 1,
+                        "max": 1
+                    }
+                },
+                "bridge": {
+                    "type": {
+                        "key": {
+                            "type": "uuid",
+                            "refTable": "Bridge"
+                        },
+                        "min": 1,
+                        "max": 1
+                    }
+                },
+                "external_ids": {
+                    "type": {
+                        "key": "string",
+                        "value": "string",
+                        "min": 0,
+                        "max": "unlimited"
+                    }
+                }
+            },
+            "isRoot": true,
+            "indexes": [
+                [
+                    "id",
+                    "bridge"
+                ]
+            ]
         }
     }
 }
@@ -106,6 +146,14 @@ type BridgeType struct {
 type OvsType struct {
 	UUID    string   `ovsdb:"_uuid"`
 	Bridges []string `ovsdb:"bridges"`
+}
+
+type FlowSampleCollectorSetType struct {
+	UUID        string            `ovsdb:"_uuid"`
+	Bridge      string            `ovsdb:"bridge"`
+	ExternalIDs map[string]string `ovsdb:"external_ids"`
+	ID          int               `ovsdb:"id"`
+	IPFIX       *string           // `ovsdb:"ipfix"`
 }
 
 func GetSchema() (ovsdb.DatabaseSchema, error) {

--- a/test/test_data.go
+++ b/test/test_data.go
@@ -1,3 +1,12 @@
+package test
+
+import (
+	"encoding/json"
+
+	"github.com/ovn-org/libovsdb/ovsdb"
+)
+
+const schema = `
 {
     "name": "Open_vSwitch",
     "version": "0.0.1",
@@ -78,4 +87,29 @@
             ]
         }
     }
+}
+`
+
+// BridgeType is the simplified ORM model of the Bridge table
+type BridgeType struct {
+	UUID         string            `ovsdb:"_uuid"`
+	Name         string            `ovsdb:"name"`
+	DatapathType string            `ovsdb:"datapath_type"`
+	DatapathID   *string           `ovsdb:"datapath_id"`
+	OtherConfig  map[string]string `ovsdb:"other_config"`
+	ExternalIds  map[string]string `ovsdb:"external_ids"`
+	Ports        []string          `ovsdb:"ports"`
+	Status       map[string]string `ovsdb:"status"`
+}
+
+// OvsType is the simplified ORM model of the Bridge table
+type OvsType struct {
+	UUID    string   `ovsdb:"_uuid"`
+	Bridges []string `ovsdb:"bridges"`
+}
+
+func GetSchema() (ovsdb.DatabaseSchema, error) {
+	var dbSchema ovsdb.DatabaseSchema
+	err := json.Unmarshal([]byte(schema), &dbSchema)
+	return dbSchema, err
 }


### PR DESCRIPTION
Per RFC7047, index duplication is a commit constraint and errors should
be reported as an additional operation result. Verification should be deferred 
until all operations have been processed and can be taken into account.

This commit also includes:

* moving the database & transaction to its own package
for better clarity & organization.
*  Make sure that the server transact has conformance with 
RFC7047, that is operations are processed until first error,
a result is provided for each operation, being null for non executed
operations, and include an additional result in case of a deferred
constraint validation error.
* Other small fixes and improvements made along the way.

Excerpts from the RFC7047.

  * About transact:

       ```
       The database server executes each of the specified operations in the
       specified order, except if an operation fails, then the remaining
       operations are not executed.
       ```

  * About results

    ```
     In general, "result" contains some number of successful results,
     possibly followed by an error, in turn followed by enough JSON null
     values to match the number of elements in "params".  There is one
     exception: if all of the operations succeed, but the results cannot
     be committed, then "result" will have one more element than "params",
     with the additional element being an <error>.
     ```

* About indexes

    ```
    If "indexes" is specified, it must be an array of zero or more
    <column-set>s.  A <column-set> is an array of one or more strings,
    each of which names a column.  Each <column-set> is a set of
    columns whose values, taken together within any given row, must be
    unique within the table.  This is a "deferred" constraint,
    enforced only at transaction commit time, after unreferenced rows
    are deleted and dangling weak references are removed.  Ephemeral
    columns may not be part of indexes.
    ```

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>