### PR TITLE
Fix race conditions when calling RPC methods right after Close()

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -599,6 +599,13 @@ func (o *ovsdbClient) DisconnectNotify() chan struct{} {
 	return o.disconnect
 }
 
+// isShutdown returns true if the client is in the process of shutting down
+func (o *ovsdbClient) isShutdown() bool {
+	o.shutdownMutex.Lock()
+	defer o.shutdownMutex.Unlock()
+	return o.shutdown
+}
+
 // RFC 7047 : Section 4.1.6 : Echo
 func (o *ovsdbClient) echo(args []any, reply *[]any) error {
 	*reply = args
@@ -831,7 +838,7 @@ func (o *ovsdbClient) transact(ctx context.Context, dbName string, skipChWrite b
 	}
 
 	args := ovsdb.NewTransactArgs(dbName, operation...)
-	if o.rpcClient == nil {
+	if o.rpcClient == nil || o.isShutdown() {
 		return nil, ErrNotConnected
 	}
 	dbgLogger := logger.WithValues("database", dbName).V(4)
@@ -872,7 +879,7 @@ func (o *ovsdbClient) MonitorCancel(ctx context.Context, cookie MonitorCookie) e
 	args := ovsdb.NewMonitorCancelArgs(cookie)
 	o.rpcMutex.Lock()
 	defer o.rpcMutex.Unlock()
-	if o.rpcClient == nil {
+	if o.rpcClient == nil || o.isShutdown() {
 		return ErrNotConnected
 	}
 	err := o.rpcClient.CallWithContext(ctx, "monitor_cancel", args, &reply)
@@ -927,7 +934,7 @@ func (o *ovsdbClient) monitor(ctx context.Context, cookie MonitorCookie, reconne
 		o.rpcMutex.RLock()
 		defer o.rpcMutex.RUnlock()
 	}
-	if o.rpcClient == nil {
+	if o.rpcClient == nil || o.isShutdown() {
 		return ErrNotConnected
 	}
 	if len(monitor.Errors) != 0 {
@@ -1083,7 +1090,7 @@ func (o *ovsdbClient) Echo(ctx context.Context) error {
 	var reply []any
 	o.rpcMutex.RLock()
 	defer o.rpcMutex.RUnlock()
-	if o.rpcClient == nil {
+	if o.rpcClient == nil || o.isShutdown() {
 		return ErrNotConnected
 	}
 	err := o.rpcClient.CallWithContext(ctx, "echo", args, &reply)

--- a/client/client.go
+++ b/client/client.go
@@ -1252,7 +1252,7 @@ func (o *ovsdbClient) handleDisconnectNotification() {
 	// wait for client related handlers to shutdown
 	o.handlerShutdown.Wait()
 	o.rpcMutex.Lock()
-	if o.options.reconnect && !o.shutdown {
+	if o.options.reconnect && !o.isShutdown() {
 		o.rpcClient = nil
 		o.rpcMutex.Unlock()
 		suppressionCounter := 1


### PR DESCRIPTION
- **client: check shutdown state before RPC calls to prevent panic**
- **client: fix data race reading shutdown flag in reconnect logic**

Fixes https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5885
