### PR TITLE
ci: continue on coverage upload failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Upload test coverage
         uses: shogo82148/actions-goveralls@v1
+        continue-on-error: true
         with:
           path-to-profile: profile.cov
 


### PR DESCRIPTION
Coveralls is down which is causing the CI to fail.
We should continue on errors to avoid our CI failing when there's an issue with an external service.