### PR TITLE
test: wait for disconnect teardown before setting reconnect

### DIFF
--- a/test/ovs/ovs_integration_test.go
+++ b/test/ovs/ovs_integration_test.go
@@ -1092,13 +1092,16 @@ func (suite *OVSIntegrationSuite) TestOpsWaitForReconnect() {
 	// Shutdown client
 	suite.clientWithoutInactvityCheck.Disconnect()
 
+	var err error
+	// Connected becomes false before the asynchronous disconnect handler has
+	// cleared the RPC client. Wait until teardown is complete before changing
+	// the reconnect option.
 	suite.Eventually(func() bool {
-		return !suite.clientWithoutInactvityCheck.Connected()
-	}, 5*time.Second, 1*time.Second)
-
-	err := suite.clientWithoutInactvityCheck.SetOption(
-		client.WithReconnect(2*time.Second, &backoff.ZeroBackOff{}),
-	)
+		err = suite.clientWithoutInactvityCheck.SetOption(
+			client.WithReconnect(2*time.Second, &backoff.ZeroBackOff{}),
+		)
+		return err == nil
+	}, 5*time.Second, 10*time.Millisecond)
 	suite.Require().NoError(err)
 	var insertOp []ovsdb.Operation
 	insertOp, err = suite.clientWithoutInactvityCheck.Create(&ipfix)


### PR DESCRIPTION
Disconnect marks the client disconnected before its asynchronous handler clears the RPC client. TestOpsWaitForReconnect waited only for Connected to become false, so SetOption could still reject the reconnect option and make the integration test fail intermittently.

Retry SetOption until disconnect teardown has completed. Failed attempts do not apply the option. The successful attempt confirms the client can be reconfigured and installs the reconnect behavior.

Assisted-by: OpenAI Codex <codex@openai.com>