### PR TITLE
ci: Test changes to images workflow

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,8 +1,16 @@
 name: libovsdb-images
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
+    paths:
+      - .github/workflows/images.yml
+      - ovs/**
+  pull_request:
+    paths:
+      - .github/workflows/images.yml
+      - ovs/**
   schedule:
     # run weekly to ensure our copy of ovs is up-to-date
     - cron: "42 0 * * 0"
@@ -44,18 +52,19 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-      - name: Build and push
+      - name: Build and (optionally) push
         id: docker_build
         uses: docker/build-push-action@v6
         with:
           context: ovs
           builder: ${{ steps.buildx.outputs.name }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           build-args: OVS_VERSION=${{ matrix.image.ovs_version }}
           tags: libovsdb/ovs:${{ matrix.image.tag }}
           cache-from: type=local,src=/tmp/.buildx-cache


### PR DESCRIPTION
This adds a paths filter to the `push` event to only run the workflow when files have changed. The same filter is used to run this on PR events when the files have changed. On a PR run, we skip the Docker login and image push since the credentials aren't available. Worfklow_dispatch was added so the workflow can be manually run.

This should avoid needing to merge changes to main to test them out.