### PR TITLE
model: add Types() back to ClientDBModel

### DIFF
--- a/model/client.go
+++ b/model/client.go
@@ -36,6 +36,13 @@ func (db ClientDBModel) newModel(table string) (Model, error) {
 	return model.Interface().(Model), nil
 }
 
+// Types returns the ClientDBModel Types
+// The ClientDBModel types is a map of reflect.Types indexed by string
+// The reflect.Type is a pointer to a struct that contains 'ovs' tags.
+func (db ClientDBModel) Types() map[string]reflect.Type {
+	return db.types
+}
+
 // Name returns the database name
 func (db ClientDBModel) Name() string {
 	return db.name


### PR DESCRIPTION
The commit in the Fixes tag removed the Types() from the API. The intent was to centralize the internal use of the model around the DatabaseModel struct which contains both the ClientDBModel and the Schema.

However, it breaks the public API in a way that is not easy to fix for clients that used to use dbModel.Types() to access the Types that will be used in libovsdb. An example of such clients is https://github.com/amorenoz/ovsdb-mon  who uses the type information to generate a things like filters and autocompletion information.

This commit adds the deleted API back to ClientDBModel to allow clients an easy access of the internal typing information.

Fixes: 15361fce1eb3 ("model: move methods from ClientModel to DatabaseModel")