### PR TITLE
client: fix race condition in Echo() function

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1091,6 +1091,7 @@ func (o *ovsdbClient) Echo(ctx context.Context) error {
 		if err == rpc2.ErrShutdown {
 			return ErrNotConnected
 		}
+		return err
 	}
 	if !reflect.DeepEqual(args, reply) {
 		return fmt.Errorf("incorrect server response: %v, %v", args, reply)

--- a/client/echo_test.go
+++ b/client/echo_test.go
@@ -1,0 +1,79 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEchoRace reproduces the race condition in Echo() where the function
+// falls through after CallWithContext error and reads reply while the RPC
+// readLoop might still be writing to it.
+func TestEchoRace(t *testing.T) {
+	var defSchema ovsdb.DatabaseSchema
+	err := json.Unmarshal([]byte(schema), &defSchema)
+	require.NoError(t, err)
+
+	server, sock := newOVSDBServer(t, defDB, defSchema)
+	defer server.Close()
+
+	endpoint := fmt.Sprintf("unix:%s", sock)
+
+	client, err := NewOVSDBClient(defDB,
+		WithEndpoint(endpoint),
+		WithInactivityCheck(50*time.Millisecond, 25*time.Millisecond, backoff.NewConstantBackOff(time.Millisecond)),
+	)
+	require.NoError(t, err)
+
+	err = client.Connect(context.Background())
+	require.NoError(t, err)
+	defer client.Close()
+
+	var wg sync.WaitGroup
+
+	// Launch goroutines that continuously call Echo
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+				_ = client.Echo(ctx)
+				cancel()
+			}
+		}()
+	}
+
+	// Concurrently disconnect/reconnect to trigger errors
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				client.Disconnect()
+				time.Sleep(time.Millisecond)
+				_ = client.Connect(context.Background())
+				time.Sleep(time.Millisecond)
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		t.Fatal("Test timeout")
+	}
+}


### PR DESCRIPTION
The Echo() function had a race condition where it would fall through
and access the reply variable after CallWithContext() returned an error
(other than ErrShutdown). This caused a data race between the calling
goroutine reading reply in reflect.DeepEqual() and the RPC readLoop
goroutine potentially still writing to it during JSON unmarshaling.

The fix adds the missing error return, matching the pattern used in
all other RPC call sites (transact, getSchema, listDbs, etc).

Race detector output before fix:

```
WARNING: DATA RACE
Write at 0x00c000474930 by goroutine 438:
  reflect.Value.grow()
      /nix/store/60z37432vmgkg54krwr1z057bqwp7583-go-1.25.5/share/go/src/reflect/value.go:2677 +0x151
  reflect.Value.Grow()
      /nix/store/60z37432vmgkg54krwr1z057bqwp7583-go-1.25.5/share/go/src/reflect/value.go:2664 +0x7c
  encoding/json.(*decodeState).array()
      /nix/store/60z37432vmgkg54krwr1z057bqwp7583-go-1.25.5/share/go/src/encoding/json/decode.go:552 +0x784
  encoding/json.(*decodeState).value()
      /nix/store/60z37432vmgkg54krwr1z057bqwp7583-go-1.25.5/share/go/src/encoding/json/decode.go:370 +0x10d
  encoding/json.(*decodeState).unmarshal()
      /nix/store/60z37432vmgkg54krwr1z057bqwp7583-go-1.25.5/share/go/src/encoding/json/decode.go:183 +0x284
  encoding/json.Unmarshal()
      /nix/store/60z37432vmgkg54krwr1z057bqwp7583-go-1.25.5/share/go/src/encoding/json/decode.go:113 +0x224
  github.com/cenkalti/rpc2/jsonrpc.(*jsonCodec).ReadResponseBody()
      /home/ihrachyshka/go/pkg/mod/github.com/cenkalti/rpc2@v1.0.4/jsonrpc/jsonrpc.go:174 +0x7b
  github.com/cenkalti/rpc2.(*Client).readResponse()
      /home/ihrachyshka/go/pkg/mod/github.com/cenkalti/rpc2@v1.0.4/client.go:223 +0x395
  github.com/cenkalti/rpc2.(*Client).readLoop()
      /home/ihrachyshka/go/pkg/mod/github.com/cenkalti/rpc2@v1.0.4/client.go:99 +0x2d9
  github.com/cenkalti/rpc2.(*Client).Run()
      /home/ihrachyshka/go/pkg/mod/github.com/cenkalti/rpc2@v1.0.4/client.go:63 +0x33
  github.com/ovn-kubernetes/libovsdb/client.(*ovsdbClient).createRPC2Client.gowrap1()
      /home/ihrachyshka/src/libovsdb/client/client.go:446 +0x17

Previous read at 0x00c000474930 by goroutine 132:
  github.com/ovn-kubernetes/libovsdb/client.(*ovsdbClient).Echo()
      /home/ihrachyshka/src/libovsdb/client/client.go:1095 +0x279
  github.com/ovn-kubernetes/libovsdb/client.TestEchoRace.func1()
      /home/ihrachyshka/src/libovsdb/client/echo_concurrency_test.go:51 +0xd0
```

The race is reliably reproduced by the new TestEchoRace test which
runs concurrent Echo() calls while triggering disconnects/reconnects.
