### PR TITLE
client: limit cache predicates by UUID

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -489,6 +489,25 @@ func (r *RowCache) RowsShallow() map[string]model.Model {
 	return result
 }
 
+// RowsByUUIDsShallow returns matching rows without cloning the models.
+// Returned models are READ ONLY.
+func (r *RowCache) RowsByUUIDsShallow(uuids []string) map[string]model.Model {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	capacity := len(uuids)
+	if capacity > len(r.cache) {
+		capacity = len(r.cache)
+	}
+	result := make(map[string]model.Model, capacity)
+	for _, uuid := range uuids {
+		if row, ok := r.cache[uuid]; ok {
+			result[uuid] = row
+		}
+	}
+	return result
+}
+
 // uuidsByConditionsAsIndexes checks possible indexes that can be built with a
 // subset of the provided conditions and returns the uuids for the models that
 // match that subset of conditions. If no conditions could be used as indexes,

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -132,6 +132,29 @@ func TestRowCache_Rows(t *testing.T) {
 	}
 }
 
+func TestRowCache_RowsByUUIDsShallow(t *testing.T) {
+	row1 := &testModel{UUID: "test1", Foo: "one"}
+	row2 := &testModel{UUID: "test2", Foo: "two"}
+	r := &RowCache{
+		cache: map[string]model.Model{
+			row1.UUID: row1,
+			row2.UUID: row2,
+		},
+	}
+
+	got := r.RowsByUUIDsShallow([]string{row2.UUID, "missing", row1.UUID, row1.UUID})
+	require.Len(t, got, 2)
+	assert.Same(t, row1, got[row1.UUID])
+	assert.Same(t, row2, got[row2.UUID])
+	delete(got, row1.UUID)
+	assert.Len(t, r.cache, 2)
+	assert.Same(t, row1, r.cache[row1.UUID])
+
+	empty := r.RowsByUUIDsShallow(nil)
+	assert.NotNil(t, empty)
+	assert.Empty(t, empty)
+}
+
 func TestRowCacheCreate(t *testing.T) {
 	var schema ovsdb.DatabaseSchema
 	db, err := model.NewClientDBModel("Open_vSwitch", map[string]model.Model{"Open_vSwitch": &testModel{}})

--- a/client/api.go
+++ b/client/api.go
@@ -27,6 +27,14 @@ type API interface {
 	// ConditionFromFunc(func(l *LogicalSwitch) bool { return l.Enabled })
 	WhereCache(predicate any) ConditionalAPI
 
+	// WhereCacheByUUIDs filters cached rows using a predicate limited to the
+	// supplied UUIDs. The predicate must accept a Model implementation and
+	// return a boolean. Missing UUIDs are ignored, duplicate UUIDs are evaluated
+	// once, and an empty UUID list matches no rows.
+	//
+	// Like WhereCache, the result can be used for List or server-side operations.
+	WhereCacheByUUIDs(predicate any, uuids ...string) ConditionalAPI
+
 	// Create a ConditionalAPI from a Model's index data, where operations
 	// apply to elements that match the values provided in one or more
 	// model.Models according to the indexes. All provided Models must be
@@ -224,6 +232,11 @@ func (a api) WhereCache(predicate any) ConditionalAPI {
 	return newConditionalAPI(a.cache, a.conditionFromFunc(predicate), a.logger, a.validateModel, a.withReadLock)
 }
 
+// WhereCacheByUUIDs filters cached rows using a predicate limited to the supplied UUIDs.
+func (a api) WhereCacheByUUIDs(predicate any, uuids ...string) ConditionalAPI {
+	return newConditionalAPI(a.cache, a.conditionFromFuncByUUIDs(predicate, uuids), a.logger, a.validateModel, a.withReadLock)
+}
+
 // Conditional interface implementation
 // FromFunc returns a Condition from a function
 func (a api) conditionFromFunc(predicate any) Conditional {
@@ -233,6 +246,20 @@ func (a api) conditionFromFunc(predicate any) Conditional {
 	}
 
 	condition, err := newPredicateConditional(table, a.cache, predicate)
+	if err != nil {
+		return newErrorConditional(err)
+	}
+	return condition
+}
+
+// conditionFromFuncByUUIDs returns a UUID-limited predicate condition.
+func (a api) conditionFromFuncByUUIDs(predicate any, uuids []string) Conditional {
+	table, err := a.getTableFromFunc(predicate)
+	if err != nil {
+		return newErrorConditional(err)
+	}
+
+	condition, err := newPredicateConditionalByUUIDs(table, a.cache, predicate, uuids)
 	if err != nil {
 		return newErrorConditional(err)
 	}
@@ -627,6 +654,9 @@ func (a api) getTableFromModel(m any) (string, error) {
 	if _, ok := m.(model.Model); !ok {
 		return "", &ErrWrongType{reflect.TypeOf(m), "Type does not implement Model interface"}
 	}
+	if a.cache == nil {
+		return "", ErrNotConnected
+	}
 	table := a.cache.DatabaseModel().FindTable(reflect.TypeOf(m))
 	if table == "" {
 		return "", &ErrWrongType{reflect.TypeOf(m), "Model not found in Database Model"}
@@ -653,6 +683,9 @@ func (a api) getTableFromFunc(predicate any) (string, error) {
 	if !modelType.Implements(modelInterface) {
 		return "", &ErrWrongType{predType,
 			fmt.Sprintf("Type %s does not implement Model interface", modelType.String())}
+	}
+	if a.cache == nil {
+		return "", ErrNotConnected
 	}
 
 	table := a.cache.DatabaseModel().FindTable(modelType)

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -28,6 +28,23 @@ var (
 
 var discardLogger = logr.Discard()
 
+type cacheOnlyClient struct {
+	Client
+	tableCache *cache.TableCache
+}
+
+func (c *cacheOnlyClient) Cache() *cache.TableCache {
+	return c.tableCache
+}
+
+func (c *cacheOnlyClient) WhereCache(predicate any) ConditionalAPI {
+	return newAPI(c.tableCache, &discardLogger, false).WhereCache(predicate)
+}
+
+func (c *cacheOnlyClient) WhereCacheByUUIDs(predicate any, uuids ...string) ConditionalAPI {
+	return newAPI(c.tableCache, &discardLogger, false).WhereCacheByUUIDs(predicate, uuids...)
+}
+
 func TestAPIListSimple(t *testing.T) {
 
 	lscacheList := []model.Model{
@@ -217,6 +234,7 @@ func TestAPIListPredicate(t *testing.T) {
 		"Logical_Switch": lscache,
 	}
 	tcache := apiTestCache(t, testData)
+	cacheClient := &cacheOnlyClient{tableCache: tcache}
 
 	test := []struct {
 		name      string
@@ -291,6 +309,97 @@ func TestAPIListPredicate(t *testing.T) {
 		err := cond.List(context.Background(), &result)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "Expected non-nil function")
+	})
+
+	t.Run("ApiListPredicate: limited by UUIDs", func(t *testing.T) {
+		candidateUUIDs := []string{aUUID0, aUUID1, aUUID3, "missing", aUUID1}
+		var predicateCalls []string
+		cond := cacheClient.WhereCacheByUUIDs(func(ls *testLogicalSwitch) bool {
+			predicateCalls = append(predicateCalls, ls.UUID)
+			return strings.HasPrefix(ls.Name, "magic")
+		}, candidateUUIDs...)
+		candidateUUIDs[0] = aUUID2
+
+		var result []*testLogicalSwitch
+		err := cond.List(context.Background(), &result)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []*testLogicalSwitch{
+			lscacheList[1].(*testLogicalSwitch),
+			lscacheList[3].(*testLogicalSwitch),
+		}, result)
+		assert.ElementsMatch(t, []string{aUUID0, aUUID1, aUUID3}, predicateCalls)
+	})
+
+	t.Run("ApiListPredicate: empty UUID list", func(t *testing.T) {
+		predicateCalls := 0
+		var result []*testLogicalSwitch
+		err := cacheClient.WhereCacheByUUIDs(func(*testLogicalSwitch) bool {
+			predicateCalls++
+			return true
+		}).List(context.Background(), &result)
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Empty(t, result)
+		assert.Zero(t, predicateCalls)
+	})
+
+	t.Run("ApiListPredicate: UUID-limited results are cloned", func(t *testing.T) {
+		var result []*testLogicalSwitch
+		err := cacheClient.WhereCacheByUUIDs(func(*testLogicalSwitch) bool {
+			return true
+		}, aUUID1).List(context.Background(), &result)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		result[0].ExternalIDs["mutated"] = "true"
+
+		var freshResult []*testLogicalSwitch
+		err = cacheClient.WhereCacheByUUIDs(func(*testLogicalSwitch) bool {
+			return true
+		}, aUUID1).List(context.Background(), &freshResult)
+		require.NoError(t, err)
+		require.Len(t, freshResult, 1)
+		assert.NotContains(t, freshResult[0].ExternalIDs, "mutated")
+	})
+
+	t.Run("ApiListPredicate: UUID-limited delete operations", func(t *testing.T) {
+		ops, err := cacheClient.WhereCacheByUUIDs(func(ls *testLogicalSwitch) bool {
+			return strings.HasPrefix(ls.Name, "magic")
+		}, aUUID0, aUUID1, aUUID3).Delete()
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []ovsdb.Operation{
+			{
+				Op:    ovsdb.OperationDelete,
+				Table: "Logical_Switch",
+				Where: []ovsdb.Condition{{Column: "_uuid", Function: ovsdb.ConditionEqual, Value: ovsdb.UUID{GoUUID: aUUID1}}},
+			},
+			{
+				Op:    ovsdb.OperationDelete,
+				Table: "Logical_Switch",
+				Where: []ovsdb.Condition{{Column: "_uuid", Function: ovsdb.ConditionEqual, Value: ovsdb.UUID{GoUUID: aUUID3}}},
+			},
+		}, ops)
+
+		emptyOps, err := cacheClient.WhereCacheByUUIDs(func(*testLogicalSwitch) bool {
+			return true
+		}).Delete()
+		require.NoError(t, err)
+		assert.Empty(t, emptyOps)
+	})
+
+	t.Run("ApiListPredicate: typed nil function with UUIDs must fail", func(t *testing.T) {
+		var predicate func(*testLogicalSwitch) bool
+		var result []*testLogicalSwitch
+		err := cacheClient.WhereCacheByUUIDs(predicate, aUUID0).List(context.Background(), &result)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "Expected non-nil function")
+	})
+
+	t.Run("ApiListPredicate: disconnected client with UUIDs must fail", func(t *testing.T) {
+		var result []*testLogicalSwitch
+		err := (&cacheOnlyClient{}).WhereCacheByUUIDs(func(*testLogicalSwitch) bool {
+			return true
+		}, aUUID0).List(context.Background(), &result)
+		require.ErrorIs(t, err, ErrNotConnected)
 	})
 }
 
@@ -1818,6 +1927,85 @@ func BenchmarkAPIList(b *testing.B) {
 				}
 				err := cond.List(context.Background(), &result)
 				assert.NoError(b, err)
+			}
+		})
+	}
+}
+
+func BenchmarkWhereCacheByUUIDs(b *testing.B) {
+	const (
+		totalRows     = 10000
+		candidateRows = 512
+	)
+
+	rows := make([]*testLogicalSwitchPort, 0, totalRows)
+	rowCache := make(map[string]model.Model, totalRows)
+	for i := 0; i < totalRows; i++ {
+		row := &testLogicalSwitchPort{
+			UUID:        uuid.New().String(),
+			Name:        fmt.Sprintf("lsp-%d", i),
+			ExternalIDs: map[string]string{"owner": fmt.Sprintf("owner-%d", i)},
+		}
+		rows = append(rows, row)
+		rowCache[row.UUID] = row
+	}
+	tcache := apiTestCache(b, cache.Data{"Logical_Switch_Port": rowCache})
+	cacheClient := &cacheOnlyClient{tableCache: tcache}
+	candidateUUIDs := make([]string, 0, candidateRows)
+	allUUIDs := make([]string, 0, len(rows))
+	for _, row := range rows {
+		allUUIDs = append(allUUIDs, row.UUID)
+	}
+	for _, row := range rows[:candidateRows] {
+		candidateUUIDs = append(candidateUUIDs, row.UUID)
+	}
+	targetName := rows[candidateRows-1].Name
+	predicate := func(row *testLogicalSwitchPort) bool {
+		return row.Name == targetName
+	}
+
+	tests := []struct {
+		name      string
+		condition func() ConditionalAPI
+	}{
+		{
+			name: "global/T=10000/K=1",
+			condition: func() ConditionalAPI {
+				return cacheClient.WhereCache(predicate)
+			},
+		},
+		{
+			name: "candidate/C=512/T=10000/K=1",
+			condition: func() ConditionalAPI {
+				return cacheClient.WhereCacheByUUIDs(predicate, candidateUUIDs...)
+			},
+		},
+		{
+			name: "candidate/C=10000/T=10000/K=1",
+			condition: func() ConditionalAPI {
+				return cacheClient.WhereCacheByUUIDs(predicate, allUUIDs...)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			var result []*testLogicalSwitchPort
+			condition := tt.condition()
+			err := condition.List(context.Background(), &result)
+			require.NoError(b, err)
+			require.Len(b, result, 1)
+
+			b.ReportAllocs()
+			for b.Loop() {
+				result = nil
+				err = tt.condition().List(context.Background(), &result)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			if len(result) != 1 {
+				b.Fatalf("matches = %d, want 1", len(result))
 			}
 		})
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -1454,6 +1454,11 @@ func (o *ovsdbClient) WhereCache(predicate any) ConditionalAPI {
 	return o.primaryDB().api.WhereCache(predicate)
 }
 
+// WhereCacheByUUIDs implements the API interface's WhereCacheByUUIDs function
+func (o *ovsdbClient) WhereCacheByUUIDs(predicate any, uuids ...string) ConditionalAPI {
+	return o.primaryDB().api.WhereCacheByUUIDs(predicate, uuids...)
+}
+
 // Select implements the API interface's Select function
 func (o *ovsdbClient) Select(m model.Model, fields ...any) ([]ovsdb.Operation, error) {
 	return o.primaryDB().api.Select(m, fields...)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2104,39 +2104,74 @@ func TestConditionalWhereListWaitsForCacheConsistency(t *testing.T) {
 	primaryDB.monitors["monitor"] = &Monitor{}
 	primaryDB.monitorsMutex.Unlock()
 
+	type embeddedClient struct {
+		Client
+	}
+	tests := []struct {
+		name      string
+		condition func() ConditionalAPI
+	}{
+		{
+			name: "Where",
+			condition: func() ConditionalAPI {
+				return ovs.Where(&Bridge{Name: bridge.Name})
+			},
+		},
+		{
+			name: "WhereCacheByUUIDs",
+			condition: func() ConditionalAPI {
+				return ovs.WhereCacheByUUIDs(func(*Bridge) bool { return true }, bridge.UUID)
+			},
+		},
+		{
+			name: "WhereCacheByUUIDs through embedded client",
+			condition: func() ConditionalAPI {
+				return (&embeddedClient{Client: ovs}).WhereCacheByUUIDs(func(*Bridge) bool { return true }, bridge.UUID)
+			},
+		},
+	}
+
 	type whereResult struct {
 		err  error
 		rows []*Bridge
 	}
-	done := make(chan whereResult, 1)
-	go func() {
-		var rows []*Bridge
-		err := ovs.Where(&Bridge{Name: "br0"}).List(context.Background(), &rows)
-		done <- whereResult{
-			err:  err,
-			rows: rows,
-		}
-	}()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			primaryDB.cacheMutex.Lock()
+			primaryDB.deferUpdates = true
+			primaryDB.cacheMutex.Unlock()
 
-	// While cache is inconsistent, conditional List should block.
-	select {
-	case result := <-done:
-		t.Fatalf("Where(...).List returned before cache was marked consistent: err=%v rows=%d", result.err, len(result.rows))
-	case <-time.After(120 * time.Millisecond):
-	}
+			done := make(chan whereResult, 1)
+			go func() {
+				var rows []*Bridge
+				err := tt.condition().List(context.Background(), &rows)
+				done <- whereResult{
+					err:  err,
+					rows: rows,
+				}
+			}()
 
-	// Mark replay complete; reads should now proceed.
-	primaryDB.cacheMutex.Lock()
-	primaryDB.deferUpdates = false
-	primaryDB.cacheMutex.Unlock()
+			// While cache is inconsistent, conditional List should block.
+			select {
+			case result := <-done:
+				t.Fatalf("conditional List returned before cache was marked consistent: err=%v rows=%d", result.err, len(result.rows))
+			case <-time.After(120 * time.Millisecond):
+			}
 
-	// After consistency, the same conditional List should complete and return the row.
-	select {
-	case result := <-done:
-		require.NoError(t, result.err)
-		require.Len(t, result.rows, 1)
-		require.Equal(t, bridge.UUID, result.rows[0].UUID)
-	case <-time.After(time.Second):
-		t.Fatal("Where(...).List did not complete after cache became consistent")
+			// Mark replay complete; reads should now proceed.
+			primaryDB.cacheMutex.Lock()
+			primaryDB.deferUpdates = false
+			primaryDB.cacheMutex.Unlock()
+
+			// After consistency, the same conditional List should complete and return the row.
+			select {
+			case result := <-done:
+				require.NoError(t, result.err)
+				require.Len(t, result.rows, 1)
+				require.Equal(t, bridge.UUID, result.rows[0].UUID)
+			case <-time.After(time.Second):
+				t.Fatal("conditional List did not complete after cache became consistent")
+			}
+		})
 	}
 }

--- a/client/condition.go
+++ b/client/condition.go
@@ -175,9 +175,11 @@ func newExplicitConditional(table string, cache *cache.TableCache, matchAll bool
 // predicateConditional is a Conditional that calls a provided function pointer
 // to match on models.
 type predicateConditional struct {
-	tableName string
-	predicate any
-	cache     *cache.TableCache
+	tableName      string
+	predicate      any
+	cache          *cache.TableCache
+	candidateUUIDs []string
+	limitToUUIDs   bool
 }
 
 // matches returns the result of the execution of the predicate
@@ -191,8 +193,15 @@ func (c *predicateConditional) Matches() (map[string]model.Model, error) {
 	found := map[string]model.Model{}
 	// run the predicate on a shallow copy of the models for speed and only
 	// clone the matches
-	for u, m := range tableCache.RowsShallow() {
-		ret := reflect.ValueOf(c.predicate).Call([]reflect.Value{reflect.ValueOf(m)})
+	var rows map[string]model.Model
+	if c.limitToUUIDs {
+		rows = tableCache.RowsByUUIDsShallow(c.candidateUUIDs)
+	} else {
+		rows = tableCache.RowsShallow()
+	}
+	predicate := reflect.ValueOf(c.predicate)
+	for u, m := range rows {
+		ret := predicate.Call([]reflect.Value{reflect.ValueOf(m)})
 		if ret[0].Bool() {
 			found[u] = model.Clone(m)
 		}
@@ -220,6 +229,19 @@ func newPredicateConditional(table string, cache *cache.TableCache, predicate an
 		tableName: table,
 		predicate: predicate,
 		cache:     cache,
+	}, nil
+}
+
+// newPredicateConditionalByUUIDs creates a UUID-limited predicate condition.
+func newPredicateConditionalByUUIDs(table string, cache *cache.TableCache, predicate any, uuids []string) (Conditional, error) {
+	candidateUUIDs := make([]string, len(uuids))
+	copy(candidateUUIDs, uuids)
+	return &predicateConditional{
+		tableName:      table,
+		predicate:      predicate,
+		cache:          cache,
+		candidateUUIDs: candidateUUIDs,
+		limitToUUIDs:   true,
 	}, nil
 }
 

--- a/client/condition_test.go
+++ b/client/condition_test.go
@@ -264,6 +264,55 @@ func TestPredicateConditional(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("limited by UUIDs", func(t *testing.T) {
+		candidateUUIDs := []string{aUUID0, aUUID1, aUUID3, "missing", aUUID1}
+		var predicateCalls []string
+		predicate := func(lsp *testLogicalSwitchPort) bool {
+			predicateCalls = append(predicateCalls, lsp.UUID)
+			return lsp.Enabled != nil && !*lsp.Enabled
+		}
+		cond, err := newPredicateConditionalByUUIDs("Logical_Switch_Port", tcache, predicate, candidateUUIDs)
+		require.NoError(t, err)
+		candidateUUIDs[0] = aUUID2
+
+		matches, err := cond.Matches()
+		require.NoError(t, err)
+		require.Len(t, matches, 1)
+		assert.Equal(t, lspcacheList[1], matches[aUUID1])
+		assert.NotSame(t, tcache.Table("Logical_Switch_Port").RowsShallow()[aUUID1], matches[aUUID1])
+		assert.ElementsMatch(t, []string{aUUID0, aUUID1, aUUID3}, predicateCalls)
+
+		predicateCalls = nil
+		generated, err := cond.Generate()
+		require.NoError(t, err)
+		assert.Equal(t, [][]ovsdb.Condition{{{
+			Column:   "_uuid",
+			Function: ovsdb.ConditionEqual,
+			Value:    ovsdb.UUID{GoUUID: aUUID1},
+		}}}, generated)
+		assert.ElementsMatch(t, []string{aUUID0, aUUID1, aUUID3}, predicateCalls)
+	})
+
+	t.Run("empty UUID list", func(t *testing.T) {
+		predicateCalls := 0
+		cond, err := newPredicateConditionalByUUIDs("Logical_Switch_Port", tcache, func(*testLogicalSwitchPort) bool {
+			predicateCalls++
+			return true
+		}, nil)
+		require.NoError(t, err)
+
+		matches, err := cond.Matches()
+		require.NoError(t, err)
+		assert.NotNil(t, matches)
+		assert.Empty(t, matches)
+		assert.Zero(t, predicateCalls)
+
+		generated, err := cond.Generate()
+		require.NoError(t, err)
+		assert.Empty(t, generated)
+		assert.Zero(t, predicateCalls)
+	})
 }
 
 func TestExplicitConditionalWithNoCache(t *testing.T) {

--- a/client/doc.go
+++ b/client/doc.go
@@ -48,7 +48,7 @@ Some API functions (Create() and Get()), can be run directly. Others, require us
 a ConditionalAPI. The ConditionalAPI injects RFC7047 Conditions into ovsdb Operations as well as
 uses the Conditions to search the internal cache.
 
-The ConditionalAPI is created using the Where(), WhereCache() and WhereAll() functions.
+The ConditionalAPI is created using the Where(), WhereCache(), WhereCacheByUUIDs() and WhereAll() functions.
 
 Where() accepts a Model (pointer to a struct with ovs tags) and a number of Condition instances.
 Conditions must refer to fields of the provided Model (via pointer to fields). Example:
@@ -109,6 +109,16 @@ Server side operations can be executed using WhereCache() conditions but it's no
 cache element, an operation will be created matching on the "_uuid" column. The number of operations can be
 quite large depending on the cache size and the provided function. Most likely there is a way to express the
 same condition using Where() or WhereAll() which will be more efficient.
+
+WhereCacheByUUIDs() applies a WhereCache()-style predicate only to the supplied cached UUIDs. Use it when
+the candidate UUIDs are already known to avoid scanning unrelated rows. Missing UUIDs are ignored, duplicate
+UUIDs are evaluated once, and an empty UUID list matches no rows.
+
+	lsList := &[]LogicalSwitch{}
+	err := ovs.WhereCacheByUUIDs(
+	func(ls *LogicalSwitch) bool {
+		return strings.HasPrefix(ls.Name, "ext_")
+	}, candidateUUIDs...).List(context.Background(), lsList)
 
 # Get
 


### PR DESCRIPTION
WhereCache avoids cloning non-matching rows, but still scans the entire cached table. Callers that know the candidate UUIDs must otherwise choose between that global scan and cloning every candidate before filtering.

Add WhereCacheByUUIDs so predicates evaluate only the selected immutable cache rows and only matching rows are cloned. Preserve native client consistency hooks, document fallback semantics, and cover cache isolation, operations, reconnect consistency, and allocation behavior.

Assisted-by: OpenAI Codex