### PR TITLE
make: fix lint target failing when GOPATH is not in PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ install-deps:
 .PHONY: lint
 lint: install-deps prebuild
 	@echo "+ $@"
-	@golangci-lint run
+	@$(shell go env GOPATH)/bin/golangci-lint run
 
 ovsdb/serverdb/_server.ovsschema:
 	@curl -sSL https://raw.githubusercontent.com/openvswitch/ovs/${OVS_VERSION}/ovsdb/_server.ovsschema -o $@


### PR DESCRIPTION
Without the patch it fails with:

```
make: golangci-lint: No such file or directory
make: *** [Makefile:52: lint] Error 127
```
