### PR TITLE
build: upgrade Go to 1.25.12 and golangci-lint to 2.12.2

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1260,7 +1260,7 @@ func valueFromColumnKey(info *mapper.Info, columnKey model.ColumnKey) (any, erro
 	}
 	// if the value is a non-nil pointer of an optional, dereference
 	v := reflect.ValueOf(val)
-	if v.Kind() == reflect.Ptr && !v.IsNil() {
+	if v.Kind() == reflect.Pointer && !v.IsNil() {
 		val = v.Elem().Interface()
 	}
 	return val, err

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -444,7 +444,8 @@ func TestRowCacheCreateMultiIndex(t *testing.T) {
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.wantIndexExistsErr {
-					assert.IsType(t, &ErrIndexExists{}, err)
+					var indexExistsErr *ErrIndexExists
+					require.ErrorAs(t, err, &indexExistsErr)
 				}
 			} else {
 				require.NoError(t, err)

--- a/client/api.go
+++ b/client/api.go
@@ -128,7 +128,7 @@ func (a api) List(ctx context.Context, result any) error {
 	}
 
 	resultPtr := reflect.ValueOf(result)
-	if resultPtr.Type().Kind() != reflect.Ptr {
+	if resultPtr.Type().Kind() != reflect.Pointer {
 		return &ErrWrongType{resultPtr.Type(), "Expected pointer to slice of valid Models"}
 	}
 
@@ -141,7 +141,7 @@ func (a api) List(ctx context.Context, result any) error {
 	// structs
 	var appendValue func(reflect.Value)
 	var m model.Model
-	if resultVal.Type().Elem().Kind() == reflect.Ptr {
+	if resultVal.Type().Elem().Kind() == reflect.Pointer {
 		m = reflect.New(resultVal.Type().Elem().Elem()).Interface()
 		appendValue = func(v reflect.Value) {
 			resultVal.Set(reflect.Append(resultVal, v))

--- a/client/client.go
+++ b/client/client.go
@@ -1470,7 +1470,7 @@ func (o *ovsdbClient) GetSelectResultsByIndex(ops []ovsdb.Operation, results []o
 
 	// Validate target parameter
 	slicePtr := reflect.ValueOf(target)
-	if slicePtr.Type().Kind() != reflect.Ptr || slicePtr.IsNil() {
+	if slicePtr.Type().Kind() != reflect.Pointer || slicePtr.IsNil() {
 		return &ErrWrongType{slicePtr.Type(), "target must be a non-nil pointer to a slice of models"}
 	}
 
@@ -1481,7 +1481,7 @@ func (o *ovsdbClient) GetSelectResultsByIndex(ops []ovsdb.Operation, results []o
 
 	// GetSelectResultsByIndex only accepts a pointer to a slice of pointers to models
 	modelType := sliceVal.Type().Elem()
-	if modelType.Kind() != reflect.Ptr {
+	if modelType.Kind() != reflect.Pointer {
 		return &ErrWrongType{slicePtr.Type(), "target must be a pointer to a slice of model pointers"}
 	}
 	modelType = modelType.Elem()

--- a/client/validation.go
+++ b/client/validation.go
@@ -25,11 +25,11 @@ func init() {
 // formatValidationErrors formats validator.ValidationErrors into a detailed human-readable string
 func formatValidationErrors(modelName string, context string, validationErrs validator.ValidationErrors) string {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("validation error for model %s", modelName))
+	fmt.Fprintf(&sb, "validation error for model %s", modelName)
 
 	// Append context if provided (e.g., "mutation on column X")
 	if context != "" {
-		sb.WriteString(fmt.Sprintf(": %s", context))
+		fmt.Fprintf(&sb, ": %s", context)
 	}
 
 	if len(validationErrs) > 0 {

--- a/mapper/info.go
+++ b/mapper/info.go
@@ -74,7 +74,7 @@ func (i *Info) SetField(column string, value any) error {
 // ColumnByPtr returns the column name that corresponds to the field by the field's pointer
 func (i *Info) ColumnByPtr(fieldPtr any) (string, error) {
 	fieldPtrVal := reflect.ValueOf(fieldPtr)
-	if fieldPtrVal.Kind() != reflect.Ptr {
+	if fieldPtrVal.Kind() != reflect.Pointer {
 		return "", ovsdb.NewErrWrongType("ColumnByPointer", "pointer to a field in the struct", fieldPtr)
 	}
 	offset := fieldPtrVal.Pointer() - reflect.ValueOf(i.Obj).Pointer()
@@ -127,7 +127,7 @@ OUTER:
 // NewInfo creates a MapperInfo structure around an object based on a given table schema
 func NewInfo(tableName string, table *ovsdb.TableSchema, obj any) (*Info, error) {
 	objPtrVal := reflect.ValueOf(obj)
-	if objPtrVal.Type().Kind() != reflect.Ptr {
+	if objPtrVal.Type().Kind() != reflect.Pointer {
 		return nil, ovsdb.NewErrWrongType("NewMapperInfo", "pointer to a struct", obj)
 	}
 	objVal := reflect.Indirect(objPtrVal)

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
 [tools]
-go = "1.24.0"
-golangci-lint = "2.2.1"
+go = "1.25.12"
+golangci-lint = "2.12.2"
 "go:golang.org/x/perf/cmd/benchstat" = "b57e4e3"

--- a/model/client.go
+++ b/model/client.go
@@ -136,7 +136,7 @@ func NewClientDBModel(name string, models map[string]Model) (ClientDBModel, erro
 	types := make(map[string]reflect.Type, len(models))
 	for table, model := range models {
 		modelType := reflect.TypeOf(model)
-		if modelType.Kind() != reflect.Ptr || modelType.Elem().Kind() != reflect.Struct {
+		if modelType.Kind() != reflect.Pointer || modelType.Elem().Kind() != reflect.Struct {
 			return ClientDBModel{}, fmt.Errorf("model is expected to be a pointer to struct")
 		}
 		hasUUID := false

--- a/ovsdb/bindings.go
+++ b/ovsdb/bindings.go
@@ -150,7 +150,7 @@ func OvsToNative(column *ColumnSchema, ovsElem any) (any, error) {
 		// The inner slice is []any
 		// We need to convert it to the real type os slice
 		switch naType.Kind() {
-		case reflect.Ptr:
+		case reflect.Pointer:
 			switch ovsSet := ovsElem.(type) {
 			case OvsSet:
 				if len(ovsSet.GoSet) > 1 {
@@ -410,7 +410,7 @@ func isDefaultBaseValue(elem any, etype ExtendedType) bool {
 	if !value.IsValid() {
 		return true
 	}
-	if reflect.TypeOf(elem).Kind() == reflect.Ptr {
+	if reflect.TypeOf(elem).Kind() == reflect.Pointer {
 		return reflect.ValueOf(elem).IsZero()
 	}
 	switch etype {

--- a/ovsdb/set.go
+++ b/ovsdb/set.go
@@ -21,7 +21,7 @@ type OvsSet struct {
 func NewOvsSet(obj any) (OvsSet, error) {
 	ovsSet := make([]any, 0)
 	var v reflect.Value
-	if reflect.TypeOf(obj).Kind() == reflect.Ptr {
+	if reflect.TypeOf(obj).Kind() == reflect.Pointer {
 		v = reflect.ValueOf(obj).Elem()
 		if v.Kind() == reflect.Invalid {
 			// must be a nil pointer, so just return an empty set

--- a/server/server_integration_test.go
+++ b/server/server_integration_test.go
@@ -258,7 +258,8 @@ func TestClientServerInsertDuplicate(t *testing.T) {
 	opErrs, err := ovsdb.CheckOperationResults(reply, ops)
 	require.Nil(t, opErrs)
 	require.Error(t, err)
-	require.IsTypef(t, &ovsdb.ConstraintViolation{}, err, err.Error())
+	var constraintViolation *ovsdb.ConstraintViolation
+	require.ErrorAs(t, err, &constraintViolation)
 }
 
 func TestClientServerInsertAndUpdate(t *testing.T) {

--- a/test/ovs/ovs_integration_test.go
+++ b/test/ovs/ovs_integration_test.go
@@ -843,7 +843,8 @@ func (suite *OVSIntegrationSuite) TestInsertDuplicateTransactIntegration() {
 
 	_, err = suite.createBridge("br-dup", nil, nil)
 	suite.Require().Error(err)
-	suite.IsType(&ovsdb.ConstraintViolation{}, err)
+	var constraintViolation *ovsdb.ConstraintViolation
+	suite.ErrorAs(err, &constraintViolation)
 }
 
 func (suite *OVSIntegrationSuite) TestUpdate() {


### PR DESCRIPTION
## Summary

golangci-lint 2.2.1 was compiled with Go 1.24 and explicitly rejects modules targeting `go 1.25.0` (which is what `main` already declares in `go.mod`). This causes the lint step to fail on any PR against current main.

## Changes

- `mise.toml`: bump Go `1.24.0` → `1.25.12`, golangci-lint `2.2.1` → `2.12.2`

## Pre-existing lint issues fixed by the upgraded linter

- `reflect.Ptr` → `reflect.Pointer` across 7 sites (`govet` `inline` check; `Ptr` is a deprecated alias)
- `WriteString(fmt.Sprintf(...))` → `fmt.Fprintf` in `client/validation.go` (staticcheck QF1012)
- `IsType` on errors → `ErrorAs` in 3 test files (testifylint `error-is-as`)