### PR TITLE
ci(check-ovs-versions): Add permissions

### DIFF
--- a/.github/workflows/check-ovs-versions.yml
+++ b/.github/workflows/check-ovs-versions.yml
@@ -6,6 +6,10 @@ on:
     - cron: "0 3 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   check-ovs-versions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CI was failing due to lack of permissions.
Add permissions to read contents and write pull-requests.