### PR TITLE
client: avoid closing trafficSeen during disconnect

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1251,13 +1251,14 @@ func (o *ovsdbClient) handleDisconnectNotification() {
 	<-o.rpcClient.DisconnectNotify()
 	// close the stopCh, which will stop the cache event processor
 	close(o.stopCh)
-	if o.trafficSeen != nil {
-		close(o.trafficSeen)
-	}
 	o.metrics.numDisconnects.Inc()
 	// wait for client related handlers to shutdown
 	o.handlerShutdown.Wait()
 	o.rpcMutex.Lock()
+	// trafficSeen may still have senders from transactions that hold rpcMutex
+	// for reading. stopCh also stops the inactivity handler, so trafficSeen
+	// must remain open until those transactions have completed.
+	o.trafficSeen = nil
 	if o.options.reconnect && !o.isShutdown() {
 		o.rpcClient = nil
 		o.rpcMutex.Unlock()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1135,6 +1135,41 @@ loop1:
 	}
 }
 
+func TestTrafficSeenNotClosedOnDisconnect(t *testing.T) {
+	var defSchema ovsdb.DatabaseSchema
+	err := json.Unmarshal([]byte(schema), &defSchema)
+	require.NoError(t, err)
+
+	serverDBModel, err := serverdb.FullDatabaseModel()
+	require.NoError(t, err)
+	_, sock := newOVSDBServer(t, defDB, defSchema)
+
+	endpoint := fmt.Sprintf("unix:%s", sock)
+	ovs, err := newOVSDBClient(serverDBModel,
+		WithInactivityCheck(time.Hour, time.Second, &backoff.ZeroBackOff{}),
+		WithEndpoint(endpoint))
+	require.NoError(t, err)
+	require.NoError(t, ovs.Connect(context.Background()))
+	t.Cleanup(ovs.Close)
+
+	oldTrafficSeen := ovs.trafficSeen
+	require.NotNil(t, oldTrafficSeen)
+
+	ovs.Disconnect()
+	require.Eventually(t, func() bool {
+		ovs.rpcMutex.RLock()
+		defer ovs.rpcMutex.RUnlock()
+		return ovs.connected && ovs.trafficSeen != oldTrafficSeen
+	}, 5*time.Second, 10*time.Millisecond)
+
+	require.NotPanics(t, func() {
+		select {
+		case oldTrafficSeen <- struct{}{}:
+		default:
+		}
+	})
+}
+
 func TestClientReconnectLeaderOnly(t *testing.T) {
 	var connected1, connected2, disConnected1, disConnected2 int32
 	cli1, row1, endpoint1 := newClientServerPair(t, &connected1, &disConnected1, true)


### PR DESCRIPTION
Transactions can still signal trafficSeen after the disconnect handler has stopped the inactivity handler. Closing trafficSeen before waiting for those transactions can cause a send-on-closed-channel panic.

Leave trafficSeen open and clear the field only after taking rpcMutex, which ensures all in-flight transactions have completed.

Add a regression test that verifies the old channel remains safe to signal after reconnecting.

Fixes: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6738