### PR TITLE
Allow using client indices for `*string` columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ The table is inferred from the type that the function accepts as only argument.
 The client will track schema indexes and use them when appropriate in `Get`, `Where`, and `WhereAll` as explained above.
 
 Additional indexes can be specified for a client instance to track. Just as schema indexes, client indexes are specified in sets per table.
-where each set consists of the columns that compose the index. Unlike schema indexes, a key within a column can be addressed if the column
-type is a map.
+where each set consists of the columns that compose the index. However, unlike schema indexes, client indexes:
+- can be used with columns that are maps, where specific map keys can be indexed (see example below).
+- can be used with columns that are optional, where no-value columns are indexed as well.
 
 Client indexes are leveraged through `Where`, and `WhereAll`. Since client indexes value uniqueness is not enforced as it happens with schema indexes,
 conditions based on them can match multiple rows.

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1261,6 +1261,11 @@ func valueFromColumnKey(info *mapper.Info, columnKey model.ColumnKey) (interface
 			return "", fmt.Errorf("can't get key value from map: %v", err)
 		}
 	}
+	// if the value is a non-nil pointer of an optional, dereference
+	v := reflect.ValueOf(val)
+	if v.Kind() == reflect.Ptr && !v.IsNil() {
+		val = v.Elem().Interface()
+	}
 	return val, err
 }
 


### PR DESCRIPTION
When getting cache values, dereference pointers.
This allows using pointer fields (e.g. *string) as client indices.

Addresses https://github.com/ovn-org/libovsdb/issues/386