### PR TITLE
fix comment operation

### DIFF
--- a/ovsdb/notation.go
+++ b/ovsdb/notation.go
@@ -30,7 +30,7 @@ const (
 // Operation represents an operation according to RFC7047 section 5.2
 type Operation struct {
 	Op        string      `json:"op"`
-	Table     string      `json:"table"`
+	Table     string      `json:"table,omitempty"`
 	Row       Row         `json:"row,omitempty"`
 	Rows      []Row       `json:"rows,omitempty"`
 	Columns   []string    `json:"columns,omitempty"`

--- a/test/ovs/ovs_integration_test.go
+++ b/test/ovs/ovs_integration_test.go
@@ -454,6 +454,10 @@ func (suite *OVSIntegrationSuite) TestMultipleOpsTransactIntegration() {
 	require.NoError(suite.T(), err)
 	operations = append(operations, op2...)
 
+	var op3Comment = "update external ids"
+	op3 := ovsdb.Operation{Op: ovsdb.OperationComment, Comment: &op3Comment}
+	operations = append(operations, op3)
+
 	reply, err := suite.client.Transact(context.TODO(), operations...)
 	require.NoError(suite.T(), err)
 


### PR DESCRIPTION
comment operation should not contain an empty table field.
![image](https://github.com/ovn-org/libovsdb/assets/4113173/5da275e8-fb1d-4814-9cb9-37ea0606f208)
https://datatracker.ietf.org/doc/html/rfc7047.txt#section-5.2.9
```
{
    "method":"transact",
    "params":[
        "OVN_Northbound",
        {
            "op":"comment",
            "table":"", // should not have this field
            "comment":"my test comment"
        }
    ],
    "id":7
}
```

fix #343 