### PR TITLE
test: Enable the integration tests to run on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,4 +93,4 @@ jobs:
       - name: Integration Test
         run: make integration-test
         env:
-          OVS_IMAGE_TAG: ${{ matrix.ovs_version }}
+          OVS_VERSION: ${{ matrix.ovs_version }}

--- a/test/ovs/ovs_integration_test.go
+++ b/test/ovs/ovs_integration_test.go
@@ -34,9 +34,9 @@ func (suite *OVSIntegrationSuite) SetupSuite() {
 	suite.pool, err = dockertest.NewPool("")
 	suite.Require().NoError(err)
 
-	tag := os.Getenv("OVS_IMAGE_TAG")
+	tag := os.Getenv("OVS_VERSION")
 	if tag == "" {
-		tag = "2.15.0"
+		tag = "latest"
 	}
 
 	options := &dockertest.RunOptions{


### PR DESCRIPTION
Uses OVS_VERSION as the single environment variable for specifying the OVS version. This ensures the schemas and the version under test are consistent.

Replaces the hard-coded backup of 2.15.0 when OVS_VERSION is not set to use "latest" instead. OVS_VERSION is set in the Makefile so this branch should not be hit.