### PR TITLE
build: update OVS versions to latest releases (3.7.1, 3.6.3, 3.5.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,9 @@ jobs:
     strategy:
       matrix:
         ovs_version:
-          - 3.5.0
-          - 3.4.0
-          - 3.3.0
+          - 3.7.1
+          - 3.6.3
+          - 3.5.4
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -28,12 +28,12 @@ jobs:
         image:
           - ovs_version: master
             tag: latest
-          - ovs_version: v3.5.0
-            tag: 3.5.0
-          - ovs_version: v3.4.0
-            tag: 3.4.0
-          - ovs_version: v3.3.0
-            tag: 3.3.0
+          - ovs_version: v3.7.1
+            tag: 3.7.1
+          - ovs_version: v3.6.3
+            tag: 3.6.3
+          - ovs_version: v3.5.4
+            tag: 3.5.4
         arch: [linux/amd64, linux/arm64]
     runs-on: ${{ matrix.arch == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
@@ -116,9 +116,9 @@ jobs:
       matrix:
         image:
           - tag: latest
-          - tag: 3.5.0
-          - tag: 3.4.0
-          - tag: 3.3.0
+          - tag: 3.7.1
+          - tag: 3.6.3
+          - tag: 3.5.4
     steps:
       - name: Download digests
         uses: actions/download-artifact@v8

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-OVS_VERSION ?= v3.5.0
+OVS_VERSION ?= v3.7.1
 
 TESTS ?=
 


### PR DESCRIPTION
## Summary

- Updates OVS versions tested and built to the latest patch releases as reported by `.github/scripts/check_ovs_versions.py`
- 3.3.0 → 3.7.1, 3.4.0 → 3.6.3, 3.5.0 → 3.5.4
- Updates `Makefile` `OVS_VERSION` to the overall latest release (`v3.7.1`)

## Test plan

- [ ] `images.yml` CI builds OVS container images for the new versions
- [ ] `ci.yml` integration tests run against the new OVS versions
- [ ] `.github/scripts/check_ovs_versions.py` reports versions are up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)