### PR TITLE
docs: restructure README and introduce docs/ tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,143 +1,109 @@
 # libovsdb
 
-[![libovsdb-ci](https://github.com/ovn-kubernetes/libovsdb/actions/workflows/ci.yml/badge.svg)](https://github.com/ovn-kubernetes/libovsdb/actions/workflows/ci.yml) [![Coverage Status](https://coveralls.io/repos/github/ovn-kubernetes/libovsdb/badge.svg?branch=main)](https://coveralls.io/github/ovn-kubernetes/libovsdb?branch=main) [![Go Report Card](https://goreportcard.com/badge/github.com/ovn-kubernetes/libovsdb)](https://goreportcard.com/report/github.com/ovn-kubernetes/libovsdb)
+[![libovsdb-ci](https://github.com/ovn-kubernetes/libovsdb/actions/workflows/ci.yml/badge.svg)](https://github.com/ovn-kubernetes/libovsdb/actions/workflows/ci.yml)
+[![Coverage Status](https://coveralls.io/repos/github/ovn-kubernetes/libovsdb/badge.svg?branch=main)](https://coveralls.io/github/ovn-kubernetes/libovsdb?branch=main)
+[![Go Report Card](https://goreportcard.com/badge/github.com/ovn-kubernetes/libovsdb)](https://goreportcard.com/report/github.com/ovn-kubernetes/libovsdb)
 
-An OVSDB Library written in Go
+An OVSDB client library written in Go.
 
 ## What is OVSDB?
 
-OVSDB is the Open vSwitch Database Protocol.
-It's defined in [RFC 7047](http://tools.ietf.org/html/rfc7047)
-It's used mainly for managing the configuration of Open vSwitch and OVN, but it could also be used to manage your stamp collection. Philatelists Rejoice!
+OVSDB is the Open vSwitch Database Protocol, defined in [RFC 7047](http://tools.ietf.org/html/rfc7047).
+It is used primarily to manage the configuration of Open vSwitch and OVN.
 
-## Quick Overview
+## Quick Start
 
-The API to interact with OVSDB is based on tagged golang structs. We call it a Model. e.g:
+### 1. Define a Model
 
-    type MyLogicalSwitch struct {
-        UUID   string            `ovsdb:"_uuid"` // _uuid tag is mandatory
-        Name   string            `ovsdb:"name"`
-        Ports  []string          `ovsdb:"ports"`
-        Config map[string]string `ovsdb:"other_config"`
-    }
+Models are tagged Go structs that map to OVSDB tables:
 
-libovsdb is able to translate a Model in to OVSDB format.
-To make the API use go idioms, the following mappings occur:
+```go
+type MyLogicalSwitch struct {
+    UUID   string            `ovsdb:"_uuid"` // required
+    Name   string            `ovsdb:"name"`
+    Ports  []string          `ovsdb:"ports"`
+    Config map[string]string `ovsdb:"other_config"`
+}
+```
 
-1. OVSDB Set with min 0 and max unlimited = Slice
-1. OVSDB Set with min 0 and max 1 = Pointer to scalar type
-1. OVSDB Set with min 0 and max N = Array of N
-1. OVSDB Enum = Type-aliased Enum Type
-1. OVSDB Map = Map
-1. OVSDB Scalar Type = Equivalent scalar Go type
+OVSDB types map to Go types as follows:
 
-A Open vSwitch Database is modeled using a ClientDBModel which is a created by assigning table names to pointers to these structs:
+| OVSDB type | Go type |
+|---|---|
+| Set (min 0, max unlimited) | Slice |
+| Set (min 0, max 1) | Pointer to scalar |
+| Set (min 0, max N) | Array of N |
+| Enum | Type-aliased string |
+| Map | Map |
+| Scalar | Equivalent Go scalar |
 
-    dbModelReq, _ := model.NewClientDBModel("OVN_Northbound", map[string]model.Model{
-                "Logical_Switch": &MyLogicalSwitch{},
-    })
-    
-You can create a client object with options such as the endpoint:
+### 2. Create a Database Model
 
-    ovs, _ := client.NewOVSDBClient(*dbModelReq, client.WithEndpoint("tcp:172.18.0.4:6641"))
+```go
+dbModel, err := model.NewClientDBModel("OVN_Northbound", map[string]model.Model{
+    "Logical_Switch": &MyLogicalSwitch{},
+})
+```
 
-Finally, the client must be connected before use:
+### 3. Connect
 
-    ovs.Connect(context.Background())
-    ovs.MonitorAll(context.Background()) // Only needed if you want to use the built-in cache
+```go
+ovs, err := client.NewOVSDBClient(dbModel, client.WithEndpoint("tcp:172.18.0.4:6641"))
+if err != nil { ... }
 
-Once the client object is created, a generic API can be used to interact with the Database. Some API calls can be performed on the generic API: `List`, `Get`, `Create`, `Select` (for all rows).
+err = ovs.Connect(context.Background())
+err = ovs.MonitorAll(context.Background()) // required for cache-based operations
+```
 
-Others, have to be called on a `ConditionalAPI` (`Update`, `Delete`, `Mutate`, `Select` with conditions). There are three ways to create a `ConditionalAPI`:
+### 4. Interact with the Database
 
-**Where()**: `Where()` can be used to create a `ConditionalAPI` based on the index information that the provided Models contain. Example:
+```go
+// List all rows
+var switches []MyLogicalSwitch
+err = ovs.List(context.Background(), &switches)
 
-      ls := &LogicalSwitch{UUID: "foo"}
-      ls2 := &LogicalSwitch{UUID: "foo2"}
-      ops, _ := ovs.Where(ls, ls2).Delete()
+// Create
+ops, err := ovs.Create(&MyLogicalSwitch{Name: "foo"})
+_, err = ovs.Transact(context.Background(), ops...)
 
-It will check the field corresponding to the `_uuid` column as well as all the other schema-defined or client-defined indexes in that order of priority.
-The first available index will be used to generate a condition.
+// Get by index
+ls := &MyLogicalSwitch{Name: "foo"}
+err = ovs.Get(context.Background(), ls)
 
-**WhereAny()**: `WhereAny()` can be used to create a `ConditionalAPI` using a list of Condition objects. Each condition object specifies a field using a pointer
-to a Model's field, a `ovsdb.ConditionFunction` and a value. The type of the value depends on the type of the field being mutated. Example:
+// Update
+ls.Config["key"] = "value"
+ops, err = ovs.Where(ls).Update(ls)
+_, err = ovs.Transact(context.Background(), ops...)
 
-      ls := &LogicalSwitch{}
-      ops, _ := ovs.WhereAny(ls, client.Condition{
-          Field: &ls.Config,
-          Function: ovsdb.ConditionIncludes,
-          Value: map[string]string{"foo": "bar"},
-      }).Delete()
+// Delete
+ops, err = ovs.Where(ls).Delete()
+_, err = ovs.Transact(context.Background(), ops...)
+```
 
-The resulting `ConditionalAPI` will create one operation per condition, so all the rows that match _any_ of the specified conditions will be affected.
+For the full API — conditional queries (`Where`, `WhereAny`, `WhereAll`, `WhereCache`),
+client-defined indexes, `Select`, and cache event handlers — see the [API guide](docs/api.md).
 
-**WhereAll()**: `WhereAll()` behaves like `WhereAny()` but with _AND_ semantics. The resulting `ConditionalAPI` will put all the
-conditions into a single operation. Therefore the operation will affect the rows that satisfy _all_ the conditions.
+## Code Generation
 
-**WhereCache()**: `WhereCache()` uses a function callback to filter on the local cache. It's primary use is to perform cache operations such as
-`List()`. However, it can also be used to create server-side operations (such as `Delete()`, `Update()` or `Delete()`). If used this way, it will
-create an equality condition (using `ovsdb.ConditionEqual`) on the `_uuid` field for every matching row. Example:
+`modelgen` generates Go model types from an OVSDB schema file, so you don't have to
+write them by hand. See the [modelgen guide](docs/modelgen.md).
 
-    lsList := []LogicalSwitch{}
-    ovs.WhereCache(
-        func(ls *MyLogicalSwitch) bool {
-            return strings.HasPrefix(ls.Name, "ext_")
-    }).List(&lsList)
+## Package Documentation
 
-The table is inferred from the type that the function accepts as only argument.
+API reference for each sub-package is available on [pkg.go.dev](https://pkg.go.dev/):
 
-### Client indexes
+| Package | Description | |
+|---|---|---|
+| `client` | OVSDB client and API | [![][clientbadge]][clientdoc] |
+| `cache` | Model-based cache | [![][cachebadge]][cachedoc] |
+| `model` | Model and database model | [![][modelbadge]][modeldoc] |
+| `ovsdb` | Low-level OVSDB types | [![][ovsdbbadge]][ovsdbdoc] |
+| `mapper` | Tagged struct ↔ OVSDB mapping | [![][mapperbadge]][mapperdoc] |
+| `modelgen` | Code-generator library | [![][genbadge]][gendoc] |
+| `server` | In-process test server | [![][serverbadge]][serverdoc] |
+| `database` | Database types and interfaces | [![][dbbadge]][dbdoc] |
+| `updates` | Model update helpers | [![][updatesbadge]][updatesdoc] |
 
-The client will track schema indexes and use them when appropriate in `Get`, `Where`, and `WhereAll` as explained above.
-
-Additional indexes can be specified for a client instance to track. Just as schema indexes, client indexes are specified in sets per table.
-where each set consists of the columns that compose the index. However, unlike schema indexes, client indexes:
-
-- can be used with columns that are maps, where specific map keys can be indexed (see example below).
-- can be used with columns that are optional, where no-value columns are indexed as well.
-
-Client indexes are leveraged through `Where`, and `WhereAll`. Since client indexes value uniqueness is not enforced as it happens with schema indexes,
-conditions based on them can match multiple rows.
-
-Indexed based operations generally provide better performance than operations based on explicit conditions.
-
-As an example, where you would have:
-
-    // slow predicate run on all the LB table rows...
-    ovn.WhereCache(func (lb *LoadBalancer) bool {
-        return lb.ExternalIds["myIdKey"] == "myIdValue"
-    }).List(ctx, &results)
-
-can now be improved with:
-
-    dbModel, err := nbdb.FullDatabaseModel()
-    dbModel.SetIndexes(map[string][]model.ClientIndex{
-        "Load_Balancer": {{Columns: []model.ColumnKey{{Column: "external_ids", Key: "myIdKey"}}}},
-    })
-
-    // connect ....
-
-    lb := &LoadBalancer{
-        ExternalIds: map[string]string{"myIdKey": "myIdValue"},
-    }
-    // quick indexed result
-    ovn.Where(lb).List(ctx, &results)
-
-## Documentation
-
-This package is divided into several sub-packages. Documentation for each sub-package is available at [pkg.go.dev][doc]:
-
-- **client**: ovsdb client and API [![godoc for libovsdb/client][clientbadge]][clientdoc]
-- **mapper**: mapping from tagged structs to ovsdb types [![godoc for libovsdb/mapper][mapperbadge]][mapperdoc]
-- **model**: model and database model used for mapping [![godoc for libovsdb/model][modelbadge]][modeldoc]
-- **ovsdb**: low level OVS types [![godoc for libovsdb/ovsdb][ovsdbbadge]][ovsdbdoc]
-- **cache**: model-based cache [![godoc for libovsdb/cache][cachebadge]][cachedoc]
-- **modelgen**: common code-generator functions [![godoc for libovsdb/modelgen][genbadge]][gendoc]
-- **server**: ovsdb test server [![godoc for libovsdb/server][serverbadge]][serverdoc]
-- **database**: database related types, interfaces and implementations [![godoc for libovsdb/database][dbbadge]][dbdoc]
-- **updates**: common code to handle model updates [![godoc for libovsdb/updates][updatesbadge]][updatesdoc]
-
-[doc]: https://pkg.go.dev/
 [clientbadge]: https://pkg.go.dev/badge/github.com/ovn-kubernetes/libovsdb/client
 [mapperbadge]: https://pkg.go.dev/badge/github.com/ovn-kubernetes/libovsdb/mapper
 [modelbadge]: https://pkg.go.dev/badge/github.com/ovn-kubernetes/libovsdb/model
@@ -146,7 +112,7 @@ This package is divided into several sub-packages. Documentation for each sub-pa
 [genbadge]: https://pkg.go.dev/badge/github.com/ovn-kubernetes/libovsdb/modelgen
 [serverbadge]: https://pkg.go.dev/badge/github.com/ovn-kubernetes/libovsdb/server
 [dbbadge]: https://pkg.go.dev/badge/github.com/ovn-kubernetes/libovsdb/database
-[updatesbadge]: https://pkg.go.dev/badge/github.com/ovn-kubernetes/libovsdb/server
+[updatesbadge]: https://pkg.go.dev/badge/github.com/ovn-kubernetes/libovsdb/updates
 [clientdoc]: https://pkg.go.dev/github.com/ovn-kubernetes/libovsdb/client
 [mapperdoc]: https://pkg.go.dev/github.com/ovn-kubernetes/libovsdb/mapper
 [modeldoc]: https://pkg.go.dev/github.com/ovn-kubernetes/libovsdb/model
@@ -157,319 +123,33 @@ This package is divided into several sub-packages. Documentation for each sub-pa
 [dbdoc]: https://pkg.go.dev/github.com/ovn-kubernetes/libovsdb/database
 [updatesdoc]: https://pkg.go.dev/github.com/ovn-kubernetes/libovsdb/updates
 
-## Quick API Examples
+## Testing
 
-List the content of the database:
+### Unit Tests
 
-    var lsList *[]MyLogicalSwitch
-    ovs.List(lsList)
+```console
+make test
+```
 
-    for _, ls := range lsList {
-        fmt.Printf("%+v\n", ls)
-    }
+### Integration Tests
 
-Search the cache for elements that match a certain predicate:
+Integration tests require Docker with a running OVS container:
 
-    var lsList *[]MyLogicalSwitch
-    ovs.WhereCache(
-        func(ls *MyLogicalSwitch) bool {
-            return strings.HasPrefix(ls.Name, "ext_")
-    }).List(&lsList)
+```console
+make integration-test
+```
 
-    for _, ls := range lsList {
-        fmt.Printf("%+v\n", ls)
-    }
+To test against a specific OVS version:
 
-Create a new element
+```console
+OVS_VERSION=v3.4.0 make integration-test
+```
 
-    ops, _ := ovs.Create(&MyLogicalSwitch{
-        Name: "foo",
-    })
+## Contributing
 
-    ovs.Transact(ops...)
-
-Get an element:
-
-    ls := &MyLogicalSwitch{Name: "foo"} // "name" is in the table index list
-    ovs.Get(ls)
-
-And update it:
-
-    ls.Config["foo"] = "bar"
-    ops, _ := ovs.Where(ls).Update(&ls)
-    ovs.Transact(ops...)
-
-Or mutate an it:
-
-    ops, _ := ovs.Where(ls).Mutate(ls, ovs.Mutation {
-            Field:   &ls.Config,
-            Mutator: ovsdb.MutateOperationInsert,
-            Value:   map[string]string{"foo": "bar"},
-        })
-    ovs.Transact(ops...)
-
-Update, Mutate and Delete operations need a condition to be specified.
-Conditions can be created based on a Model's data:
-
-    ls := &LogicalSwitch{UUID:"myUUID"}
-    ops, _ := ovs.Where(ls).Delete()
-    ovs.Transact(ops...)
-
-They can also be created based on a list of Conditions:
-
-    ops, _ := ovs.Where(ls, client.Condition{
-        Field: &ls.Config,
-        Function: ovsdb.ConditionIncludes,
-        Value: map[string]string{"foo": "bar"},
-    }).Delete()
-
-    ovs.Transact(ops...)
-
-    ops, _ := ovs.WhereAll(ls,
-        client.Condition{
-            Field: &ls.Config,
-            Function: ovsdb.ConditionIncludes,
-            Value: map[string]string{"foo": "bar"},
-        }, client.Condition{
-            Field: &ls.Config,
-            Function: ovsdb.ConditionIncludes,
-            Value: map[string]string{"bar": "baz"},
-        }).Delete()
-    ovs.Transact(ops...)
-
-### Querying with Select
-
-The `Select` operation is used to build an OVSDB `select` query. Unlike the `List` operation, which returns results directly from the cache, `Select` only generates `ovsdb.Operation`(s). You must pass these operations to `Transact` to execute them against the database, and then use a helper function like `GetSelectResults` to parse the reply.
-
-The `Select` operation can be used in two ways:
-- **Direct Select**: Call `Select()` directly on the API for unconditional selection (selects all rows from a table)
-- **Conditional Select**: Call `Select()` on a `ConditionalAPI` created with `WhereXxx()` methods for filtered selection
-
-The core workflows are:
-- **Direct**: `ovs.Select(model, fields...) -> Transact(...) -> GetSelectResults(...)`
-- **Conditional**: `ovs.WhereXxx(...).Select(model, fields...) -> Transact(...) -> GetSelectResults(...)`
-
-#### Selecting Rows
-
-**Select All Rows from a Table:**
-
-To select all rows from a table, call `Select()` directly on the API. The model instance is used only to determine the target table and doesn't filter results.
-
-    // var ovs client.Client
-    // var ctx context.Context
-    var allSwitches []*MyLogicalSwitch // Target must be a slice of pointers to models
-    // 1. Generate Op: Direct Select selects all rows
-    selectOps, err := ovs.Select(&MyLogicalSwitch{})
-    // ...
-    // 2. Execute transaction
-    reply, err := ovs.Transact(ctx, selectOps...)
-    // ...
-    // 3. Parse result
-    err = ovs.GetSelectResults(selectOps, reply, &allSwitches)
-    // ...
-
-**Select by Index:**
-
-You can use `Where()` with a model instance that has indexed fields populated. This will create a condition to find matching rows based on the first available index.
-
-    // Assuming "Name" is an indexed field
-    ls := &MyLogicalSwitch{Name: "switch1"}
-    var results []*MyLogicalSwitch
-    // 1. Generate Op
-    selectOps, err := ovs.Where(ls).Select(ls)
-    // ...
-    // 2. Transact and parse
-    reply, err := ovs.Transact(ctx, selectOps...)
-    err = ovs.GetSelectResults(selectOps, reply, &results)
-    // ...
-
-**Select with Conditions (AND):**
-
-Use `WhereAll()` to set the table context and one or more filter conditions. All conditions are combined with an `AND` operator.
-
-    var specificSwitches []*MyLogicalSwitch
-    lsModel := &MyLogicalSwitch{}
-    cond1 := model.Condition{Field: &lsModel.Name, Function: ovsdb.ConditionEqual, Value: "sw1"}
-    cond2 := model.Condition{Field: &lsModel.Ports, Function: ovsdb.ConditionIncludes, Value: "some_port_uuid"}
-
-    // 1. Generate Op: Use WhereAll for one or more AND conditions
-    selectOps, err := ovs.WhereAll(lsModel, cond1, cond2).Select(lsModel)
-    // ...
-    // 2. Transact and parse
-    reply, err := ovs.Transact(ctx, selectOps...)
-    err = ovs.GetSelectResults(selectOps, reply, &specificSwitches)
-    // ...
-
-**Select with Conditions (OR):**
-
-Use `WhereAny()` to set the table context and one or more filter conditions. `WhereAny` will generate one `select` operation per condition. All generated operations belong to the same select query, allowing `GetSelectResults` to aggregate the results into a single slice.
-
-    var specificSwitches []*MyLogicalSwitch
-    lsModel := &MyLogicalSwitch{}
-    cond1 := model.Condition{Field: &lsModel.Name, Function: ovsdb.ConditionEqual, Value: "sw1"}
-    cond2 := model.Condition{Field: &lsModel.Ports, Function: ovsdb.ConditionIncludes, Value: "some_port_uuid"}
-
-    // 1. Generate Ops: Use WhereAny for one or more OR conditions
-    // This generates multiple operations, one for each condition
-    selectOps, err := ovs.WhereAny(lsModel, cond1, cond2).Select(lsModel)
-    // ...
-    // 2. Transact and parse
-    reply, err := ovs.Transact(ctx, selectOps...)
-    // GetSelectResults will parse all results and populate them into the target slice.
-    err = ovs.GetSelectResults(selectOps, reply, &specificSwitches)
-    // ...
-
-**Select with Cache-based Filtering:**
-
-Use `WhereCache()` to filter rows based on a predicate function that operates on cached data. This generates one `select` operation per matching cached row, using UUID-based conditions. All generated operations belong to the same select query.
-
-    var matchingSwitches []*MyLogicalSwitch
-
-    // 1. Generate Ops: Use WhereCache with a predicate function
-    // This generates multiple operations, one for each matching row in cache
-    selectOps, err := ovs.WhereCache(func(ls *MyLogicalSwitch) bool {
-        return strings.HasPrefix(ls.Name, "ext_")
-    }).Select(&MyLogicalSwitch{})
-    // ...
-    // 2. Transact and parse
-    reply, err := ovs.Transact(ctx, selectOps...)
-    // GetSelectResults will parse all results and populate them into the target slice.
-    err = ovs.GetSelectResults(selectOps, reply, &matchingSwitches)
-    // ...
-
-#### Selecting Specific Columns
-
-By default, `Select` queries all columns of a table. You can pass field pointers to the `Select` method to retrieve only specific columns. The `_uuid` column is always included in the result.
-
-**For Direct Select (all rows with specific columns):**
-
-    // Selects only the "name" and "ports" columns for all rows using field pointers
-    ls := &MyLogicalSwitch{}
-    selectOps, err := ovs.Select(ls, &ls.Name, &ls.Ports)
-
-**For Conditional Select (filtered rows with specific columns):**
-
-    // Selects only the "name" and "ports" columns for rows matching the condition
-    ls := &MyLogicalSwitch{Name: "sw1"}
-    selectOps, err := ovs.Where(ls).Select(ls, &ls.Name, &ls.Ports)
-
-#### Processing Select Results with GetSelectResults and GetSelectResultsByIndex
-
-Multiple `Select()` operations can be bundled within a transaction.
-**GetSelectResults** retrieves the results for the first select operation.
-**GetSelectResultsByIndex** allows you to choose which select operation to retrieve the results for:
-
-    // Example: Multiple separate Select() calls for the same model
-    var ptrResults1, ptrResults2 []*MyLogicalSwitch  // Target must be a pointer slice
-
-    // First Select() call - creates select query #0
-    ls1 := &MyLogicalSwitch{Name: "sw1"}
-    selectOps1, _ := ovs.Where(ls1).Select(ls1)
-
-    // Second Select() call - creates select query #1
-    ls2 := &MyLogicalSwitch{Name: "sw2"}
-    selectOps2, _ := ovs.Where(ls2).Select(ls2)
-
-    // Combine operations for a single transaction
-    allOps := append(selectOps1, selectOps2...)
-    reply, _ := ovs.Transact(ctx, allOps...)
-
-    // Get results from first Select() call (index 0)
-    err = ovs.GetSelectResults(allOps, reply, &ptrResults1)
-    err = ovs.GetSelectResultsByIndex(allOps, reply, &ptrResults1, 0) // Explicit index 0
-
-    // Get results from second Select() call (index 1)
-    err = ovs.GetSelectResultsByIndex(allOps, reply, &ptrResults2, 1)
-
-## Monitor for updates
-
-You can also register a notification handler to get notified every time an element is added, deleted or updated from the database.
-
-    handler := &cache.EventHandlerFuncs{
-        AddFunc: func(table string, model model.Model) {
-            if table == "Logical_Switch" {
-                fmt.Printf("A new switch named %s was added!!\n!", model.(*MyLogicalSwitch).Name)
-            }
-        },
-    }
-    ovs.Cache.AddEventHandler(handler)
-
-## modelgen
-
-In this repository there is also a code-generator capable of generating all the Model types for a given ovsdb schema (json) file.
-
-It can be used as follows:
-
-    go install github.com/ovn-kubernetes/libovsdb/cmd/modelgen
-
-    $GOPATH/bin/modelgen -p ${PACKAGE_NAME} -o {OUT_DIR} ${OVSDB_SCHEMA}
-    Usage of modelgen:
-            modelgen [flags] OVS_SCHEMA
-    Flags:
-      -d    Dry run
-      -o string
-            Directory where the generated files shall be stored (default ".")
-      -p string
-            Package name (default "ovsmodel")
-
-The result will be the definition of a Model per table defined in the ovsdb schema file.
-Additionally, a function called `FullDatabaseModel()` that returns the `ClientDBModel` is created for convenience.
-
-Example:
-
-Download the schema:
-
-    ovsdb-client get-schema "tcp:localhost:6641" > mypackage/ovs-nb.ovsschema
-
-Run `go generate`
-
-    cat <<EOF > mypackage/gen.go
-    package mypackage
-
-    // go:generate modelgen -p mypackage -o . ovs-nb.ovsschema
-    EOF
-    go generate ./...
-
-In your application, load the ClientDBModel, connect to the server and start interacting with the database:
-
-    import (
-        "fmt"
-        "github.com/ovn-kubernetes/libovsdb/client"
-
-        generated "example.com/example/mypackage"
-    )
-
-    func main() {
-        dbModelReq, _ := generated.FullDatabaseModel()
-        ovs, _ := client.Connect(context.Background(), dbModelReq, client.WithEndpoint("tcp:localhost:6641"))
-        ovs.MonitorAll()
-
-        // Create a *LogicalRouter, as a pointer to a Model is required by the API
-        lr := &generated.LogicalRouter{
-            Name: "myRouter",
-        }
-        ovs.Get(lr)
-        fmt.Printf("My Router has UUID: %s and %d Ports\n", lr.UUID, len(lr.Ports))
-    }
-
-## Running the tests
-
-To run integration tests, you'll need access to docker to run an Open vSwitch container.
-Mac users can use [boot2docker](http://boot2docker.io)
-
-    export DOCKER_IP=$(boot2docker ip)
-
-    docker-compose run test /bin/sh
-    # make test-local
-    ...
-    # exit
-    docker-compose down
-
-By invoking the command **make**, you will automatically get the same behavior as what
-is shown above. In other words, it will start the two containers and execute
-**make test-local** from the test container.
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Contact
 
-The libovsdb community is part of ovn-kubernetes and can be contacted in the _#libovsdb_ channel in
-[CNCF Slack server](https://cloud-native.slack.com/)
+The libovsdb community is part of ovn-kubernetes. Find us in the
+[#libovsdb channel](https://cloud-native.slack.com/) on the CNCF Slack server.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,307 @@
+# API Guide
+
+- [Conditional API](#conditional-api)
+  - [Where](#where)
+  - [WhereAny](#whereany)
+  - [WhereAll](#whereall)
+  - [WhereCache](#wherecache)
+- [Client Indexes](#client-indexes)
+- [Examples](#examples)
+  - [List](#list)
+  - [Create](#create)
+  - [Get](#get)
+  - [Update](#update)
+  - [Mutate](#mutate)
+  - [Delete](#delete)
+- [Select](#select)
+  - [Selecting Rows](#selecting-rows)
+  - [Selecting Specific Columns](#selecting-specific-columns)
+  - [Multiple Select Queries in One Transaction](#multiple-select-queries-in-one-transaction)
+- [Cache Event Handlers](#cache-event-handlers)
+
+## Conditional API
+
+Operations that affect specific rows (`Update`, `Delete`, `Mutate`, `Select`) must
+be called on a `ConditionalAPI`. There are four ways to create one.
+
+### Where
+
+`Where()` creates a `ConditionalAPI` based on the index fields of the provided models.
+It checks `_uuid` first, then schema-defined indexes, then client-defined indexes, in
+that order, and uses the first available index to generate a condition.
+
+```go
+ls := &LogicalSwitch{UUID: "foo"}
+ls2 := &LogicalSwitch{UUID: "foo2"}
+ops, err := ovs.Where(ls, ls2).Delete()
+```
+
+### WhereAny
+
+`WhereAny()` creates a `ConditionalAPI` from an explicit list of `Condition` objects.
+It generates one operation per condition, so rows matching **any** condition are affected.
+
+```go
+ls := &LogicalSwitch{}
+ops, err := ovs.WhereAny(ls, client.Condition{
+    Field:    &ls.Config,
+    Function: ovsdb.ConditionIncludes,
+    Value:    map[string]string{"foo": "bar"},
+}).Delete()
+```
+
+### WhereAll
+
+`WhereAll()` behaves like `WhereAny()` but with **AND** semantics. All conditions are
+combined into a single operation, so only rows satisfying every condition are affected.
+
+```go
+ops, err := ovs.WhereAll(ls,
+    client.Condition{
+        Field:    &ls.Config,
+        Function: ovsdb.ConditionIncludes,
+        Value:    map[string]string{"foo": "bar"},
+    },
+    client.Condition{
+        Field:    &ls.Config,
+        Function: ovsdb.ConditionIncludes,
+        Value:    map[string]string{"bar": "baz"},
+    },
+).Delete()
+```
+
+### WhereCache
+
+`WhereCache()` filters rows using a predicate on the local cache. It is primarily
+used for `List()`, but can also drive server-side operations — in that case it
+generates one equality condition on `_uuid` per matching cached row.
+
+```go
+var lsList []LogicalSwitch
+err = ovs.WhereCache(func(ls *LogicalSwitch) bool {
+    return strings.HasPrefix(ls.Name, "ext_")
+}).List(context.Background(), &lsList)
+```
+
+The table is inferred from the type accepted by the predicate function.
+
+## Client Indexes
+
+By default the client tracks schema indexes and uses them in `Get`, `Where`, and
+`WhereAll`. You can declare additional indexes for a client instance — for example,
+to index on a specific map key or on an optional column:
+
+```go
+dbModel, err := nbdb.FullDatabaseModel()
+dbModel.SetIndexes(map[string][]model.ClientIndex{
+    "Load_Balancer": {
+        {Columns: []model.ColumnKey{{Column: "external_ids", Key: "myIdKey"}}},
+    },
+})
+// connect ...
+```
+
+With this index, instead of a full cache scan:
+
+```go
+// slow — predicate runs against every row in the cache
+ovs.WhereCache(func(lb *LoadBalancer) bool {
+    return lb.ExternalIds["myIdKey"] == "myIdValue"
+}).List(ctx, &results)
+```
+
+you can use an indexed lookup:
+
+```go
+lb := &LoadBalancer{
+    ExternalIds: map[string]string{"myIdKey": "myIdValue"},
+}
+ovs.Where(lb).List(ctx, &results)
+```
+
+Unlike schema indexes, client indexes do not enforce uniqueness, so conditions based
+on them may match multiple rows.
+
+## Examples
+
+### List
+
+```go
+var switches []MyLogicalSwitch
+err = ovs.List(context.Background(), &switches)
+for _, ls := range switches {
+    fmt.Printf("%+v\n", ls)
+}
+```
+
+### Create
+
+```go
+ops, err := ovs.Create(&MyLogicalSwitch{Name: "foo"})
+_, err = ovs.Transact(context.Background(), ops...)
+```
+
+### Get
+
+```go
+ls := &MyLogicalSwitch{Name: "foo"} // "name" is in the index list
+err = ovs.Get(context.Background(), ls)
+```
+
+### Update
+
+```go
+ls.Config["foo"] = "bar"
+ops, err := ovs.Where(ls).Update(ls)
+_, err = ovs.Transact(context.Background(), ops...)
+```
+
+### Mutate
+
+```go
+ops, err := ovs.Where(ls).Mutate(ls, client.Mutation{
+    Field:   &ls.Config,
+    Mutator: ovsdb.MutateOperationInsert,
+    Value:   map[string]string{"foo": "bar"},
+})
+_, err = ovs.Transact(context.Background(), ops...)
+```
+
+### Delete
+
+```go
+// By index
+ls := &LogicalSwitch{UUID: "myUUID"}
+ops, err := ovs.Where(ls).Delete()
+_, err = ovs.Transact(context.Background(), ops...)
+
+// With a condition
+ops, err = ovs.WhereAny(ls, client.Condition{
+    Field:    &ls.Config,
+    Function: ovsdb.ConditionIncludes,
+    Value:    map[string]string{"foo": "bar"},
+}).Delete()
+_, err = ovs.Transact(context.Background(), ops...)
+```
+
+## Select
+
+`Select` builds an OVSDB `select` query. Unlike `List` (which reads from the local
+cache), `Select` generates `ovsdb.Operation`s that must be executed via `Transact`.
+Use `GetSelectResults` to parse the reply.
+
+Core patterns:
+
+```
+// All rows
+ovs.Select(model, fields...) → Transact → GetSelectResults
+
+// Filtered rows
+ovs.WhereXxx(...).Select(model, fields...) → Transact → GetSelectResults
+```
+
+### Selecting Rows
+
+**All rows:**
+
+```go
+var allSwitches []*MyLogicalSwitch
+selectOps, err := ovs.Select(&MyLogicalSwitch{})
+reply, err := ovs.Transact(ctx, selectOps...)
+err = ovs.GetSelectResults(selectOps, reply, &allSwitches)
+```
+
+**By index:**
+
+```go
+ls := &MyLogicalSwitch{Name: "switch1"} // "Name" is indexed
+var results []*MyLogicalSwitch
+selectOps, err := ovs.Where(ls).Select(ls)
+reply, err := ovs.Transact(ctx, selectOps...)
+err = ovs.GetSelectResults(selectOps, reply, &results)
+```
+
+**AND conditions:**
+
+```go
+lsModel := &MyLogicalSwitch{}
+selectOps, err := ovs.WhereAll(lsModel,
+    client.Condition{Field: &lsModel.Name, Function: ovsdb.ConditionEqual, Value: "sw1"},
+    client.Condition{Field: &lsModel.Ports, Function: ovsdb.ConditionIncludes, Value: "port-uuid"},
+).Select(lsModel)
+reply, err := ovs.Transact(ctx, selectOps...)
+err = ovs.GetSelectResults(selectOps, reply, &results)
+```
+
+**OR conditions:**
+
+`WhereAny` generates one `select` operation per condition; `GetSelectResults` aggregates
+all results into a single slice.
+
+```go
+selectOps, err := ovs.WhereAny(lsModel,
+    client.Condition{Field: &lsModel.Name, Function: ovsdb.ConditionEqual, Value: "sw1"},
+    client.Condition{Field: &lsModel.Name, Function: ovsdb.ConditionEqual, Value: "sw2"},
+).Select(lsModel)
+reply, err := ovs.Transact(ctx, selectOps...)
+err = ovs.GetSelectResults(selectOps, reply, &results)
+```
+
+**Cache-based filtering:**
+
+```go
+selectOps, err := ovs.WhereCache(func(ls *MyLogicalSwitch) bool {
+    return strings.HasPrefix(ls.Name, "ext_")
+}).Select(&MyLogicalSwitch{})
+reply, err := ovs.Transact(ctx, selectOps...)
+err = ovs.GetSelectResults(selectOps, reply, &results)
+```
+
+### Selecting Specific Columns
+
+Pass field pointers to `Select` to retrieve only those columns. `_uuid` is always included.
+
+```go
+ls := &MyLogicalSwitch{}
+selectOps, err := ovs.Select(ls, &ls.Name, &ls.Ports)
+
+// or conditionally:
+selectOps, err = ovs.Where(&MyLogicalSwitch{Name: "sw1"}).Select(ls, &ls.Name, &ls.Ports)
+```
+
+### Multiple Select Queries in One Transaction
+
+Use `GetSelectResultsByIndex` to retrieve results for a specific `Select` call when
+multiple are bundled into one transaction.
+
+```go
+ls1 := &MyLogicalSwitch{Name: "sw1"}
+selectOps1, _ := ovs.Where(ls1).Select(ls1)
+
+ls2 := &MyLogicalSwitch{Name: "sw2"}
+selectOps2, _ := ovs.Where(ls2).Select(ls2)
+
+allOps := append(selectOps1, selectOps2...)
+reply, _ := ovs.Transact(ctx, allOps...)
+
+var results1, results2 []*MyLogicalSwitch
+err = ovs.GetSelectResultsByIndex(allOps, reply, &results1, 0)
+err = ovs.GetSelectResultsByIndex(allOps, reply, &results2, 1)
+```
+
+## Cache Event Handlers
+
+Register a handler to be notified when rows are added, updated, or deleted:
+
+```go
+handler := &cache.EventHandlerFuncs{
+    AddFunc: func(table string, model model.Model) {
+        if table == "Logical_Switch" {
+            fmt.Printf("New switch: %s\n", model.(*MyLogicalSwitch).Name)
+        }
+    },
+    UpdateFunc: func(table string, old, new model.Model) { ... },
+    DeleteFunc: func(table string, model model.Model) { ... },
+}
+ovs.Cache().AddEventHandler(handler)
+```

--- a/docs/modelgen.md
+++ b/docs/modelgen.md
@@ -1,0 +1,74 @@
+# modelgen
+
+`modelgen` generates Go model types from an OVSDB schema file, so you don't need
+to write them by hand. It produces one struct per table and a `FullDatabaseModel()`
+convenience function.
+
+## Installation
+
+```console
+go install github.com/ovn-kubernetes/libovsdb/cmd/modelgen
+```
+
+## Usage
+
+```console
+modelgen [flags] OVS_SCHEMA
+
+Flags:
+  -d        Dry run (print output, don't write files)
+  -o string Directory where generated files are stored (default ".")
+  -p string Package name (default "ovsmodel")
+```
+
+## Example
+
+**1. Get the schema from a running OVSDB server:**
+
+```console
+ovsdb-client get-schema "tcp:localhost:6641" > mypackage/ovs-nb.ovsschema
+```
+
+**2. Add a `go:generate` directive:**
+
+```go
+// mypackage/gen.go
+package mypackage
+
+//go:generate modelgen -p mypackage -o . ovs-nb.ovsschema
+```
+
+**3. Run code generation:**
+
+```console
+go generate ./...
+```
+
+This writes one `.go` file per table plus a `FullDatabaseModel()` function.
+
+## Using the Generated Code
+
+```go
+import (
+    "context"
+    "fmt"
+
+    "github.com/ovn-kubernetes/libovsdb/client"
+    generated "example.com/example/mypackage"
+)
+
+func main() {
+    dbModel, err := generated.FullDatabaseModel()
+    if err != nil { ... }
+
+    ovs, err := client.NewOVSDBClient(dbModel, client.WithEndpoint("tcp:localhost:6641"))
+    if err != nil { ... }
+
+    err = ovs.Connect(context.Background())
+    err = ovs.MonitorAll(context.Background())
+
+    lr := &generated.LogicalRouter{Name: "myRouter"}
+    err = ovs.Get(context.Background(), lr)
+    fmt.Printf("Router %s has %d ports\n", lr.Name, len(lr.Ports))
+}
+```


### PR DESCRIPTION
## Summary

- Rewrites `README.md` as a clean quick-start:
  - Badges on separate lines
  - Type mapping rendered as a table
  - Fenced code blocks throughout
  - Updated test instructions (removes stale `boot2docker`/`docker-compose` references)
  - Links out to new docs and `CONTRIBUTING.md`
- Introduces `docs/` tree:
  - `docs/api.md` — full API reference: conditional API (`Where`, `WhereAny`, `WhereAll`, `WhereCache`), client indexes, CRUD examples, `Select`, cache event handlers
  - `docs/modelgen.md` — code generation workflow and usage example

## Test plan

- [ ] README renders correctly on GitHub
- [ ] All links in README resolve (docs pages, CONTRIBUTING.md, pkg.go.dev badges)
- [ ] docs/api.md and docs/modelgen.md render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)