### PR TITLE
Client: Support conditional monitoring

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -840,6 +840,20 @@ func (o *ovsdbClient) Monitor(ctx context.Context, monitor *Monitor) (MonitorCoo
 	return cookie, o.monitor(ctx, cookie, false, monitor)
 }
 
+// If fields is provided, the request will be constrained to the provided columns
+// If no fields are provided, all columns will be used
+func newMonitorRequest(data *mapper.Info, fields []string) (*ovsdb.MonitorRequest, error) {
+	var columns []string
+	if len(fields) > 0 {
+		columns = append(columns, fields...)
+	} else {
+		for c := range data.Metadata.TableSchema.Columns {
+			columns = append(columns, c)
+		}
+	}
+	return &ovsdb.MonitorRequest{Columns: columns, Select: ovsdb.NewDefaultMonitorSelect()}, nil
+}
+
 //gocyclo:ignore
 // monitor must only be called with a lock on monitorsMutex
 func (o *ovsdbClient) monitor(ctx context.Context, cookie MonitorCookie, reconnecting bool, monitor *Monitor) error {
@@ -864,7 +878,6 @@ func (o *ovsdbClient) monitor(ctx context.Context, cookie MonitorCookie, reconne
 	dbName := cookie.DatabaseName
 	db := o.databases[dbName]
 	db.modelMutex.RLock()
-	mmapper := db.model.Mapper
 	typeMap := db.model.Types()
 	requests := make(map[string]ovsdb.MonitorRequest)
 	for _, o := range monitor.Tables {
@@ -880,7 +893,7 @@ func (o *ovsdbClient) monitor(ctx context.Context, cookie MonitorCookie, reconne
 		if err != nil {
 			return err
 		}
-		request, err := mmapper.NewMonitorRequest(info, o.Fields)
+		request, err := newMonitorRequest(info, o.Fields)
 		if err != nil {
 			return err
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -842,7 +842,7 @@ func (o *ovsdbClient) Monitor(ctx context.Context, monitor *Monitor) (MonitorCoo
 
 // If fields is provided, the request will be constrained to the provided columns
 // If no fields are provided, all columns will be used
-func newMonitorRequest(data *mapper.Info, fields []string) (*ovsdb.MonitorRequest, error) {
+func newMonitorRequest(data *mapper.Info, fields []string, conditions []ovsdb.Condition) (*ovsdb.MonitorRequest, error) {
 	var columns []string
 	if len(fields) > 0 {
 		columns = append(columns, fields...)
@@ -851,7 +851,7 @@ func newMonitorRequest(data *mapper.Info, fields []string) (*ovsdb.MonitorReques
 			columns = append(columns, c)
 		}
 	}
-	return &ovsdb.MonitorRequest{Columns: columns, Select: ovsdb.NewDefaultMonitorSelect()}, nil
+	return &ovsdb.MonitorRequest{Columns: columns, Where: conditions, Select: ovsdb.NewDefaultMonitorSelect()}, nil
 }
 
 //gocyclo:ignore
@@ -865,15 +865,15 @@ func (o *ovsdbClient) monitor(ctx context.Context, cookie MonitorCookie, reconne
 	if o.rpcClient == nil {
 		return ErrNotConnected
 	}
-	if len(monitor.Tables) == 0 {
-		return fmt.Errorf("at least one table should be monitored")
-	}
 	if len(monitor.Errors) != 0 {
 		var errString []string
 		for _, err := range monitor.Errors {
 			errString = append(errString, err.Error())
 		}
 		return fmt.Errorf(strings.Join(errString, ". "))
+	}
+	if len(monitor.Tables) == 0 {
+		return fmt.Errorf("at least one table should be monitored")
 	}
 	dbName := cookie.DatabaseName
 	db := o.databases[dbName]
@@ -893,7 +893,7 @@ func (o *ovsdbClient) monitor(ctx context.Context, cookie MonitorCookie, reconne
 		if err != nil {
 			return err
 		}
-		request, err := newMonitorRequest(info, o.Fields)
+		request, err := newMonitorRequest(info, o.Fields, o.Conditions)
 		if err != nil {
 			return err
 		}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1074,10 +1074,10 @@ func TestNewMonitorRequest(t *testing.T) {
 	testTable := &testType{}
 	info, err := mapper.NewInfo("TestTable", schema.Table("TestTable"), testTable)
 	assert.NoError(t, err)
-	mr, err := newMonitorRequest(info, nil)
+	mr, err := newMonitorRequest(info, nil, nil)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, mr.Columns, []string{"name", "config", "composed_1", "composed_2", "int1", "int2"})
-	mr2, err := newMonitorRequest(info, []string{"int1", "name"})
+	mr2, err := newMonitorRequest(info, []string{"int1", "name"}, nil)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, mr2.Columns, []string{"int1", "name"})
 }

--- a/client/monitor_test.go
+++ b/client/monitor_test.go
@@ -50,3 +50,34 @@ func TestWithTableAndFields(t *testing.T) {
 	assert.Equal(t, 1, len(m.Tables))
 	assert.ElementsMatch(t, []string{"bridges", "cur_cfg"}, m.Tables[0].Fields)
 }
+
+func TestWithTableAndFieldsAndConditions(t *testing.T) {
+	client, err := newOVSDBClient(defDB)
+	assert.NoError(t, err)
+	populateClientModel(t, client)
+
+	m := newMonitor()
+	bridge := Bridge{}
+
+	conditions := []model.Condition{
+		{
+			Field:    &bridge.Name,
+			Function: ovsdb.ConditionEqual,
+			Value:    "foo",
+		},
+	}
+
+	opt := WithConditionalTable(&bridge, conditions, &bridge.Name, &bridge.DatapathType)
+	err = opt(client, m)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(m.Tables))
+	assert.ElementsMatch(t, []string{"name", "datapath_type"}, m.Tables[0].Fields)
+	assert.ElementsMatch(t, []ovsdb.Condition{
+		{
+			Column:   "name",
+			Function: ovsdb.ConditionEqual,
+			Value:    "foo",
+		},
+	}, m.Tables[0].Conditions)
+}

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -315,18 +315,3 @@ func (m Mapper) equalIndexes(one, other *Info, indexes ...string) (bool, error) 
 	}
 	return false, nil
 }
-
-// NewMonitorRequest returns a monitor request for the provided tableName
-// If fields is provided, the request will be constrained to the provided columns
-// If no fields are provided, all columns will be used
-func (m *Mapper) NewMonitorRequest(data *Info, fields []string) (*ovsdb.MonitorRequest, error) {
-	var columns []string
-	if len(fields) > 0 {
-		columns = append(columns, fields...)
-	} else {
-		for c := range data.Metadata.TableSchema.Columns {
-			columns = append(columns, c)
-		}
-	}
-	return &ovsdb.MonitorRequest{Columns: columns, Select: ovsdb.NewDefaultMonitorSelect()}, nil
-}

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -1060,71 +1059,4 @@ func testOvsMap(t *testing.T, set interface{}) ovsdb.OvsMap {
 	oMap, err := ovsdb.NewOvsMap(set)
 	assert.Nil(t, err)
 	return oMap
-}
-
-func TestNewMonitorRequest(t *testing.T) {
-	var testSchema = []byte(`{
-  "cksum": "223619766 22548",
-  "name": "TestSchema",
-  "tables": {
-    "TestTable": {
-      "indexes": [["name"],["composed_1","composed_2"]],
-      "columns": {
-        "name": {
-          "type": "string"
-        },
-        "composed_1": {
-          "type": {
-            "key": "string"
-          }
-        },
-        "composed_2": {
-          "type": {
-            "key": "string"
-          }
-        },
-        "int1": {
-          "type": {
-            "key": "integer"
-          }
-        },
-        "int2": {
-          "type": {
-            "key": "integer"
-          }
-        },
-        "config": {
-          "type": {
-            "key": "string",
-            "max": "unlimited",
-            "min": 0,
-            "value": "string"
-          }
-	}
-      }
-    }
-  }
-}`)
-	type testType struct {
-		ID     string            `ovsdb:"_uuid"`
-		MyName string            `ovsdb:"name"`
-		Config map[string]string `ovsdb:"config"`
-		Comp1  string            `ovsdb:"composed_1"`
-		Comp2  string            `ovsdb:"composed_2"`
-		Int1   int               `ovsdb:"int1"`
-		Int2   int               `ovsdb:"int2"`
-	}
-	var schema ovsdb.DatabaseSchema
-	err := json.Unmarshal(testSchema, &schema)
-	require.NoError(t, err)
-	mapper := NewMapper(schema)
-	testTable := &testType{}
-	info, err := NewInfo("TestTable", schema.Table("TestTable"), testTable)
-	assert.NoError(t, err)
-	mr, err := mapper.NewMonitorRequest(info, nil)
-	require.NoError(t, err)
-	assert.ElementsMatch(t, mr.Columns, []string{"name", "config", "composed_1", "composed_2", "int1", "int2"})
-	mr2, err := mapper.NewMonitorRequest(info, []string{"int1", "name"})
-	require.NoError(t, err)
-	assert.ElementsMatch(t, mr2.Columns, []string{"int1", "name"})
 }


### PR DESCRIPTION
Today the WithConditionalTable interface exists for condition monitor
but it doesn't really work.

This patches fix the interface WithConditionalTable to support multiple
conditions, properly convert the model.Condition to ovsdb.Condition, and
apply the conditions in client.monitor implementation.

Signed-off-by: Han Zhou <hzhou@ovn.org>