### PR TITLE
ci: fix check-ovs-versions workflow PR creation

### DIFF
--- a/.github/workflows/check-ovs-versions.yml
+++ b/.github/workflows/check-ovs-versions.yml
@@ -32,10 +32,14 @@ jobs:
         if: steps.check_ovs.outputs.exit_code == '2'
         uses: peter-evans/create-pull-request@v8
         with:
-          commit-message: "chore: update OVS versions in images.yml to latest 3 releases"
+          commit-message: |
+            chore: update OVS versions in images.yml to latest 3 releases
+
+            Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           branch: update-ovs-versions
           title: "Update OVS versions in images.yml to latest 3 releases"
           body: |
             This PR updates the OVS versions in `.github/workflows/images.yml` to the latest patch release of the last 3 major.minor versions, as determined from https://github.com/openvswitch/ovs/tags.
           labels: "automation,dependencies"
-          sign-commits: true


### PR DESCRIPTION
## Summary

- Remove `sign-commits: true` from `peter-evans/create-pull-request@v8` — with this option the action uses the GitHub git data API (blobs/trees/commits) to push the branch, which fails with `Resource not accessible by integration` in this org's environment
- Add explicit `author`/`committer` set to `github-actions[bot]` with its canonical noreply email, and include a matching `Signed-off-by` trailer in the commit message to satisfy DCO checks

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` and confirm the PR creation step succeeds
- [ ] Confirm the generated commit has the `Signed-off-by` trailer and passes DCO

🤖 Generated with [Claude Code](https://claude.com/claude-code)