### PR TITLE
Fix spurious validate= due to float arithmetics bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Generate Code
         run: make prebuild
 
+      - name: Check generated files are up to date
+        run: make check-generated
+
       # This cannot be run in parallel because we require running go-generate first
       # We need to skip the go installation and caching to avoid "File exists" errors in tbe logs
       - name: Lint

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,15 @@ prebuild: modelgen ovsdb/serverdb/_server.ovsschema example/vswitchd/ovs.ovssche
 	@echo "+ $@"
 	@go generate -v ./...
 
+.PHONY: check-generated
+check-generated: prebuild
+	@echo "+ $@"
+	@if ! git diff --quiet; then \
+		echo "Error: generated files are out of date. Please run 'make prebuild' and commit the changes."; \
+		git diff --stat; \
+		exit 1; \
+	fi
+
 .PHONY: build
 build: prebuild
 	@echo "+ $@"

--- a/ovsdb/schema.go
+++ b/ovsdb/schema.go
@@ -246,11 +246,11 @@ func (b *BaseType) MinInteger() (int, error) {
 	if b.minInteger != nil {
 		return *b.minInteger, nil
 	}
-	return int(math.Pow(-2, 63)), nil
+	return math.MinInt64, nil
 }
 
-// MaxInteger returns the minimum integer value
-// RFC7047 specifies the minimum to be 2^63-1
+// MaxInteger returns the maximum integer value
+// RFC7047 specifies the maximum to be 2^63-1
 func (b *BaseType) MaxInteger() (int, error) {
 	if b.Type != TypeInteger {
 		return 0, fmt.Errorf("%s is not an integer", b.Type)
@@ -258,7 +258,7 @@ func (b *BaseType) MaxInteger() (int, error) {
 	if b.maxInteger != nil {
 		return *b.maxInteger, nil
 	}
-	return int(math.Pow(2, 63)) - 1, nil
+	return math.MaxInt64, nil
 }
 
 // MinLength returns the minimum string length
@@ -276,15 +276,15 @@ func (b *BaseType) MinLength() (int, error) {
 
 // MaxLength returns the maximum string length
 // RFC7047 doesn't specify a default, but we assume
-// that it must 2^63-1
+// that it must be 2^63-1
 func (b *BaseType) MaxLength() (int, error) {
 	if b.Type != TypeString {
-		return 0, fmt.Errorf("%s is not an string", b.Type)
+		return 0, fmt.Errorf("%s is not a string", b.Type)
 	}
 	if b.maxLength != nil {
 		return *b.maxLength, nil
 	}
-	return int(math.Pow(2, 63)) - 1, nil
+	return math.MaxInt64, nil
 }
 
 // RefTable returns the table to which a UUID type refers


### PR DESCRIPTION
math.Pow returns float64, which - at this power level (^63) - is
imprecise. It means that when we compared:

`int(math.Pow(2, 63) - 1` and `math.MaxInt64`

in `getIntegerValidations`, we always got inequality and a spurious
validate= tag in the generated models.

This results in the following diff if `make lint` is executed:

```diff
--- a/ovsdb/serverdb/database.go
+++ b/ovsdb/serverdb/database.go
@@ -22,11 +22,11 @@ type Database struct {
 	UUID      string        `ovsdb:"_uuid"`
 	Cid       *string       `ovsdb:"cid"`
 	Connected bool          `ovsdb:"connected"`
-	Index     *int          `ovsdb:"index"`
+	Index     *int          `ovsdb:"index" validate:"omitempty,max=9223372036854775806"`
 	Leader    bool          `ovsdb:"leader"`
-	Model     DatabaseModel `ovsdb:"model" validate:"oneof='standalone' 'clustered' 'relay'"`
-	Name      string        `ovsdb:"name"`
-	Schema    *string       `ovsdb:"schema"`
+	Model     DatabaseModel `ovsdb:"model" validate:"max=9223372036854775806,oneof='standalone' 'clustered' 'relay'"`
+	Name      string        `ovsdb:"name" validate:"max=9223372036854775806"`
+	Schema    *string       `ovsdb:"schema" validate:"omitempty,max=9223372036854775806"`
 	Sid       *string       `ovsdb:"sid"`
 }
```

Good news is there's no requirement to use `math.Pow` here, since we can
just refer to `math.MaxInt64`, so we can replace the formula with it.

I believe the original `math.Pow` implementation was supposed to reflect
the mathematical formula from RFC7047:

```
   <integer>
      A JSON number with an integer value, within the range -(2**63)...+
      (2**63)-1.
```

...but it didn't consider float arithmetics implications.
