### PR TITLE
Add inactivity probe for ovsdb connection

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -986,30 +986,30 @@ func TestClientInactiveCheck(t *testing.T) {
 	// is started responding to echo requests.
 	server.DoEcho(false)
 	require.Eventually(t, func() bool {
-		ovs.inactiveMutex.Lock()
-		defer ovs.inactiveMutex.Unlock()
-		return ovs.isInActive == true
+		ovs.inactivityMutex.Lock()
+		defer ovs.inactivityMutex.Unlock()
+		return ovs.isInactivity == true
 	}, 10*time.Second, 1*time.Second)
 
 	server.DoEcho(true)
 	require.Eventually(t, func() bool {
-		ovs.inactiveMutex.Lock()
-		defer ovs.inactiveMutex.Unlock()
-		return ovs.isInActive == false
+		ovs.inactivityMutex.Lock()
+		defer ovs.inactivityMutex.Unlock()
+		return ovs.isInactivity == false
 	}, 10*time.Second, 1*time.Second)
 
 	server.DoEcho(false)
 	require.Eventually(t, func() bool {
-		ovs.inactiveMutex.Lock()
-		defer ovs.inactiveMutex.Unlock()
-		return ovs.isInActive == true
+		ovs.inactivityMutex.Lock()
+		defer ovs.inactivityMutex.Unlock()
+		return ovs.isInactivity == true
 	}, 10*time.Second, 1*time.Second)
 
 	server.DoEcho(true)
 	require.Eventually(t, func() bool {
-		ovs.inactiveMutex.Lock()
-		defer ovs.inactiveMutex.Unlock()
-		return ovs.isInActive == false
+		ovs.inactivityMutex.Lock()
+		defer ovs.inactivityMutex.Unlock()
+		return ovs.isInactivity == false
 	}, 10*time.Second, 1*time.Second)
 }
 

--- a/client/options.go
+++ b/client/options.go
@@ -17,19 +17,19 @@ const (
 )
 
 type options struct {
-	endpoints             []string
-	tlsConfig             *tls.Config
-	reconnect             bool
-	leaderOnly            bool
-	timeout               time.Duration
-	backoff               backoff.BackOff
-	logger                *logr.Logger
-	registry              prometheus.Registerer
-	shouldRegisterMetrics bool   // in case metrics are changed after-the-fact
-	metricNamespace       string // prometheus metric namespace
-	metricSubsystem       string // prometheus metric subsystem
-	inactiveCheck         bool
-	interval              time.Duration
+	endpoints               []string
+	tlsConfig               *tls.Config
+	reconnect               bool
+	leaderOnly              bool
+	timeout                 time.Duration
+	backoff                 backoff.BackOff
+	logger                  *logr.Logger
+	registry                prometheus.Registerer
+	shouldRegisterMetrics   bool   // in case metrics are changed after-the-fact
+	metricNamespace         string // prometheus metric namespace
+	metricSubsystem         string // prometheus metric subsystem
+	inactivityCheck         bool
+	inactivityCheckInterval time.Duration
 }
 
 type Option func(o *options) error
@@ -114,17 +114,17 @@ func WithReconnect(timeout time.Duration, backoff backoff.BackOff) Option {
 }
 
 // WithInactivityCheck tells the client to send Echo request to ovsdb
-// server periodically at specified interval. When echo request fails
-// consecutively 2 * interval, then attempts to reconnect with server.
-// Once reconnect is successful, then aliveness check would go on until
-// connection to the server is shutdown. The timeout argument is used
-// for constructing the context for sending each Echo and Reconnect
-// requests.
-func WithInactivityCheck(timeout, interval time.Duration) Option {
+// server periodically at specified inactivityCheckInterval. When echo
+// request fails consecutively 2 * inactivityCheckInterval, then attempts
+// to reconnect with server. Once reconnect is successful, then inactivity
+// check would go on until connection to the server is shutdown.
+// The timeout argument is used for constructing the context for sending
+// each Echo and Reconnect requests.
+func WithInactivityCheck(timeout, inactivityCheckInterval time.Duration) Option {
 	return func(o *options) error {
-		o.inactiveCheck = true
+		o.inactivityCheck = true
 		o.timeout = timeout
-		o.interval = interval
+		o.inactivityCheckInterval = inactivityCheckInterval
 		return nil
 	}
 }

--- a/modelgen/table_test.go
+++ b/modelgen/table_test.go
@@ -719,7 +719,7 @@ func TestFieldType(t *testing.T) {
 		out        string
 	}{
 		{"t1", "c1", &singleValueSetSchema, "*string"},
-		{"t1", "c2", &multipleValueSetSchema, "[2]string"},
+		{"t1", "c2", &multipleValueSetSchema, "[]string"},
 	}
 
 	for _, tt := range tests {

--- a/server/server.go
+++ b/server/server.go
@@ -36,10 +36,13 @@ type OvsdbServer struct {
 	txnMutex     sync.Mutex
 }
 
+func init() {
+	stdr.SetVerbosity(5)
+}
+
 // NewOvsdbServer returns a new OvsdbServer
 func NewOvsdbServer(db database.Database, models ...model.DatabaseModel) (*OvsdbServer, error) {
 	l := stdr.NewWithOptions(log.New(os.Stderr, "", log.LstdFlags), stdr.Options{LogCaller: stdr.All}).WithName("server")
-	stdr.SetVerbosity(5)
 	o := &OvsdbServer{
 		done:         make(chan struct{}, 1),
 		doEcho:       true,

--- a/server/server.go
+++ b/server/server.go
@@ -26,6 +26,7 @@ type OvsdbServer struct {
 	done         chan struct{}
 	db           database.Database
 	ready        bool
+	doEcho       bool
 	readyMutex   sync.RWMutex
 	models       map[string]model.DatabaseModel
 	modelsMutex  sync.RWMutex
@@ -41,6 +42,7 @@ func NewOvsdbServer(db database.Database, models ...model.DatabaseModel) (*Ovsdb
 	stdr.SetVerbosity(5)
 	o := &OvsdbServer{
 		done:         make(chan struct{}, 1),
+		doEcho:       true,
 		db:           db,
 		models:       make(map[string]model.DatabaseModel),
 		modelsMutex:  sync.RWMutex{},
@@ -81,6 +83,12 @@ func (o *OvsdbServer) OnConnect(f func(*rpc2.Client)) {
 // OnDisConnect registers a function to run when a client disconnects.
 func (o *OvsdbServer) OnDisConnect(f func(*rpc2.Client)) {
 	o.srv.OnDisconnect(f)
+}
+
+func (o *OvsdbServer) DoEcho(ok bool) {
+	o.readyMutex.Lock()
+	o.doEcho = ok
+	o.readyMutex.Unlock()
 }
 
 // Serve starts the OVSDB server on the given path and protocol
@@ -382,6 +390,11 @@ func (o *OvsdbServer) Unlock(client *rpc2.Client, args []interface{}, reply *[]i
 
 // Echo tests the liveness of the connection
 func (o *OvsdbServer) Echo(client *rpc2.Client, args []interface{}, reply *[]interface{}) error {
+	o.readyMutex.Lock()
+	defer o.readyMutex.Unlock()
+	if !o.doEcho {
+		return fmt.Errorf("no echo reply")
+	}
 	echoReply := make([]interface{}, len(args))
 	copy(echoReply, args)
 	*reply = echoReply

--- a/test/ovs/ovs_integration_test.go
+++ b/test/ovs/ovs_integration_test.go
@@ -80,6 +80,7 @@ func (suite *OVSIntegrationSuite) SetupTest() {
 			defDB,
 			client.WithEndpoint(endpoint),
 			client.WithLeaderOnly(true),
+			client.WithInactivityCheck(10*time.Second, 5*time.Second),
 		)
 		if err != nil {
 			return err

--- a/test/ovs/ovs_integration_test.go
+++ b/test/ovs/ovs_integration_test.go
@@ -80,7 +80,7 @@ func (suite *OVSIntegrationSuite) SetupTest() {
 			defDB,
 			client.WithEndpoint(endpoint),
 			client.WithLeaderOnly(true),
-			client.WithInactivityCheck(10*time.Second, 5*time.Second),
+			client.WithInactivityCheck(10*time.Second, 1*time.Second),
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
This enhances ovsdb client to sends echo request periodically at specified interval to ovsdb server, when echo request fails consecutively 2 * interval then consider connection as inactive and then attempts to reconnect with server. This ensures early detection of ovsdb server connectivity issues and reconnect to the server immediately when it's back to operational.