### PR TITLE
Fix deadlock in inactivity probe logic

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -838,7 +838,11 @@ func (o *ovsdbClient) transact(ctx context.Context, dbName string, skipChWrite b
 	}
 
 	if !skipChWrite && o.trafficSeen != nil {
-		o.trafficSeen <- struct{}{}
+		select {
+		case o.trafficSeen <- struct{}{}:
+		default:
+			// If the channel is full, drop the message
+		}
 	}
 	return reply, nil
 }

--- a/client/client_concurrency_test.go
+++ b/client/client_concurrency_test.go
@@ -1,0 +1,64 @@
+//go:build concurrency
+// +build concurrency
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInactivityTimeoutDeadlock(t *testing.T) {
+	var defSchema ovsdb.DatabaseSchema
+	err := json.Unmarshal([]byte(schema), &defSchema)
+	require.NoError(t, err)
+
+	server, sock := newOVSDBServer(t, defDB, defSchema)
+	server.SetTransactionDelay(200 * time.Millisecond)
+	server.SetEchoDelay(100 * time.Millisecond)
+
+	endpoint := fmt.Sprintf("unix:%s", sock)
+	client, err := NewOVSDBClient(defDB,
+		WithEndpoint(endpoint),
+		WithInactivityCheck(30*time.Millisecond, 20*time.Millisecond, backoff.NewConstantBackOff(time.Millisecond)),
+	)
+	require.NoError(t, err)
+
+	err = client.Connect(context.Background())
+	require.NoError(t, err)
+	defer client.Close()
+
+	_, err = client.MonitorAll(context.Background())
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	const numConcurrentTxns = 10
+	for i := range numConcurrentTxns {
+		go func(id int) {
+			bridge := &Bridge{
+				UUID:        fmt.Sprintf("deadlock-test-bridge-%d", id),
+				Name:        fmt.Sprintf("br-deadlock-%d", id),
+				ExternalIDs: map[string]string{"test": "deadlock"},
+			}
+
+			ops, err := client.Create(bridge)
+			if err != nil {
+				return
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			client.Transact(ctx, ops...)
+		}(i)
+	}
+
+	select {}
+}

--- a/client/options.go
+++ b/client/options.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"crypto/tls"
+	"errors"
 	"net/url"
 	"time"
 
@@ -120,6 +121,9 @@ func WithReconnect(timeout time.Duration, backoff backoff.BackOff) Option {
 func WithInactivityCheck(inactivityTimeout, reconnectTimeout time.Duration,
 	reconnectBackoff backoff.BackOff) Option {
 	return func(o *options) error {
+		if reconnectTimeout >= inactivityTimeout {
+			return errors.New("inactivity timeout value should be greater than reconnect timeout value")
+		}
 		o.reconnect = true
 		o.timeout = reconnectTimeout
 		o.backoff = reconnectBackoff


### PR DESCRIPTION
This PR fixes the deadlock(s) reported in #391.
The root cause of this deadlock is as follows:

1. A transaction completes, sending to `trafficSeen` which fills the channel (it's unbuffered)
2. Another transaction starts, taking `o.rpcMutex.RLock`
3. Meanwhile the `handleInactivityProbes` goroutine hits the `case <-time.After(o.options.inactivityTimeout):` branch calling `o.Disconnect()`. This acquires a `o.rpcMutex.Lock`. Per the Go documentation, all calls to `o.rpcMutex.RLock` will now block until the write lock has been acquired.
4. The in-flight transaction completes, but cannot send to `trafficSeen` since it's full. It therefore can't release the `RLock`

I've added a test case to reproduce this scenario by adding some artificial delays to the server echo and transact methods. This will reliably reproduce the deadlock - instructions are in the commit.

Commit 2 fixes the issue by simply doing a non-blocking send to the `trafficSeen` channel.
This is the minimum amount of code we can change to fix the issue.

Commit 3 is cherry-picked from #368 since it greatly cleans up the `handleInactivityProbes` function and makes it easier to maintain. I've made some minor changes here:
- Minor readability changes and comments around the use of the timer.
- The Echo request is sent using a context value of `o.options.inactivityTimeout` given that we'd expect the Echo request to return within this time. The documented purpose of `o.options.timeout` is that it's used in calls to `connect` only.

This differs from #368 in that it doesn't include any of the fixes relating to the rpc2 connection ending up in a bad state - i.e writes blocking for 30 mins. That is a different issue to this deadlock and can be handled seperately.