### PR TITLE
fix: don't panic on typed nil predicate

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -636,6 +636,9 @@ func (a api) getTableFromFunc(predicate any) (string, error) {
 	if predType == nil || predType.Kind() != reflect.Func {
 		return "", &ErrWrongType{predType, "Expected function"}
 	}
+	if reflect.ValueOf(predicate).IsNil() {
+		return "", &ErrWrongType{predType, "Expected non-nil function"}
+	}
 	if predType.NumIn() != 1 || predType.NumOut() != 1 || predType.Out(0).Kind() != reflect.Bool {
 		return "", &ErrWrongType{predType, "Expected func(Model) bool"}
 	}

--- a/client/api.go
+++ b/client/api.go
@@ -158,9 +158,14 @@ func (a api) List(ctx context.Context, result any) error {
 		return err
 	}
 
-	if a.cond != nil && a.cond.Table() != table {
-		return &ErrWrongType{resultPtr.Type(),
-			fmt.Sprintf("Table derived from input type (%s) does not match Table from Condition (%s)", table, a.cond.Table())}
+	if a.cond != nil {
+		if errCond, ok := a.cond.(*errorConditional); ok {
+			return errCond.err
+		}
+		if a.cond.Table() != table {
+			return &ErrWrongType{resultPtr.Type(),
+				fmt.Sprintf("Table derived from input type (%s) does not match Table from Condition (%s)", table, a.cond.Table())}
+		}
 	}
 
 	tableCache := a.cache.Table(table)

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -223,6 +223,7 @@ func TestAPIListPredicate(t *testing.T) {
 		predicate any
 		content   []model.Model
 		err       bool
+		errText   string
 	}{
 		{
 			name: "none",
@@ -241,8 +242,9 @@ func TestAPIListPredicate(t *testing.T) {
 			err:     false,
 		},
 		{
-			name: "nil interface must fail",
-			err:  true,
+			name:    "nil interface must fail",
+			err:     true,
+			errText: "Expected function",
 		},
 		{
 			name: "arbitrary condition",
@@ -269,6 +271,9 @@ func TestAPIListPredicate(t *testing.T) {
 			err := cond.List(context.Background(), &result)
 			if tt.err {
 				require.Error(t, err)
+				if tt.errText != "" {
+					require.ErrorContains(t, err, tt.errText)
+				}
 			} else {
 				require.NoError(t, err)
 				assert.ElementsMatchf(t, tt.content, result, "Content should match")

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -241,7 +241,7 @@ func TestAPIListPredicate(t *testing.T) {
 			err:     false,
 		},
 		{
-			name: "nil function must fail",
+			name: "nil interface must fail",
 			err:  true,
 		},
 		{
@@ -276,6 +276,17 @@ func TestAPIListPredicate(t *testing.T) {
 
 		})
 	}
+
+	t.Run("ApiListPredicate: typed nil function must fail", func(t *testing.T) {
+		var predicate func(*testLogicalSwitch) bool
+		var result []*testLogicalSwitch
+		api := newAPI(tcache, &discardLogger, false)
+		cond := api.WhereCache(predicate)
+
+		err := cond.List(context.Background(), &result)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "Expected non-nil function")
+	})
 }
 
 func TestAPIListWhereConditions(t *testing.T) {


### PR DESCRIPTION
- **client: reject typed nil predicates in WhereCache**
- **client: expose invalid predicate errors from List**
