### PR TITLE
waitForCacheConsistent with ConditionalAPI

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -115,10 +115,18 @@ type api struct {
 	cond          Conditional
 	logger        *logr.Logger
 	validateModel bool
+	// withReadLock optionally acquires a read lock (and any preconditions such as
+	// cache-consistency checks) and returns an unlock function.
+	withReadLock func(context.Context) func()
 }
 
 // List populates a slice of Models given as parameter based on the configured Condition
-func (a api) List(_ context.Context, result any) error {
+func (a api) List(ctx context.Context, result any) error {
+	unlock := a.lockForRead(ctx)
+	if unlock != nil {
+		defer unlock()
+	}
+
 	resultPtr := reflect.ValueOf(result)
 	if resultPtr.Type().Kind() != reflect.Ptr {
 		return &ErrWrongType{resultPtr.Type(), "Expected pointer to slice of valid Models"}
@@ -191,24 +199,24 @@ func (a api) List(_ context.Context, result any) error {
 // Where returns a conditionalAPI based on model indexes. All provided models
 // must be the same type.
 func (a api) Where(models ...model.Model) ConditionalAPI {
-	return newConditionalAPI(a.cache, a.conditionFromModels(models), a.logger, a.validateModel)
+	return newConditionalAPI(a.cache, a.conditionFromModels(models), a.logger, a.validateModel, a.withReadLock)
 }
 
 // WhereAny returns a conditionalAPI based on a Condition list that matches any
 // of the conditions individually
 func (a api) WhereAny(m model.Model, cond ...model.Condition) ConditionalAPI {
-	return newConditionalAPI(a.cache, a.conditionFromExplicitConditions(false, m, cond...), a.logger, a.validateModel)
+	return newConditionalAPI(a.cache, a.conditionFromExplicitConditions(false, m, cond...), a.logger, a.validateModel, a.withReadLock)
 }
 
 // WhereAll returns a conditionalAPI based on a Condition list that matches all
 // of the conditions together
 func (a api) WhereAll(m model.Model, cond ...model.Condition) ConditionalAPI {
-	return newConditionalAPI(a.cache, a.conditionFromExplicitConditions(true, m, cond...), a.logger, a.validateModel)
+	return newConditionalAPI(a.cache, a.conditionFromExplicitConditions(true, m, cond...), a.logger, a.validateModel, a.withReadLock)
 }
 
 // WhereCache returns a conditionalAPI based a Predicate
 func (a api) WhereCache(predicate any) ConditionalAPI {
-	return newConditionalAPI(a.cache, a.conditionFromFunc(predicate), a.logger, a.validateModel)
+	return newConditionalAPI(a.cache, a.conditionFromFunc(predicate), a.logger, a.validateModel, a.withReadLock)
 }
 
 // Conditional interface implementation
@@ -269,7 +277,12 @@ func (a api) conditionFromExplicitConditions(matchAll bool, m model.Model, cond 
 //
 // The way the cache is searched depends on the fields already populated in 'result'
 // Any table index (including _uuid) will be used for comparison
-func (a api) Get(_ context.Context, m model.Model) error {
+func (a api) Get(ctx context.Context, m model.Model) error {
+	unlock := a.lockForRead(ctx)
+	if unlock != nil {
+		defer unlock()
+	}
+
 	table, err := a.getTableFromModel(m)
 	if err != nil {
 		return err
@@ -290,6 +303,15 @@ func (a api) Get(_ context.Context, m model.Model) error {
 	model.CloneInto(found, m)
 
 	return nil
+}
+
+// lockForRead runs the optional read-lock hook and returns an unlock function.
+// If no hook is configured, it returns nil.
+func (a api) lockForRead(ctx context.Context) func() {
+	if a.withReadLock == nil {
+		return nil
+	}
+	return a.withReadLock(ctx)
 }
 
 // Create is a generic function capable of creating any row in the DB
@@ -633,22 +655,38 @@ func (a api) getTableFromFunc(predicate any) (string, error) {
 	return table, nil
 }
 
-// newAPI returns a new API to interact with the database
-func newAPI(cache *cache.TableCache, logger *logr.Logger, validateModel bool) API {
+// newAPI returns a new API to interact with the database.
+// If withReadLock is provided, the first hook is used by read-path methods
+// (currently Get and List) to guard cache reads and return a matching unlock func.
+func newAPI(cache *cache.TableCache, logger *logr.Logger, validateModel bool, withReadLock ...func(context.Context) func()) API {
+	var readLockFn func(context.Context) func()
+	if len(withReadLock) > 0 {
+		readLockFn = withReadLock[0]
+	}
+
 	return api{
 		cache:         cache,
 		logger:        logger,
 		validateModel: validateModel,
+		withReadLock:  readLockFn,
 	}
 }
 
-// newConditionalAPI returns a new ConditionalAPI to interact with the database
-func newConditionalAPI(cache *cache.TableCache, cond Conditional, logger *logr.Logger, validateModel bool) ConditionalAPI {
+// newConditionalAPI returns a new ConditionalAPI to interact with the database.
+// If withReadLock is provided, the first hook is propagated to conditional
+// read-path methods (currently List) to guard cache reads.
+func newConditionalAPI(cache *cache.TableCache, cond Conditional, logger *logr.Logger, validateModel bool, withReadLock ...func(context.Context) func()) ConditionalAPI {
+	var readLockFn func(context.Context) func()
+	if len(withReadLock) > 0 {
+		readLockFn = withReadLock[0]
+	}
+
 	return api{
 		cache:         cache,
 		cond:          cond,
 		logger:        logger,
 		validateModel: validateModel,
+		withReadLock:  readLockFn,
 	}
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -401,7 +401,12 @@ func (o *ovsdbClient) tryEndpoint(ctx context.Context, u *url.URL) (string, erro
 				db.cacheMutex.Unlock()
 				return "", err
 			}
-			db.api = newAPI(db.cache, o.logger, o.options.validateModel)
+			dbNameForWait := dbName
+			dbForWait := db
+			db.api = newAPI(db.cache, o.logger, o.options.validateModel, func(ctx context.Context) func() {
+				waitForCacheConsistent(ctx, dbForWait, o.logger, dbNameForWait)
+				return dbForWait.cacheMutex.RUnlock
+			})
 		}
 		db.cacheMutex.Unlock()
 	}
@@ -1408,10 +1413,7 @@ func hasMonitors(db *database) bool {
 
 // Get implements the API interface's Get function
 func (o *ovsdbClient) Get(ctx context.Context, model model.Model) error {
-	primaryDB := o.primaryDB()
-	waitForCacheConsistent(ctx, primaryDB, o.logger, o.primaryDBName)
-	defer primaryDB.cacheMutex.RUnlock()
-	return primaryDB.api.Get(ctx, model)
+	return o.primaryDB().api.Get(ctx, model)
 }
 
 // Create implements the API interface's Create function
@@ -1421,10 +1423,7 @@ func (o *ovsdbClient) Create(models ...model.Model) ([]ovsdb.Operation, error) {
 
 // List implements the API interface's List function
 func (o *ovsdbClient) List(ctx context.Context, result any) error {
-	primaryDB := o.primaryDB()
-	waitForCacheConsistent(ctx, primaryDB, o.logger, o.primaryDBName)
-	defer primaryDB.cacheMutex.RUnlock()
-	return primaryDB.api.List(ctx, result)
+	return o.primaryDB().api.List(ctx, result)
 }
 
 // Where implements the API interface's Where function

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2063,3 +2063,80 @@ func TestGetSelectResultsByIndex(t *testing.T) {
 		assert.Contains(t, err.Error(), "index 5 is out of range")
 	})
 }
+
+func TestConditionalWhereListWaitsForCacheConsistency(t *testing.T) {
+	ovs, err := newOVSDBClient(defDB)
+	require.NoError(t, err)
+
+	var s ovsdb.DatabaseSchema
+	err = json.Unmarshal([]byte(schema), &s)
+	require.NoError(t, err)
+
+	dbModel, errs := model.NewDatabaseModel(s, defDB)
+	require.Empty(t, errs)
+
+	bridge := &Bridge{
+		UUID: aUUID0,
+		Name: "br0",
+	}
+	tcache, err := cache.NewTableCache(dbModel, cache.Data{
+		"Bridge": {
+			bridge.UUID: bridge,
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	// Simulate reconnect/startup state:
+	// cache exists but monitor replay is still in progress (deferUpdates=true).
+	primaryDB := ovs.primaryDB()
+	primaryDB.cacheMutex.Lock()
+	primaryDB.cache = tcache
+	logger := logr.Discard()
+	primaryDB.api = newAPI(tcache, &logger, false, func(ctx context.Context) func() {
+		waitForCacheConsistent(ctx, primaryDB, &logger, ovs.primaryDBName)
+		return primaryDB.cacheMutex.RUnlock
+	})
+	primaryDB.deferUpdates = true
+	primaryDB.cacheMutex.Unlock()
+
+	// waitForCacheConsistent() only waits when monitors are present.
+	primaryDB.monitorsMutex.Lock()
+	primaryDB.monitors["monitor"] = &Monitor{}
+	primaryDB.monitorsMutex.Unlock()
+
+	type whereResult struct {
+		err  error
+		rows []*Bridge
+	}
+	done := make(chan whereResult, 1)
+	go func() {
+		var rows []*Bridge
+		err := ovs.Where(&Bridge{Name: "br0"}).List(context.Background(), &rows)
+		done <- whereResult{
+			err:  err,
+			rows: rows,
+		}
+	}()
+
+	// While cache is inconsistent, conditional List should block.
+	select {
+	case result := <-done:
+		t.Fatalf("Where(...).List returned before cache was marked consistent: err=%v rows=%d", result.err, len(result.rows))
+	case <-time.After(120 * time.Millisecond):
+	}
+
+	// Mark replay complete; reads should now proceed.
+	primaryDB.cacheMutex.Lock()
+	primaryDB.deferUpdates = false
+	primaryDB.cacheMutex.Unlock()
+
+	// After consistency, the same conditional List should complete and return the row.
+	select {
+	case result := <-done:
+		require.NoError(t, result.err)
+		require.Len(t, result.rows, 1)
+		require.Equal(t, bridge.UUID, result.rows[0].UUID)
+	case <-time.After(time.Second):
+		t.Fatal("Where(...).List did not complete after cache became consistent")
+	}
+}


### PR DESCRIPTION
In OVN-Kubernetes we saw in a stressed cluster that when OVNK starts up it may hit duplicate hairpinning Network Policy ACLs:

E0224 23:54:57.867583      56 factory.go:1591] Failed (will retry) while processing existing *v1.NetworkPolicy items: failed to create allow hairpin acl: failed to create or update hairpin allow ACL unexpectedly found multiple results for provided predicate

With the move to client indices in OVNK here: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/3142

we moved to use Where(...).List() instead of Get(). In the conditional API path we were not waitForCacheConsistent. Therefore on start up, we could execute this List before the client cache was finished being populated.

This fixes it by adding the missing waitForCacheConsistent to the conditional API path.