### PR TITLE
ci: add workflows permission to check-ovs-versions

### DIFF
--- a/.github/workflows/check-ovs-versions.yml
+++ b/.github/workflows/check-ovs-versions.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  workflows: write
 
 jobs:
   check-ovs-versions:


### PR DESCRIPTION
## Summary

- Add `workflows: write` permission to the `check-ovs-versions` workflow
- `contents: write` alone is insufficient when pushing changes to files under `.github/workflows/` — GitHub requires the explicit `workflows` permission for that

Followup to #476.

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` and confirm the PR creation step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)