### PR TITLE
treat unspecified max as 1

### DIFF
--- a/modelgen/table.go
+++ b/modelgen/table.go
@@ -343,7 +343,7 @@ func fieldType(tableName, columnName string, column *ovsdb.ColumnSchema, enumTyp
 			AtomicType(column.TypeObj.Value.Type))
 	case ovsdb.TypeSet:
 		// optional with max 1 element
-		if column.TypeObj.Min() == 0 && column.TypeObj.Max() == 1 {
+		if column.TypeObj.Min() == 0 && (column.TypeObj.Max() == 0 || column.TypeObj.Max() == 1) {
 			if enumTypes && FieldEnum(tableName, columnName, column) != nil {
 				return fmt.Sprintf("*%s", enumName(tableName, columnName))
 			}

--- a/ovsdb/bindings.go
+++ b/ovsdb/bindings.go
@@ -71,7 +71,7 @@ func NativeType(column *ColumnSchema) reflect.Type {
 	case TypeSet:
 		keyType := NativeTypeFromAtomic(column.TypeObj.Key.Type)
 		// optional type
-		if column.TypeObj.Min() == 0 && column.TypeObj.Max() == 1 {
+		if column.TypeObj.Min() == 0 && (column.TypeObj.Max() == 0 || column.TypeObj.Max() == 1) {
 			return reflect.PtrTo(keyType)
 		}
 		// non-optional type with max 1


### PR DESCRIPTION
 This rectifies an incongruence between the model generation and the validity checking. 
If you present a schema a scalar type with min = 0, and without a max, then the validator expects it to be a pointer, not an array.