### PR TITLE
Fixes handling column indexes with nil values

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1462,6 +1462,15 @@ func valueFromIndex(info *mapper.Info, columnKeys []model.ColumnKey) (interface{
 			if err != nil {
 				return "", err
 			}
+			// if object is nil dont try to encode it
+			value := reflect.ValueOf(val)
+			if value.Kind() == reflect.Invalid {
+				continue
+			}
+			// if object is a nil pointer dont try to encode it
+			if value.Kind() == reflect.Pointer && value.IsNil() {
+				continue
+			}
 			err = enc.Encode(val)
 			if err != nil {
 				return "", err


### PR DESCRIPTION
Ignores nil values and nil pointers when determining unique indexes from keys.

Reported-at: https://github.com/ovn-org/ovn-kubernetes/pull/3399#issuecomment-1414399986

Signed-off-by: Tim Rozet <trozet@redhat.com>

